### PR TITLE
Add centralized history logging (NMHistory) and fix circular imports (#12)

### DIFF
--- a/pyneuromatic/core/nm_channel.py
+++ b/pyneuromatic/core/nm_channel.py
@@ -20,7 +20,11 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 
-from pyneuromatic.core.nm_data import NMData
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyneuromatic.core.nm_data import NMData
+
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
 from pyneuromatic.core.nm_dimension import NMDimension, NMDimensionX
@@ -86,6 +90,8 @@ class NMChannel(NMObject):
             else:
                 # grab NMData refs from copied NMDataContainer
                 # NMDataContainer should be copied before this copy
+                from pyneuromatic.core.nm_data import NMData
+
                 data = self._folder.data
                 for d in copy.__thedata:
                     o = data.get(d.name)

--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -20,8 +20,12 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 
-from pyneuromatic.core.nm_data import NMData
-from pyneuromatic.core.nm_folder import NMFolder
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyneuromatic.core.nm_data import NMData
+    from pyneuromatic.core.nm_folder import NMFolder
+
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
 import pyneuromatic.core.nm_utilities as nmu
@@ -73,6 +77,9 @@ class NMEpoch(NMObject):
         if copy is None:
             pass
         elif isinstance(copy, NMEpoch):
+            from pyneuromatic.core.nm_data import NMData
+            from pyneuromatic.core.nm_folder import NMFolder
+
             if isinstance(self._folder, NMFolder):
                 # grab NMData refs from copied NMDataContainer
                 # NMDataContainer should be copied before this copy

--- a/pyneuromatic/core/nm_history.py
+++ b/pyneuromatic/core/nm_history.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+"""
+Centralized history logging for pyNeuroMatic.
+
+Provides NMHistory, a wrapper around Python's logging module that maintains
+an in-memory history buffer and colorama-colored console output, analogous
+to Igor Pro's history command window.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import datetime
+import logging
+from collections import deque
+
+from colorama import Fore
+
+
+class NMHistoryBufferHandler(logging.Handler):
+    """Logging handler that stores records in a fixed-size in-memory buffer.
+
+    Each record is stored as a dict with keys: date, level, treepath, message.
+    When the buffer is full, the oldest entry is discarded.
+    """
+
+    def __init__(self, maxlen: int = 10000) -> None:
+        super().__init__()
+        self._buffer: deque[dict[str, str]] = deque(maxlen=maxlen)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        entry = {
+            "date": str(datetime.datetime.now()),
+            "level": record.levelname,
+            "treepath": getattr(record, "treepath", ""),
+            "message": record.getMessage(),
+        }
+        self._buffer.append(entry)
+
+    @property
+    def buffer(self) -> list[dict[str, str]]:
+        """Return a copy of the buffer as a list."""
+        return list(self._buffer)
+
+    def clear(self) -> None:
+        """Clear all entries from the buffer."""
+        self._buffer.clear()
+
+
+class NMConsoleHandler(logging.Handler):
+    """Logging handler that prints to console with colorama colors.
+
+    Replicates the output format of nmu.history(): treepath prefix,
+    optional title, and red coloring for WARNING/ERROR levels.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        tp = getattr(record, "treepath", "")
+        title = getattr(record, "title", "")
+        msg = record.getMessage()
+
+        if tp and tp.upper() != "NONE":
+            h = tp + ": " + msg
+        else:
+            h = msg
+
+        if title:
+            h = title + ": " + h
+
+        if record.levelno >= logging.WARNING:
+            print(Fore.RED + h + Fore.BLACK)
+        else:
+            print(h)
+
+
+class NMHistory:
+    """Centralized history log for pyNeuroMatic.
+
+    Wraps Python's logging module to provide an in-memory history buffer
+    and colorama-colored console output. Analogous to Igor Pro's history
+    command window.
+
+    Access via NMManager.history property.
+
+    :param buffer_size: maximum number of entries in the history buffer.
+    :type buffer_size: int
+    :param quiet: if True, suppress console output (buffer still records).
+    :type quiet: bool
+    """
+
+    def __init__(
+        self,
+        buffer_size: int = 10000,
+        quiet: bool = False,
+    ) -> None:
+        self._logger = logging.getLogger("pyneuromatic")
+        self._logger.setLevel(logging.DEBUG)
+
+        # prevent duplicate handlers if NMHistory is created multiple times
+        self._logger.handlers.clear()
+
+        # in-memory buffer handler - always captures everything
+        self._buffer_handler = NMHistoryBufferHandler(maxlen=buffer_size)
+        self._buffer_handler.setLevel(logging.DEBUG)
+        self._logger.addHandler(self._buffer_handler)
+
+        # console handler - respects quiet flag
+        self._console_handler = NMConsoleHandler()
+        if quiet:
+            self._console_handler.setLevel(logging.CRITICAL + 1)
+        else:
+            self._console_handler.setLevel(logging.DEBUG)
+        self._logger.addHandler(self._console_handler)
+
+    def log(
+        self,
+        message: str,
+        title: str = "",
+        tp: str = "",
+        level: int = logging.INFO,
+        quiet: bool = False,
+    ) -> str:
+        """Log a message to the history buffer and optionally to console.
+
+        :param message: the message to log.
+        :type message: str
+        :param title: message title (e.g. 'ALERT' or 'ERROR').
+        :type title: str
+        :param tp: treepath string (e.g. 'nm.project0.folder0').
+        :type tp: str
+        :param level: Python logging level (e.g. logging.INFO).
+        :type level: int
+        :param quiet: if True, suppress console output for this call only.
+        :type quiet: bool
+        :return: formatted history string.
+        :rtype: str
+        """
+        # build return string matching current nmu.history() format
+        if tp and tp.upper() != "NONE":
+            h = tp + ": " + message
+        else:
+            h = message
+        if title:
+            h = title + ": " + h
+
+        # temporarily raise console handler level if quiet for this call
+        old_level = None
+        if quiet:
+            old_level = self._console_handler.level
+            self._console_handler.setLevel(logging.CRITICAL + 1)
+
+        self._logger.log(
+            level,
+            message,
+            extra={"treepath": tp, "title": title},
+        )
+
+        if old_level is not None:
+            self._console_handler.setLevel(old_level)
+
+        return h
+
+    @property
+    def buffer(self) -> list[dict[str, str]]:
+        """Return a copy of the history buffer.
+
+        Each entry is a dict with keys: date, level, treepath, message.
+        """
+        return self._buffer_handler.buffer
+
+    @property
+    def buffer_size(self) -> int:
+        """Return the maximum buffer size."""
+        return self._buffer_handler._buffer.maxlen or 0
+
+    def clear(self) -> None:
+        """Clear the history buffer."""
+        self._buffer_handler.clear()
+
+    def history_print(self, last_n: int = 0) -> None:
+        """Print history buffer contents to console.
+
+        :param last_n: number of most recent entries to print (0 for all).
+        :type last_n: int
+        """
+        entries = self.buffer
+        if last_n > 0:
+            entries = entries[-last_n:]
+        for entry in entries:
+            tp = entry.get("treepath", "")
+            msg = entry.get("message", "")
+            level = entry.get("level", "")
+
+            if tp:
+                line = tp + ": " + msg
+            else:
+                line = msg
+
+            if level in ("WARNING", "ERROR"):
+                line = level + ": " + line
+                print(Fore.RED + line + Fore.BLACK)
+            else:
+                print(line)
+
+    @property
+    def quiet(self) -> bool:
+        """True if console output is suppressed."""
+        return self._console_handler.level > logging.CRITICAL
+
+    @quiet.setter
+    def quiet(self, value: bool) -> None:
+        if value:
+            self._console_handler.setLevel(logging.CRITICAL + 1)
+        else:
+            self._console_handler.setLevel(logging.DEBUG)

--- a/pyneuromatic/core/nm_manager.py
+++ b/pyneuromatic/core/nm_manager.py
@@ -27,6 +27,7 @@ import numpy as np
 from pyneuromatic.core.nm_dataseries import NMDataSeries
 from pyneuromatic.core.nm_dimension import NMDimension, NMDimensionX
 from pyneuromatic.core.nm_folder import NMFolder, NMFolderContainer
+from pyneuromatic.core.nm_history import NMHistory
 from pyneuromatic.core.nm_object import NMObject
 import pyneuromatic.core.nm_preferences as nmp
 from pyneuromatic.core.nm_project import NMProject, NMProjectContainer
@@ -69,6 +70,10 @@ class NMManager(NMObject):
     ) -> None:
         super().__init__(parent=None, name=name)  # NMObject
 
+        # initialize centralized history logging
+        self.__history = NMHistory(quiet=quiet)
+        nmu.set_history(self.__history)
+
         # self.__configs = nmp.Configs()
         # self.__configs.quiet = quiet
 
@@ -107,10 +112,11 @@ class NMManager(NMObject):
         tstr = str(datetime.datetime.now())
         h = ("created NM manager '%s' %s"
              % (self.name, tstr))
-        # self._history(h, quiet=quiet)
-        print(h)
-        print("current NM project is '%s'" % self.__project.name)
-        print("current NM tool is '%s'" % self.__toolselect)
+        self._history(h, quiet=quiet)
+        self._history("current NM project is '%s'" % self.__project.name,
+                      quiet=quiet)
+        self._history("current NM tool is '%s'" % self.__toolselect,
+                      quiet=quiet)
 
     def tool_add(
         self,
@@ -164,6 +170,11 @@ class NMManager(NMObject):
     # @property
     # def projects(self) -> NMProjectContainer:
     #     return self.__project_container
+
+    @property
+    def history(self) -> NMHistory:
+        """Access the centralized NM history log."""
+        return self.__history
 
     @property
     def project(self) -> NMProject:

--- a/pyneuromatic/core/nm_object.py
+++ b/pyneuromatic/core/nm_object.py
@@ -19,16 +19,19 @@ Website: https://github.com/SilverLabUCL/pyNeuroMatic
 Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
+
 # import copy
 import datetime
 from tkinter.font import names
 import types
-from typing import overload
+from typing import overload, TYPE_CHECKING
 
-from pyneuromatic.core.nm_folder import NMFolder
-from pyneuromatic.core.nm_manager import NMManager
+if TYPE_CHECKING:
+    from pyneuromatic.core.nm_folder import NMFolder
+    from pyneuromatic.core.nm_manager import NMManager
+    from pyneuromatic.core.nm_project import NMProject
+
 import pyneuromatic.core.nm_preferences as nmp
-from pyneuromatic.core.nm_project import NMProject
 import pyneuromatic.core.nm_utilities as nmu
 
 
@@ -479,24 +482,15 @@ class NMObject(object):
 
     @property
     def _manager(self) -> NMManager | None:  # find NMManager of this NMObject
-        o = self._find_parent("NMManager")
-        if isinstance(o, NMManager):
-            return o
-        return None
+        return self._find_parent("NMManager")
 
     @property
     def _project(self) -> NMProject | None:  # find NMProject of this NMObject
-        o = self._find_parent("NMProject")
-        if isinstance(o, NMProject):
-            return o
-        return None
+        return self._find_parent("NMProject")
 
     @property
     def _folder(self) -> NMFolder | None:  # find NMFolder of this NMObject
-        o = self._find_parent("NMFolder")
-        if isinstance(o, NMFolder):
-            return o
-        return None
+        return self._find_parent("NMFolder")
 
     def _find_parent(self, classname: str) -> object:
         if self.__parent is None or not isinstance(classname, str):

--- a/tests/test_core/test_nm_history.py
+++ b/tests/test_core/test_nm_history.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for NMHistory centralized logging.
+
+@author: jason
+"""
+import logging
+import unittest
+
+from pyneuromatic.core.nm_history import (
+    NMHistory,
+    NMHistoryBufferHandler,
+    NMConsoleHandler,
+)
+from pyneuromatic.core.nm_manager import NMManager
+from pyneuromatic.core.nm_object import NMObject
+import pyneuromatic.core.nm_utilities as nmu
+
+QUIET = True
+
+
+class NMHistoryBufferHandlerTest(unittest.TestCase):
+    """Test the custom buffer handler independently."""
+
+    def setUp(self):
+        self.handler = NMHistoryBufferHandler(maxlen=100)
+
+    def test00_init(self):
+        self.assertEqual(len(self.handler.buffer), 0)
+        h = NMHistoryBufferHandler(maxlen=5)
+        self.assertEqual(h._buffer.maxlen, 5)
+
+    def test01_emit(self):
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="test message",
+            args=None,
+            exc_info=None,
+        )
+        record.treepath = "nm.test"
+        self.handler.emit(record)
+        self.assertEqual(len(self.handler.buffer), 1)
+        entry = self.handler.buffer[0]
+        self.assertEqual(entry["message"], "test message")
+        self.assertEqual(entry["treepath"], "nm.test")
+        self.assertEqual(entry["level"], "INFO")
+        self.assertIn("date", entry)
+
+    def test02_buffer_overflow(self):
+        h = NMHistoryBufferHandler(maxlen=3)
+        for i in range(5):
+            record = logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="msg%d" % i,
+                args=None,
+                exc_info=None,
+            )
+            record.treepath = ""
+            h.emit(record)
+        self.assertEqual(len(h.buffer), 3)
+        self.assertEqual(h.buffer[0]["message"], "msg2")
+        self.assertEqual(h.buffer[2]["message"], "msg4")
+
+    def test03_clear(self):
+        record = logging.LogRecord(
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="test",
+            args=None,
+            exc_info=None,
+        )
+        record.treepath = ""
+        self.handler.emit(record)
+        self.assertEqual(len(self.handler.buffer), 1)
+        self.handler.clear()
+        self.assertEqual(len(self.handler.buffer), 0)
+
+
+class NMHistoryTest(unittest.TestCase):
+    """Test the NMHistory wrapper class."""
+
+    def setUp(self):
+        self.h = NMHistory(buffer_size=1000, quiet=True)
+
+    def tearDown(self):
+        self.h.clear()
+
+    def test00_init(self):
+        self.assertIsInstance(self.h, NMHistory)
+        self.assertEqual(len(self.h.buffer), 0)
+        self.assertTrue(self.h.quiet)
+        self.assertEqual(self.h.buffer_size, 1000)
+
+    def test01_log_info(self):
+        result = self.h.log("test message", tp="nm.test")
+        self.assertEqual(result, "nm.test: test message")
+        self.assertEqual(len(self.h.buffer), 1)
+        entry = self.h.buffer[0]
+        self.assertEqual(entry["level"], "INFO")
+        self.assertEqual(entry["message"], "test message")
+        self.assertEqual(entry["treepath"], "nm.test")
+
+    def test02_log_alert(self):
+        result = self.h.log(
+            "alert msg", title="ALERT", tp="nm.test", level=logging.WARNING
+        )
+        self.assertEqual(result, "ALERT: nm.test: alert msg")
+        entry = self.h.buffer[-1]
+        self.assertEqual(entry["level"], "WARNING")
+        self.assertEqual(entry["message"], "alert msg")
+
+    def test03_log_error(self):
+        result = self.h.log(
+            "error msg", title="ERROR", tp="nm.test", level=logging.ERROR
+        )
+        self.assertEqual(result, "ERROR: nm.test: error msg")
+        entry = self.h.buffer[-1]
+        self.assertEqual(entry["level"], "ERROR")
+        self.assertEqual(entry["message"], "error msg")
+
+    def test04_quiet_per_call(self):
+        # messages should still go to buffer even when quiet=True
+        self.h.log("quiet msg", quiet=True)
+        self.assertEqual(len(self.h.buffer), 1)
+        self.assertEqual(self.h.buffer[0]["message"], "quiet msg")
+
+    def test05_quiet_property(self):
+        self.assertTrue(self.h.quiet)
+        self.h.quiet = False
+        self.assertFalse(self.h.quiet)
+        self.h.quiet = True
+        self.assertTrue(self.h.quiet)
+
+    def test06_clear(self):
+        self.h.log("msg1")
+        self.h.log("msg2")
+        self.assertEqual(len(self.h.buffer), 2)
+        self.h.clear()
+        self.assertEqual(len(self.h.buffer), 0)
+
+    def test07_buffer_overflow(self):
+        h = NMHistory(buffer_size=5, quiet=True)
+        for i in range(10):
+            h.log("msg%d" % i)
+        self.assertEqual(len(h.buffer), 5)
+        self.assertEqual(h.buffer[0]["message"], "msg5")
+        self.assertEqual(h.buffer[4]["message"], "msg9")
+
+    def test08_no_treepath(self):
+        result = self.h.log("bare message")
+        self.assertEqual(result, "bare message")
+        self.assertEqual(self.h.buffer[0]["treepath"], "")
+
+    def test09_treepath_none(self):
+        result = self.h.log("msg", tp="NONE")
+        self.assertEqual(result, "msg")
+        self.assertEqual(self.h.buffer[0]["treepath"], "NONE")
+
+    def test10_empty_title(self):
+        result = self.h.log("msg", title="", tp="nm.test")
+        self.assertEqual(result, "nm.test: msg")
+
+    def test11_multiple_messages(self):
+        self.h.log("first")
+        self.h.log("second")
+        self.h.log("third")
+        self.assertEqual(len(self.h.buffer), 3)
+        messages = [e["message"] for e in self.h.buffer]
+        self.assertEqual(messages, ["first", "second", "third"])
+
+
+class NMHistoryIntegrationTest(unittest.TestCase):
+    """Test NMHistory integration with NMManager and NMObject."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=QUIET)
+
+    def test00_manager_has_history(self):
+        self.assertIsInstance(self.nm.history, NMHistory)
+        self.assertTrue(self.nm.history.quiet)
+
+    def test01_history_captures_init(self):
+        # NMManager.__init__ should have logged creation messages
+        buf = self.nm.history.buffer
+        self.assertTrue(len(buf) > 0)
+        messages = [e["message"] for e in buf]
+        found_created = any("created NM manager" in m for m in messages)
+        found_project = any("current NM project" in m for m in messages)
+        found_tool = any("current NM tool" in m for m in messages)
+        self.assertTrue(found_created)
+        self.assertTrue(found_project)
+        self.assertTrue(found_tool)
+
+    def test02_nmu_history_routes_to_buffer(self):
+        self.nm.history.clear()
+        nmu.history("test via nmu", tp="nm.test", quiet=True)
+        buf = self.nm.history.buffer
+        self.assertEqual(len(buf), 1)
+        self.assertEqual(buf[0]["message"], "test via nmu")
+        self.assertEqual(buf[0]["treepath"], "nm.test")
+
+    def test03_object_history_routes_to_buffer(self):
+        self.nm.history.clear()
+        o = NMObject(parent=self.nm, name="testobj")
+        self.nm.history.clear()
+        o._history("obj history msg", quiet=True)
+        buf = self.nm.history.buffer
+        self.assertEqual(len(buf), 1)
+        self.assertIn("obj history msg", buf[0]["message"])
+
+    def test04_object_alert_routes_to_buffer(self):
+        self.nm.history.clear()
+        o = NMObject(parent=self.nm, name="testobj")
+        self.nm.history.clear()
+        o._alert("alert msg", quiet=True)
+        buf = self.nm.history.buffer
+        self.assertEqual(len(buf), 1)
+        self.assertEqual(buf[0]["level"], "WARNING")
+
+    def test05_object_error_routes_to_buffer(self):
+        self.nm.history.clear()
+        o = NMObject(parent=self.nm, name="testobj")
+        self.nm.history.clear()
+        o._error("error msg", quiet=True)
+        buf = self.nm.history.buffer
+        self.assertEqual(len(buf), 1)
+        self.assertEqual(buf[0]["level"], "ERROR")
+
+    def test06_buffer_preserves_order(self):
+        self.nm.history.clear()
+        nmu.history("first", quiet=True)
+        nmu.history("second", quiet=True)
+        nmu.history("third", quiet=True)
+        buf = self.nm.history.buffer
+        messages = [e["message"] for e in buf]
+        self.assertEqual(messages, ["first", "second", "third"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add NMHistory class wrapping Python's logging module to provide a
centralized in-memory history buffer and colorama-colored console
output.

- New: pyneuromatic/core/nm_history.py
  NMHistoryBufferHandler (circular deque), NMConsoleHandler (colorama),
  NMHistory (wrapper with log/buffer/clear/quiet interface)

- Modified: pyneuromatic/core/nm_utilities.py
  Added set_history() registration function; history() now delegates
  to NMHistory when available, resolving the TODO at former line 602

- Modified: pyneuromatic/core/nm_manager.py
  Creates NMHistory in __init__, registers with nmu.set_history(),
  exposes nm.history property, replaces print() calls with _history()

- Fixed circular imports using TYPE_CHECKING:
  nm_object.py: NMFolder, NMManager, NMProject
  nm_channel.py: NMData
  nm_epoch.py: NMData, NMFolder

- New: tests/test_core/test_nm_history.py (23 tests, all passing)