### PR TITLE
refactor(core): replace treepath method with path properties #20

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -1775,7 +1775,7 @@ def stats(
         raise TypeError(e)
 
     # results["func"] = f
-    results["data"] = data._treepath_str()
+    results["data"] = data.path_str
 
     if isinstance(data.x.units, str):
         xunits = data.x.units

--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -182,7 +182,7 @@ class NMFolder(NMObject):
             e = nmu.typeerror(tool, "tool", "string")
             raise TypeError(e)
 
-        tp = self._treepath_str()
+        tp = self.path_str
         foundkey = False
         for i in range(imax_keys):
             newkey = tool + str(i)

--- a/pyneuromatic/core/nm_history.py
+++ b/pyneuromatic/core/nm_history.py
@@ -34,7 +34,7 @@ from colorama import Fore
 class NMHistoryBufferHandler(logging.Handler):
     """Logging handler that stores records in a fixed-size in-memory buffer.
 
-    Each record is stored as a dict with keys: date, level, treepath, message.
+    Each record is stored as a dict with keys: date, level, path, message.
     When the buffer is full, the oldest entry is discarded.
     """
 
@@ -46,7 +46,7 @@ class NMHistoryBufferHandler(logging.Handler):
         entry = {
             "date": str(datetime.datetime.now()),
             "level": record.levelname,
-            "treepath": getattr(record, "treepath", ""),
+            "path": getattr(record, "path", ""),
             "message": record.getMessage(),
         }
         self._buffer.append(entry)
@@ -64,17 +64,17 @@ class NMHistoryBufferHandler(logging.Handler):
 class NMConsoleHandler(logging.Handler):
     """Logging handler that prints to console with colorama colors.
 
-    Replicates the output format of nmu.history(): treepath prefix,
+    Replicates the output format of nmu.history(): path prefix,
     optional title, and red coloring for WARNING/ERROR levels.
     """
 
     def emit(self, record: logging.LogRecord) -> None:
-        tp = getattr(record, "treepath", "")
+        path = getattr(record, "path", "")
         title = getattr(record, "title", "")
         msg = record.getMessage()
 
-        if tp and tp.upper() != "NONE":
-            h = tp + ": " + msg
+        if path and path.upper() != "NONE":
+            h = path + ": " + msg
         else:
             h = msg
 
@@ -129,7 +129,7 @@ class NMHistory:
         self,
         message: str,
         title: str = "",
-        tp: str = "",
+        path: str = "",
         level: int = logging.INFO,
         quiet: bool = False,
     ) -> str:
@@ -139,8 +139,8 @@ class NMHistory:
         :type message: str
         :param title: message title (e.g. 'ALERT' or 'ERROR').
         :type title: str
-        :param tp: treepath string (e.g. 'nm.project0.folder0').
-        :type tp: str
+        :param path: path string (e.g. 'nm.project0.folder0').
+        :type path: str
         :param level: Python logging level (e.g. logging.INFO).
         :type level: int
         :param quiet: if True, suppress console output for this call only.
@@ -149,8 +149,8 @@ class NMHistory:
         :rtype: str
         """
         # build return string matching current nmu.history() format
-        if tp and tp.upper() != "NONE":
-            h = tp + ": " + message
+        if path and path.upper() != "NONE":
+            h = path + ": " + message
         else:
             h = message
         if title:
@@ -165,7 +165,7 @@ class NMHistory:
         self._logger.log(
             level,
             message,
-            extra={"treepath": tp, "title": title},
+            extra={"path": path, "title": title},
         )
 
         if old_level is not None:
@@ -177,7 +177,7 @@ class NMHistory:
     def buffer(self) -> list[dict[str, str]]:
         """Return a copy of the history buffer.
 
-        Each entry is a dict with keys: date, level, treepath, message.
+        Each entry is a dict with keys: date, level, path, message.
         """
         return self._buffer_handler.buffer
 
@@ -200,12 +200,12 @@ class NMHistory:
         if last_n > 0:
             entries = entries[-last_n:]
         for entry in entries:
-            tp = entry.get("treepath", "")
+            path = entry.get("path", "")
             msg = entry.get("message", "")
             level = entry.get("level", "")
 
-            if tp:
-                line = tp + ": " + msg
+            if path:
+                line = path + ": " + msg
             else:
                 line = msg
 

--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -471,7 +471,7 @@ class NMObjectContainer(NMObject, MutableMapping):
                 ync = auto_confirm
             else:
                 prompt = "are you sure you want to delete '%s'?" % actual_key
-                ync = nmu.input_yesno(prompt, treepath=self._treepath_str())
+                ync = nmu.input_yesno(prompt, path=self.path_str)
             if isinstance(ync, str) and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -522,7 +522,7 @@ class NMObjectContainer(NMObject, MutableMapping):
                 q = "are you sure you want to delete the following?\n" + ", ".join(
                     self.__map.keys()
                 )
-                ync = nmu.input_yesno(q, treepath=self._treepath_str())
+                ync = nmu.input_yesno(q, path=self.path_str)
             if isinstance(ync, str) and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:

--- a/pyneuromatic/core/nm_sets.py
+++ b/pyneuromatic/core/nm_sets.py
@@ -520,7 +520,7 @@ class NMSets(NMObject, MutableMapping):
                 ync = auto_confirm
             else:
                 q = "are you sure you want to delete '%s'?" % key
-                ync = nmu.input_yesno(q, treepath=self._treepath_str())
+                ync = nmu.input_yesno(q, path=self.path_str)
             if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -562,7 +562,7 @@ class NMSets(NMObject, MutableMapping):
                 q = "are you sure you want to delete the following?\n" + ", ".join(
                     self.__map.keys()
                 )
-                ync = nmu.input_yesno(q, treepath=self._treepath_str())
+                ync = nmu.input_yesno(q, path=self.path_str)
             if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -841,7 +841,7 @@ class NMSets(NMObject, MutableMapping):
                 ync = auto_confirm
             else:
                 q = "are you sure you want to empty '%s'?" % key
-                ync = nmu.input_yesno(q, treepath=self._treepath_str())
+                ync = nmu.input_yesno(q, path=self.path_str)
             if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -862,7 +862,7 @@ class NMSets(NMObject, MutableMapping):
                 q = "are you sure you want to empty the following?\n" + ", ".join(
                     self.__map.keys()
                 )
-                ync = nmu.input_yesno(q, treepath=self._treepath_str())
+                ync = nmu.input_yesno(q, path=self.path_str)
             if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:

--- a/pyneuromatic/core/nm_utilities.py
+++ b/pyneuromatic/core/nm_utilities.py
@@ -594,7 +594,7 @@ def history_change(
 def history(
     message: str,
     title: str = "",
-    treepath: str | None = None,
+    path: str | None = None,
     frame: int = 1,
     red: bool = False,
     quiet: bool = False,
@@ -605,9 +605,9 @@ def history(
     :type message: str
     :param title: message title (e.g. 'ALERT' or 'ERROR').
     :type title: str
-    :param treepath: function treepath, pass '' for default or 'NONE' for none.
-    :type treepath: str | None
-    :param frame: inspect frame # for creating treepath.
+    :param path: function path, pass '' for default or 'NONE' for none.
+    :type path: str | None
+    :param frame: inspect frame # for creating path.
     :type frame: int
     :param red: True to print red, False to print black.
     :type red: bool
@@ -620,12 +620,12 @@ def history(
         return ""
     if not isinstance(frame, int) or frame < 0:
         frame = 1
-    if treepath is None:
-        path = get_treepath(inspect.stack(), frame=frame)
-    elif not isinstance(treepath, str):
+    if path is None:
+        path = get_path(inspect.stack(), frame=frame)
+    elif not isinstance(path, str):
         path = ""
     else:
-        path = treepath
+        path = path
 
     # determine log level from title/red
     if isinstance(title, str) and title.upper() == "ERROR":
@@ -638,7 +638,7 @@ def history(
     # delegate to NMHistory if available
     if _nm_history is not None:
         return _nm_history.log(
-            message, title=title, tp=path, level=level, quiet=quiet
+            message, title=title, path=path, level=level, quiet=quiet
         )
 
     # fallback: original print() behavior (before NMManager is created)
@@ -656,20 +656,20 @@ def history(
     return h
 
 
-def get_treepath(
+def get_path(
     stack: list, 
     frame: int = 1, 
     package: str = "nm"  # stack frame
 ) -> str:
-    """Create function ancestry treepath.
+    """Create function ancestry path.
 
     :param stack: stack list.
     :type stack: list
-    :param frame: inspect frame # for creating treepath.
+    :param frame: inspect frame # for creating path.
     :type frame: int
     :param package: package, e.g. 'nm'
     :type package: str
-    :return: treepath string.
+    :return: path string.
     :rtype: str
     """
     if not stack:
@@ -698,7 +698,7 @@ def get_class_from_stack(
 
     :param stack: stack list.
     :type stack: list
-    :param frame: inspect frame # for creating treepath.
+    :param frame: inspect frame # for creating path.
     :type frame: int
     :param module: include module name.
     :type module: bool
@@ -736,7 +736,7 @@ def get_method_from_stack(
 
     :param stack: stack list.
     :type stack: list
-    :param frame: inspect frame # for creating treepath.
+    :param frame: inspect frame # for creating path.
     :type frame: int
     :return: method name.
     :rtype: str
@@ -756,7 +756,7 @@ def get_method_from_stack(
 def input_yesno(
     prompt: str,
     title: str = "",
-    treepath: str | None = None,
+    path: str | None = None,
     frame: int = 1,
     cancel: bool = True,
     answer: str | None = None,  # for testing, bypasses input()
@@ -767,9 +767,9 @@ def input_yesno(
     :type prompt: str
     :param title: prompt title.
     :type title: str
-    :param treepath: function treepath.
-    :type treepath: str
-    :param frame: inspect frame # for creating treepath.
+    :param path: function path.
+    :type path: str
+    :param frame: inspect frame # for creating path.
     :type frame: int
     :param cancel: include 'cancel' option.
     :type cancel: bool
@@ -787,12 +787,12 @@ def input_yesno(
         txt = prompt + "\n" + "(y)es, (n)o: "
         ok.remove("c")
         ok.remove("cancel")
-    if treepath is None:
-        path = get_treepath(inspect.stack(), frame=frame)
-    if not isinstance(treepath, str):
+    if path is None:
+        path = get_path(inspect.stack(), frame=frame)
+    if not isinstance(path, str):
         path = ""
     else:
-        path = treepath  # + '.userinput'
+        path = path  # + '.userinput'
     if path:
         txt = path + ":\n" + txt
     if title:

--- a/tests/test_analysis/test_nm_stats.py
+++ b/tests/test_analysis/test_nm_stats.py
@@ -308,7 +308,7 @@ class NMStatsTest(unittest.TestCase):
         for k in keys:
             self.assertTrue(k in r[0])
         self.assertEqual(r[0]["id"], "bsln")
-        self.assertEqual(r[0]["data"], self.datanan._treepath_str())
+        self.assertEqual(r[0]["data"], self.datanan.path_str)
         keys = ['win', 'id', 'func', 'x0', 'x1', 'data', 'i0', 'i1',
                 'n', 'nans', 'infs', 's', 'sunits', 'i',
                 'x', 'xunits', 'Δs']
@@ -544,7 +544,7 @@ class NMStatsTest(unittest.TestCase):
         keys = ['data', 'i0', 'i1', 'n', 'nans', 'infs', 's', 'sunits',
                 'i', 'x', 'xunits']
         self.assertEqual(list(r.keys()), keys)
-        self.assertEqual(r["data"], self.datanan._treepath_str())
+        self.assertEqual(r["data"], self.datanan.path_str)
         self.assertEqual(r["i0"], 0)  # xclip = True
         pnts = len(self.datanan.y.nparray)
         self.assertEqual(r["i1"], pnts-1)  # xclip = True

--- a/tests/test_core/test_nm_history.py
+++ b/tests/test_core/test_nm_history.py
@@ -41,12 +41,12 @@ class NMHistoryBufferHandlerTest(unittest.TestCase):
             args=None,
             exc_info=None,
         )
-        record.treepath = "nm.test"
+        record.path = "nm.test"
         self.handler.emit(record)
         self.assertEqual(len(self.handler.buffer), 1)
         entry = self.handler.buffer[0]
         self.assertEqual(entry["message"], "test message")
-        self.assertEqual(entry["treepath"], "nm.test")
+        self.assertEqual(entry["path"], "nm.test")
         self.assertEqual(entry["level"], "INFO")
         self.assertIn("date", entry)
 
@@ -62,7 +62,7 @@ class NMHistoryBufferHandlerTest(unittest.TestCase):
                 args=None,
                 exc_info=None,
             )
-            record.treepath = ""
+            record.path = ""
             h.emit(record)
         self.assertEqual(len(h.buffer), 3)
         self.assertEqual(h.buffer[0]["message"], "msg2")
@@ -78,7 +78,7 @@ class NMHistoryBufferHandlerTest(unittest.TestCase):
             args=None,
             exc_info=None,
         )
-        record.treepath = ""
+        record.path = ""
         self.handler.emit(record)
         self.assertEqual(len(self.handler.buffer), 1)
         self.handler.clear()
@@ -101,17 +101,17 @@ class NMHistoryTest(unittest.TestCase):
         self.assertEqual(self.h.buffer_size, 1000)
 
     def test01_log_info(self):
-        result = self.h.log("test message", tp="nm.test")
+        result = self.h.log("test message", path="nm.test")
         self.assertEqual(result, "nm.test: test message")
         self.assertEqual(len(self.h.buffer), 1)
         entry = self.h.buffer[0]
         self.assertEqual(entry["level"], "INFO")
         self.assertEqual(entry["message"], "test message")
-        self.assertEqual(entry["treepath"], "nm.test")
+        self.assertEqual(entry["path"], "nm.test")
 
     def test02_log_alert(self):
         result = self.h.log(
-            "alert msg", title="ALERT", tp="nm.test", level=logging.WARNING
+            "alert msg", title="ALERT", path="nm.test", level=logging.WARNING
         )
         self.assertEqual(result, "ALERT: nm.test: alert msg")
         entry = self.h.buffer[-1]
@@ -120,7 +120,7 @@ class NMHistoryTest(unittest.TestCase):
 
     def test03_log_error(self):
         result = self.h.log(
-            "error msg", title="ERROR", tp="nm.test", level=logging.ERROR
+            "error msg", title="ERROR", path="nm.test", level=logging.ERROR
         )
         self.assertEqual(result, "ERROR: nm.test: error msg")
         entry = self.h.buffer[-1]
@@ -155,18 +155,18 @@ class NMHistoryTest(unittest.TestCase):
         self.assertEqual(h.buffer[0]["message"], "msg5")
         self.assertEqual(h.buffer[4]["message"], "msg9")
 
-    def test08_no_treepath(self):
+    def test08_no_path(self):
         result = self.h.log("bare message")
         self.assertEqual(result, "bare message")
-        self.assertEqual(self.h.buffer[0]["treepath"], "")
+        self.assertEqual(self.h.buffer[0]["path"], "")
 
-    def test09_treepath_none(self):
-        result = self.h.log("msg", tp="NONE")
+    def test09_path_none(self):
+        result = self.h.log("msg", path="NONE")
         self.assertEqual(result, "msg")
-        self.assertEqual(self.h.buffer[0]["treepath"], "NONE")
+        self.assertEqual(self.h.buffer[0]["path"], "NONE")
 
     def test10_empty_title(self):
-        result = self.h.log("msg", title="", tp="nm.test")
+        result = self.h.log("msg", title="", path="nm.test")
         self.assertEqual(result, "nm.test: msg")
 
     def test11_multiple_messages(self):
@@ -202,11 +202,11 @@ class NMHistoryIntegrationTest(unittest.TestCase):
 
     def test02_nmu_history_routes_to_buffer(self):
         self.nm.history.clear()
-        nmu.history("test via nmu", treepath="nm.test", quiet=True)
+        nmu.history("test via nmu", path="nm.test", quiet=True)
         buf = self.nm.history.buffer
         self.assertEqual(len(buf), 1)
         self.assertEqual(buf[0]["message"], "test via nmu")
-        self.assertEqual(buf[0]["treepath"], "nm.test")
+        self.assertEqual(buf[0]["path"], "nm.test")
 
     def test03_object_history_routes_to_buffer(self):
         self.nm.history.clear()

--- a/tests/test_core/test_nm_object.py
+++ b/tests/test_core/test_nm_object.py
@@ -207,17 +207,27 @@ class NMObjectTest(unittest.TestCase):
         ct = {"nmmanager": "nm", "nmobject": self.o0.name}
         self.assertEqual(self.o0.content_tree, ct)
 
-    def test06_treepath(self):
-        tp = NM0.name + "." + self.o0.name
-        self.assertEqual(self.o0._treepath_str(), tp)
-        tp = [NM0.name, self.o0.name]
-        self.assertEqual(self.o0.treepath(), tp)
+    def test06_path(self):
+        # Test path property (list of names)
+        expected_path = [NM0.name, self.o0.name]
+        self.assertEqual(self.o0.path, expected_path)
 
+        # Test path_str property (dotted string)
+        expected_str = NM0.name + "." + self.o0.name
+        self.assertEqual(self.o0.path_str, expected_str)
+
+        # Test path_objects property (list of NMObject references)
+        path_objs = self.o0.path_objects
+        self.assertEqual(len(path_objs), 2)
+        self.assertIs(path_objs[0], NM0)
+        self.assertIs(path_objs[1], self.o0)
+
+        # Test nested object
         o2 = NMObject2(parent=NM0, name=ONAME0)
-        tp = NM0.name + "." + ONAME0 + ".myobject"
-        self.assertEqual(o2.myobject._treepath_str(), tp)
-        tp = [NM0.name, ONAME0, "myobject"]
-        self.assertEqual(o2.myobject.treepath(), tp)
+        expected_path = [NM0.name, ONAME0, "myobject"]
+        self.assertEqual(o2.myobject.path, expected_path)
+        expected_str = NM0.name + "." + ONAME0 + ".myobject"
+        self.assertEqual(o2.myobject.path_str, expected_str)
 
     def test07_notes(self):
         self.assertTrue(self.o0.notes_on)

--- a/tests/test_core/test_nm_utilities.py
+++ b/tests/test_core/test_nm_utilities.py
@@ -155,7 +155,7 @@ class NMUtilitiesTest(unittest.TestCase):
         self.assertEqual(nmu.input_yesno("test", answer="CANCEL"), "c")
         self.assertEqual(nmu.input_yesno("test", answer="C"), "c")
         self.assertEqual(nmu.input_yesno("test", cancel=False, answer="C"), "error")
-        p1 = nmu.input_yesno("testprompt", title='MyTitle', treepath='my.path')
+        p1 = nmu.input_yesno("testprompt", title='MyTitle', path='my.path')
         p2 = "MyTitle:" + "\n" + "my.path:" + "\n" + "testprompt" + "\n" + "(y)es (n)o (c)ancel: "
         self.assertEqual(p1, p2)
         # print(p1)
@@ -306,14 +306,14 @@ class NMUtilitiesTest(unittest.TestCase):
         r = tp + ': ' + h
         self.assertEqual(nmu.history(h, tp=tp, quiet=quiet), r)
 
-        # get_treepath
+        # get_path
         stack = inspect.stack()
         fxn = 'test_all'  # calling fxn
         r = 'nm.' + c + '.' + fxn
-        self.assertEqual(nmu.get_treepath(stack), r)
+        self.assertEqual(nmu.get_path(stack), r)
         tp = 'one.two.three'
         r = 'nm.one.two.three.' + fxn
-        self.assertEqual(nmu.get_treepath(stack, tp=tp), r)
+        self.assertEqual(nmu.get_path(stack, path=tp), r)
         # get_class
         stack = inspect.stack()
         self.assertEqual(nmu.get_class_from_stack(stack), c)


### PR DESCRIPTION
Issue #20

Replace NMObject.treepath() method with cleaner property-based accessors:
- path: list of names ['project0', 'folder0', 'recordA0']
- path_str: dotted string 'project0.folder0.recordA0'
- path_objects: list of NMObject references

Changes:
- Remove treepath() method and _treepath_str() helper
- Add path, path_str, path_objects properties to NMObject
- Rename 'treepath'/'tp' parameter to 'path' throughout codebase
- Update nm_utilities.py and nm_history.py to use 'path' parameter
- Update tests for new path properties