### PR TITLE
Consolidate history logging and improve PEP 8 naming (Issue #24)

### DIFF
--- a/pyneuromatic/analysis/nm_tool.py
+++ b/pyneuromatic/analysis/nm_tool.py
@@ -56,7 +56,7 @@ class NMTool(object):
         elif isinstance(project, NMProject):
             self.__project = project
         else:
-            e = nmu.typeerror(project, "project", "NMProject")
+            e = nmu.type_error_str(project, "project", "NMProject")
             raise TypeError(e)
         return None
 
@@ -79,7 +79,7 @@ class NMTool(object):
                          folder.name, self.__project.name)
                     raise ValueError(e)
         else:
-            e = nmu.typeerror(folder, "folder", "NMFolder")
+            e = nmu.type_error_str(folder, "folder", "NMFolder")
             raise TypeError(e)
         return None
 
@@ -101,7 +101,7 @@ class NMTool(object):
                      data.name, self.__folder.name)
                 raise ValueError(e)
         else:
-            e = nmu.typeerror(data, "data", "NMData")
+            e = nmu.type_error_str(data, "data", "NMData")
             raise TypeError(e)
         return None
 
@@ -123,7 +123,7 @@ class NMTool(object):
                      dataseries.name, self.__folder.name)
                 raise ValueError(e)
         else:
-            e = nmu.typeerror(dataseries, "dataseries", "NMDataSeries")
+            e = nmu.type_error_str(dataseries, "dataseries", "NMDataSeries")
             raise TypeError(e)
         return None
 
@@ -145,7 +145,7 @@ class NMTool(object):
                      channel.name, self.__dataseries.name)
                 raise ValueError(e)
         else:
-            e = nmu.typeerror(channel, "channel", "NMChannel")
+            e = nmu.type_error_str(channel, "channel", "NMChannel")
             raise TypeError(e)
         return None
 
@@ -167,7 +167,7 @@ class NMTool(object):
                      epoch.name, self.__dataseries.name)
                 raise ValueError(e)
         else:
-            e = nmu.typeerror(epoch, "epoch", "NMEpoch")
+            e = nmu.type_error_str(epoch, "epoch", "NMEpoch")
             raise TypeError(e)
         return None
 
@@ -193,42 +193,42 @@ class NMTool(object):
             if v is None or isinstance(v, NMProject):
                 self.project = v
             else:
-                e = nmu.typeerror(v, "project", "NMProject")
+                e = nmu.type_error_str(v, "project", "NMProject")
                 raise TypeError(e)
         if "folder" in select_values:
             v = select_values["folder"]
             if v is None or isinstance(v, NMFolder):
                 self.folder = v
             else:
-                e = nmu.typeerror(v, "folder", "NMFolder")
+                e = nmu.type_error_str(v, "folder", "NMFolder")
                 raise TypeError(e)
         if "data" in select_values:
             v = select_values["data"]
             if v is None or isinstance(v, NMData):
                 self.data = v
             else:
-                e = nmu.typeerror(v, "data", "NMData")
+                e = nmu.type_error_str(v, "data", "NMData")
                 raise TypeError(e)
         if "dataseries" in select_values:
             v = select_values["dataseries"]
             if v is None or isinstance(v, NMDataSeries):
                 self.dataseries = v
             else:
-                e = nmu.typeerror(v, "dataseries", "NMDataSeries")
+                e = nmu.type_error_str(v, "dataseries", "NMDataSeries")
                 raise TypeError(e)
         if "channel" in select_values:
             v = select_values["channel"]
             if v is None or isinstance(v, NMChannel):
                 self.channel = v
             else:
-                e = nmu.typeerror(v, "channel", "NMChannel")
+                e = nmu.type_error_str(v, "channel", "NMChannel")
                 raise TypeError(e)
         if "epoch" in select_values:
             v = select_values["epoch"]
             if v is None or isinstance(v, NMEpoch):
                 self.epoch = v
             else:
-                e = nmu.typeerror(v, "epoch", "NMEpoch")
+                e = nmu.type_error_str(v, "epoch", "NMEpoch")
                 raise TypeError(e)
 
     @property

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -143,7 +143,7 @@ class NMToolStats(NMTool):
         if isinstance(xclip, bool):
             self.__xclip = xclip
         else:
-            e = nmu.typeerror(xclip, "xclip", "boolean")
+            e = nmu.type_error_str(xclip, "xclip", "boolean")
             raise TypeError(e)
 
     @property
@@ -162,7 +162,7 @@ class NMToolStats(NMTool):
         if isinstance(ignore_nans, bool):
             self.__ignore_nans = ignore_nans
         else:
-            e = nmu.typeerror(ignore_nans, "ignore_nans", "boolean")
+            e = nmu.type_error_str(ignore_nans, "ignore_nans", "boolean")
             raise TypeError(e)
 
     # override, no super
@@ -349,7 +349,7 @@ class NMStatsWin(NMObject):
         elif isinstance(win, dict):
             self._win_set(win, quiet=True)
         else:
-            e = nmu.typeerror(win, "win", "dictionary")
+            e = nmu.type_error_str(win, "win", "dictionary")
             raise TypeError(e)
 
     # override
@@ -432,11 +432,11 @@ class NMStatsWin(NMObject):
         quiet: bool = nmp.QUIET
     ) -> None:
         if not isinstance(win, dict):
-            e = nmu.typeerror(win, "win", "dictionary")
+            e = nmu.type_error_str(win, "win", "dictionary")
             raise TypeError(e)
         for k, v in win.items():
             if not isinstance(k, str):
-                e = nmu.typeerror(k, "key", "string")
+                e = nmu.type_error_str(k, "key", "string")
                 raise TypeError(e)
             k = k.lower()
             if k == "on":
@@ -471,7 +471,7 @@ class NMStatsWin(NMObject):
 
     def _on_set(self, on: bool, quiet: bool = nmp.QUIET) -> None:
         if not isinstance(on, bool):
-            e = nmu.typeerror(on, "on", "boolean")
+            e = nmu.type_error_str(on, "on", "boolean")
             raise TypeError(e)
         self.__on = on
         return None
@@ -511,14 +511,14 @@ class NMStatsWin(NMObject):
             func_name = func
             func = {"name": func_name}
         else:
-            e = nmu.typeerror(func, "func", "dictionary, string or None")
+            e = nmu.type_error_str(func, "func", "dictionary, string or None")
             raise TypeError(e)
 
         if func_name is None:
             self.__func.clear()
             return None
         if not isinstance(func_name, str):
-            e = nmu.typeerror(func_name, "func_name", "string")
+            e = nmu.type_error_str(func_name, "func_name", "string")
             raise TypeError(e)
 
         found = False
@@ -623,7 +623,7 @@ class NMStatsWin(NMObject):
         if transform_list is None:
             pass
         elif not isinstance(transform_list, list):
-            e = nmu.typeerror(transform_list, "transform_list", "list")
+            e = nmu.type_error_str(transform_list, "transform_list", "list")
             raise TypeError(e)
         self.__transform = transform_list
         return None
@@ -638,7 +638,7 @@ class NMStatsWin(NMObject):
 
     def _bsln_on_set(self, on: bool, quiet: bool = nmp.QUIET) -> None:
         if not isinstance(on, bool):
-            e = nmu.typeerror(on, "on", "boolean")
+            e = nmu.type_error_str(on, "on", "boolean")
             raise TypeError(e)
         self.__bsln_on = on
         return None
@@ -672,14 +672,14 @@ class NMStatsWin(NMObject):
         elif isinstance(func, str):
             func_name = func
         else:
-            e = nmu.typeerror(func, "func", "dictionary, string or None")
+            e = nmu.type_error_str(func, "func", "dictionary, string or None")
             raise TypeError(e)
 
         if func_name is None:
             self.__bsln_func.clear()
             return None
         if not isinstance(func_name, str):
-            e = nmu.typeerror(func_name, "func_name", "string")
+            e = nmu.type_error_str(func_name, "func_name", "string")
             raise TypeError(e)
 
         found = False
@@ -738,7 +738,7 @@ class NMStatsWin(NMObject):
         f = self.__func["name"]
 
         if not isinstance(f, str):
-            e = nmu.typeerror(f, "func_name", "string")
+            e = nmu.type_error_str(f, "func_name", "string")
             raise TypeError(e)
 
         f = f.lower()
@@ -1322,7 +1322,7 @@ def check_meanatmaxmin(
                 if isinstance(v, str):
                     func_name = v
                 else:
-                    e = nmu.typeerror(v, "func name", "string")
+                    e = nmu.type_error_str(v, "func name", "string")
                     raise TypeError(e)
             elif k == "imean":
                 if v is not None:
@@ -1332,7 +1332,7 @@ def check_meanatmaxmin(
     elif isinstance(func, str):
         func_name = func
     else:
-        e = nmu.typeerror(func, "func", "dictionary or string")
+        e = nmu.type_error_str(func, "func", "dictionary or string")
         raise TypeError(e)
     if func_name is None:
         raise KeyError("missing func key 'name'")
@@ -1362,7 +1362,7 @@ def input_meanatmaxmin(
     test_input: str | None = None
 ) -> dict:
     if not isinstance(func_name, str):
-        e = nmu.typeerror(func_name, "func_name", "string")
+        e = nmu.type_error_str(func_name, "func_name", "string")
         raise TypeError(e)
     f = func_name.lower()
     fnames = ["max", "min", "mean@max", "mean@min"]
@@ -1379,7 +1379,7 @@ def input_meanatmaxmin(
     elif isinstance(test_input, str):
         imean = int(test_input)  # might raise type error
     else:
-        e = nmu.typeerror(test_input, "test_input", "string or None")
+        e = nmu.type_error_str(test_input, "test_input", "string or None")
         raise TypeError(e)
     if math.isnan(imean) or math.isinf(imean) or imean < 0:
         raise ValueError("imean: '%s'" % imean)
@@ -1407,7 +1407,7 @@ def check_level(
                 if isinstance(v, str):
                     func_name = v
                 else:
-                    e = nmu.typeerror(v, "func name", "string")
+                    e = nmu.type_error_str(v, "func name", "string")
                     raise TypeError(e)
             elif k == "option":
                 option = int(v)  # might raise type error
@@ -1427,7 +1427,7 @@ def check_level(
     elif isinstance(func, str):
         func_name = func
     else:
-        e = nmu.typeerror(func, "func", "dictionary or string")
+        e = nmu.type_error_str(func, "func", "dictionary or string")
         raise TypeError(e)
     if func_name is None:
         raise KeyError("missing func key 'name'")
@@ -1488,7 +1488,7 @@ def input_level(
                2: "# std (nstd) > baseline",
                3: "# std (nstd) < baseline"}
     if not isinstance(func_name, str):
-        e = nmu.typeerror(func_name, "func_name", "string")
+        e = nmu.type_error_str(func_name, "func_name", "string")
         raise TypeError(e)
     f = func_name.lower()
     if f not in fnames:
@@ -1498,7 +1498,7 @@ def input_level(
     if test_input is None or isinstance(test_input, str):
         pass
     else:
-        e = nmu.typeerror(test_input, "test_input", "string or None")
+        e = nmu.type_error_str(test_input, "test_input", "string or None")
         raise TypeError(e)
     t = "stats " + f + ": "
     if option not in options:
@@ -1564,7 +1564,7 @@ def check_risefall(
                 if isinstance(v, str):
                     func_name = v
                 else:
-                    e = nmu.typeerror(func_name, "func name", "string")
+                    e = nmu.type_error_str(func_name, "func name", "string")
                     raise TypeError(e)
             elif k == "p0":
                 if v is not None:
@@ -1577,7 +1577,7 @@ def check_risefall(
     elif isinstance(func, str):
         func_name = func.lower()
     else:
-        e = nmu.typeerror(func, "func", "dictionary or string")
+        e = nmu.type_error_str(func, "func", "dictionary or string")
         raise TypeError(e)
     if func_name is None:
         raise KeyError("missing func key 'name'")
@@ -1635,7 +1635,7 @@ def input_risefall(
     fnames = ["risetime+", "risetime-", "risetimeslope+", "risetimeslope-",
               "falltime+", "falltime-", "falltimeslope+", "falltimeslope-"]
     if not isinstance(func_name, str):
-        e = nmu.typeerror(func_name, "func_name", "string")
+        e = nmu.type_error_str(func_name, "func_name", "string")
         raise TypeError(e)
     f = func_name.lower()
     if f not in fnames:
@@ -1665,7 +1665,7 @@ def input_risefall(
     elif isinstance(test_input, str):
         option = int(test_input)
     else:
-        e = nmu.typeerror(test_input, "test_input", "string or None")
+        e = nmu.type_error_str(test_input, "test_input", "string or None")
         raise TypeError(e)
     if option not in options:
         keys = list(options.keys())
@@ -1692,7 +1692,7 @@ def check_fwhm(
                 if isinstance(v, str):
                     func_name = v
                 else:
-                    e = nmu.typeerror(v, "func name", "string")
+                    e = nmu.type_error_str(v, "func name", "string")
                     raise TypeError(e)
             elif k == "p0":
                 if v is not None:
@@ -1705,7 +1705,7 @@ def check_fwhm(
     elif isinstance(func, str):
         func_name = func
     else:
-        e = nmu.typeerror(func, "func", "dictionary or string")
+        e = nmu.type_error_str(func, "func", "dictionary or string")
         raise TypeError(e)
     if func_name is None:
         raise KeyError("missing func key 'name'")
@@ -1741,14 +1741,14 @@ def stats(
 ) -> dict:  # returns results
 
     if not isinstance(data, NMData):
-        e = nmu.typeerror(data, "data", "NMData")
+        e = nmu.type_error_str(data, "data", "NMData")
         raise TypeError(e)
     if not isinstance(data.y.nparray, np.ndarray):
-        e = nmu.typeerror(data.y.nparray, "nparray", "NumPy.ndarray")
+        e = nmu.type_error_str(data.y.nparray, "nparray", "NumPy.ndarray")
         raise TypeError(e)
 
     if not isinstance(func, dict):
-        e = nmu.typeerror(func, "func", "dictionary")
+        e = nmu.type_error_str(func, "func", "dictionary")
         raise TypeError(e)
     if "name" not in func:
         e = "missing key 'name' in func dictionary"
@@ -1756,7 +1756,7 @@ def stats(
 
     f = func["name"]
     if not isinstance(f, str):
-        e = nmu.typeerror(f, "func_name", "string")
+        e = nmu.type_error_str(f, "func_name", "string")
         raise TypeError(e)
     f = f.lower()
 
@@ -1771,7 +1771,7 @@ def stats(
     if results is None:
         results = {}
     elif not isinstance(results, dict):
-        e = nmu.typeerror(results, "results", "dictionary")
+        e = nmu.type_error_str(results, "results", "dictionary")
         raise TypeError(e)
 
     # results["func"] = f
@@ -2156,7 +2156,7 @@ def find_level_crossings(
     #    x-interp = 14.3333
 
     if not isinstance(func_name, str):
-        e = nmu.typeerror(func_name, "func_name", "string")
+        e = nmu.type_error_str(func_name, "func_name", "string")
         raise TypeError(e)
 
     f = func_name.lower()
@@ -2171,7 +2171,7 @@ def find_level_crossings(
         ylevel = float(ylevel)  # might raise type error
 
     if not isinstance(yarray, np.ndarray):
-        e = nmu.typeerror(yarray, "yarray", "NumPy.ndarray")
+        e = nmu.type_error_str(yarray, "yarray", "NumPy.ndarray")
         raise TypeError(e)
 
     found_xarray = False
@@ -2186,7 +2186,7 @@ def find_level_crossings(
                  % (xarray.size, yarray.size))
             raise RuntimeError(e)
     else:
-        e = nmu.typeerror(xarray, "xarray", "NumPy.ndarray")
+        e = nmu.type_error_str(xarray, "xarray", "NumPy.ndarray")
         raise TypeError(e)
 
     if isinstance(xstart, float):
@@ -2303,7 +2303,7 @@ def linear_regression(
 ) -> tuple:  # (m, b)
 
     if not isinstance(yarray, np.ndarray):
-        e = nmu.typeerror(yarray, "yarray", "NumPy.ndarray")
+        e = nmu.type_error_str(yarray, "yarray", "NumPy.ndarray")
         raise TypeError(e)
 
     found_xarray = False
@@ -2318,7 +2318,7 @@ def linear_regression(
                  % (xarray.size, yarray.size))
             raise RuntimeError(e)
     else:
-        e = nmu.typeerror(xarray, "xarray", "NumPy.ndarray")
+        e = nmu.type_error_str(xarray, "xarray", "NumPy.ndarray")
         raise TypeError(e)
 
     if not found_xarray:
@@ -2329,7 +2329,7 @@ def linear_regression(
         elif isinstance(xstart, int) and not isinstance(xstart, bool):
             pass
         else:
-            e = nmu.typeerror(xstart, "xstart", "float")
+            e = nmu.type_error_str(xstart, "xstart", "float")
             raise TypeError(e)
 
         if isinstance(xdelta, float):
@@ -2338,7 +2338,7 @@ def linear_regression(
         elif isinstance(xdelta, int) and not isinstance(xdelta, bool):
             pass
         else:
-            e = nmu.typeerror(xdelta, "xdelta", "float")
+            e = nmu.type_error_str(xdelta, "xdelta", "float")
             raise TypeError(e)
 
         x0 = xstart

--- a/pyneuromatic/core/nm_channel.py
+++ b/pyneuromatic/core/nm_channel.py
@@ -89,7 +89,7 @@ class NMChannel(NMObject):
         elif isinstance(xscale, dict):
             self.__x = NMDimensionX(parent=self, name="xscale", scale=xscale)
         else:
-            e = nmu.typeerror(xscale, "xscale", "dictionary or NMDimensionX")
+            e = nmu.type_error_str(xscale, "xscale", "dictionary or NMDimensionX")
             raise TypeError(e)
 
         # Initialize __y based on yscale parameter
@@ -100,7 +100,7 @@ class NMChannel(NMObject):
         elif isinstance(yscale, dict):
             self.__y = NMDimension(parent=self, name="yscale", scale=yscale)
         else:
-            e = nmu.typeerror(yscale, "yscale", "dictionary or NMDimension")
+            e = nmu.type_error_str(yscale, "yscale", "dictionary or NMDimension")
             raise TypeError(e)
 
     # override

--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -90,7 +90,7 @@ class NMData(NMObject):
         elif isinstance(xdim, NMDimensionX):
             self.__x = xdim
         else:
-            e = nmu.typeerror(xdim, "xdim", "NMDimensionX")
+            e = nmu.type_error_str(xdim, "xdim", "NMDimensionX")
             raise TypeError(e)
 
         if ydim is None:
@@ -98,7 +98,7 @@ class NMData(NMObject):
         elif isinstance(ydim, NMDimension):
             self.__y = ydim
         else:
-            e = nmu.typeerror(ydim, "ydim", "NMDimension")
+            e = nmu.type_error_str(ydim, "ydim", "NMDimension")
             raise TypeError(e)
 
         self.__x.ypair = self.__y.nparray
@@ -279,12 +279,12 @@ class NMData(NMObject):
         if channel is None or isinstance(channel, NMChannel):
             self.__dataseries_channel = channel
         else:
-            e = nmu.typeerror(channel, "channel", "NMChannel")
+            e = nmu.type_error_str(channel, "channel", "NMChannel")
             raise TypeError(e)
         if epoch is None or isinstance(epoch, NMEpoch):
             self.__dataseries_epoch = epoch
         else:
-            e = nmu.typeerror(epoch, "epoch", "NMEpoch")
+            e = nmu.type_error_str(epoch, "epoch", "NMEpoch")
             raise TypeError(e)
         return self._dataseries
 
@@ -342,7 +342,7 @@ class NMDataContainer(NMObjectContainer):
 
     # override
     # TODO: this no longer works
-    def remove(self, names=[], indexes=[], confirm=True, quiet=nmp.QUIET):
+    def remove(self, names=[], indexes=[], confirm=True, quiet=False):
         rlist = super().remove(
             names=names, indexes=indexes, confirm=confirm, quiet=quiet
         )

--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -26,6 +26,7 @@ from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
 from pyneuromatic.core.nm_channel import NMChannelContainer
 from pyneuromatic.core.nm_epoch import NMEpochContainer
+import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
 
@@ -233,7 +234,7 @@ class NMDataSeries(NMObject):
         on: bool
     ) -> None:
         if not isinstance(on, bool):
-            e = nmu.typeerror(on, "channel_scale_lock", "boolean")
+            e = nmu.type_error_str(on, "channel_scale_lock", "boolean")
             raise TypeError(e)
         self.__channel_scale_lock = on
 
@@ -250,7 +251,7 @@ class NMDataSeries(NMObject):
         on: bool
     ) -> None:
         if not isinstance(on, bool):
-            e = nmu.typeerror(on, "xscale_lock", "boolean")
+            e = nmu.type_error_str(on, "xscale_lock", "boolean")
             raise TypeError(e)
         self.__xscale_lock = on
 
@@ -270,10 +271,10 @@ class NMDataSeries(NMObject):
     def _dims_set(
         self, 
         dims, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if not isinstance(dims, dict):
-            e = nmu.typeerror(dims, "dims", "dimensions dictionary")
+            e = nmu.type_error_str(dims, "dims", "dimensions dictionary")
             raise TypeError(e)
         keys = dims.keys()
         for k in keys:
@@ -315,12 +316,12 @@ class NMDataSeries(NMObject):
     def _xdata_set(
         self, 
         xdata, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if xdata is None:
             pass  # ok
         elif xdata.__class__.__name__ != "NMData":  # cannot import Data class
-            e = nmu.typeerror(xdata, "xdata", "NMData")
+            e = nmu.type_error_str(xdata, "xdata", "NMData")
             raise TypeError(e)
         old = self.xdata
         # if xdata == old:
@@ -330,8 +331,8 @@ class NMDataSeries(NMObject):
                 d._xdata_set(xdata, alert=False, quiet=True)
         self.__dims = {}  # reset
         new = self.xdata
-        h = nmu.history_change("xdata", old, new)
-        # self._history(h, quiet=quiet)
+        # h = nmh.history_change_str("xdata", old, new)
+        # nmh.history(h, quiet=quiet)
         return True
 
     @property
@@ -354,10 +355,10 @@ class NMDataSeries(NMObject):
     def _xstart_set(
         self, 
         xstart, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if not isinstance(xstart, float) and not isinstance(xstart, int):
-            e = nmu.typeerror(xstart, "xstart", "number")
+            e = nmu.type_error_str(xstart, "xstart", "number")
             raise TypeError(e)
         if not nmu.number_ok(xstart):
             raise ValueError("xstart: %s" % xstart)
@@ -386,7 +387,7 @@ class NMDataSeries(NMObject):
     def _xdelta_set(
         self, 
         xdelta, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if np.isinf(xdelta) or np.isnan(xdelta):
             return False
@@ -415,10 +416,10 @@ class NMDataSeries(NMObject):
     def _xlabel_set(
         self, 
         xlabel, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if not isinstance(xlabel, str):
-            e = nmu.typeerror(xlabel, "xlabel", "string")
+            e = nmu.type_error_str(xlabel, "xlabel", "string")
             raise TypeError(e)
         for c, cdata in self.__thedata.items():
             for d in cdata:
@@ -445,10 +446,10 @@ class NMDataSeries(NMObject):
     def _xunits_set(
         self, 
         xunits, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if not isinstance(xunits, str):
-            e = nmu.typeerror(xunits, "xunits", "string")
+            e = nmu.type_error_str(xunits, "xunits", "string")
             raise TypeError(e)
         for c, cdata in self.__thedata.items():
             for d in cdata:
@@ -475,20 +476,20 @@ class NMDataSeries(NMObject):
     def _ylabel_set(
         self, 
         chan_ylabel, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if isinstance(chan_ylabel, str):
             chan_ylabel = {"A": chan_ylabel}
         elif not isinstance(chan_ylabel, dict):
-            e = nmu.typeerror(chan_ylabel, "chan_ylabel", "channel dictionary")
+            e = nmu.type_error_str(chan_ylabel, "chan_ylabel", "channel dictionary")
             raise TypeError(e)
         for cc, ylabel in chan_ylabel.items():
             if not isinstance(ylabel, str):
-                e = nmu.typeerror(ylabel, "ylabel", "string")
+                e = nmu.type_error_str(ylabel, "ylabel", "string")
                 raise TypeError(e)
             # elif c not in self.__thedata.keys():
             if not isinstance(cc, str):
-                e = nmu.typeerror(cc, "channel", "character")
+                e = nmu.type_error_str(cc, "channel", "character")
                 raise TypeError(e)
             cc2 = nmu.chanel_char_check(cc)
             if not cc2:
@@ -532,16 +533,16 @@ class NMDataSeries(NMObject):
     def _yunits_set(
         self, 
         chan_yunits, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if isinstance(chan_yunits, str):
             chan_yunits = {"A": chan_yunits}
         elif not isinstance(chan_yunits, dict):
-            e = nmu.typeerror(chan_yunits, "chan_yunits", "channel dictionary")
+            e = nmu.type_error_str(chan_yunits, "chan_yunits", "channel dictionary")
             raise TypeError(e)
         for c, yunits in chan_yunits.items():
             if not isinstance(yunits, str):
-                e = nmu.typeerror(yunits, "yunits", "string")
+                e = nmu.type_error_str(yunits, "yunits", "string")
                 raise TypeError(e)
             # elif c not in self.__thedata.keys():
             elif not nmu.channel_char_check(c):
@@ -591,7 +592,7 @@ class NMDataSeries(NMObject):
     #    return self.__set_container
     """
     def _sets_init(self, set_list=nmp.DATASERIES_SET_LIST, select=True,
-                   quiet=nmp.QUIET):
+                   quiet=False):
         if not set_list:
             return []
         if not isinstance(set_list, list):
@@ -613,7 +614,7 @@ class NMDataSeries(NMObject):
         self, 
         chan_list=ALLSTR, 
         epoch_list=[-2], 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         d = self.get_data(chan_list=chan_list, epoch_list=epoch_list, quiet=quiet)
         n = {}
@@ -626,7 +627,7 @@ class NMDataSeries(NMObject):
         self, 
         chan_list=ALLSTR, 
         epoch_list=[-2], 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if not self.__thedata:
             return {}
@@ -640,7 +641,7 @@ class NMDataSeries(NMObject):
         for ep in epoch_list:
             if not isinstance(ep, int):
                 epoch = ep
-                e = nmu.typeerror(ep, "epoch", "integer")
+                e = nmu.type_error_str(ep, "epoch", "integer")
                 raise TypeError(e)
             if ep == -1:
                 elist = self.__epoch_select
@@ -724,7 +725,7 @@ class NMDataSeries(NMObject):
 
     def update(
         self, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         foundsomething = False
         htxt = []
@@ -742,10 +743,10 @@ class NMDataSeries(NMObject):
                 break  # no more channels
         if not foundsomething:
             a = "failed to find data with prefix '%s'" % self.name
-            self._alert(a, quiet=quiet)
-        for h in htxt:
-            h = "found data with prefix '%s' : %s" % (self.name, h)
-            # self._history(h, quiet=quiet)
+            nmh.alert(a, quiet=quiet)
+        # for h in htxt:
+            # h = "found data with prefix '%s' : %s" % (self.name, h)
+            # nmh.history(h, quiet=quiet)
         return True
 
     def make(
@@ -755,7 +756,7 @@ class NMDataSeries(NMObject):
         shape=[], 
         fill_value=0, 
         dims={}, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if not nmu.number_ok(channels, no_neg=True, no_zero=True):
             raise ValueError("channels: %s" % channels)
@@ -794,13 +795,13 @@ class NMDataSeries(NMObject):
                     dlist.append(d)
                 else:
                     a = "failed to create '%s'" % name2
-                    self._alert(a, quiet=quiet)
+                    nmh.alert(a, quiet=quiet)
             dlist2 = self.__thedata[cc]
             dlist2.extend(dlist)
             self.__thedata[cc] = dlist2
             ep = nmu.int_list_to_seq_str(elist, seperator=",")
-            h = "created '%s', ch=%s, ep=%s" % (self.name, cc, ep)
-            # self._history(h, quiet=quiet)
+            # h = "created '%s', ch=%s, ep=%s" % (self.name, cc, ep)
+            # nmh.history(h, quiet=quiet)
         if dims:
             self.dims = dims
         return True
@@ -810,10 +811,10 @@ class NMDataSeries(NMObject):
         name, 
         shape=[], 
         dims={}, 
-        quiet=nmp.QUIET
+        quiet=False
     ):
         if not isinstance(dims, dict):
-            e = nmu.typeerror(dims, "dims", "dimensions dictionary")
+            e = nmu.type_error_str(dims, "dims", "dimensions dictionary")
             raise TypeError(e)
         dims.update({"xstart": 0, "xdelta": 1})  # enforce
         if "xlabel" in dims.keys():  # switch x and y

--- a/pyneuromatic/core/nm_dimension.py
+++ b/pyneuromatic/core/nm_dimension.py
@@ -24,6 +24,7 @@ import math
 import numpy as np
 
 from pyneuromatic.core.nm_object import NMObject
+import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
 
@@ -57,7 +58,7 @@ class NMDimension(NMObject):
                      nparray.ndim)
                 raise ValueError(e)
         else:
-            e = nmu.typeerror(nparray, "nparray", "np.ndarray")
+            e = nmu.type_error_str(nparray, "nparray", "np.ndarray")
             raise TypeError(e)
 
         self.__nparray = nparray
@@ -69,7 +70,7 @@ class NMDimension(NMObject):
         elif isinstance(scale, dict):
             self._scale_set(scale, quiet=True)
         else:
-            e = nmu.typeerror(scale, "scale", "dictionary")
+            e = nmu.type_error_str(scale, "scale", "dictionary")
             raise TypeError(e)
 
     # override
@@ -191,7 +192,7 @@ class NMDimension(NMObject):
         quiet: bool = nmp.QUIET
     ) -> None:
         if not isinstance(scale, dict):
-            e = nmu.typeerror(scale, "scale", "dictionary")
+            e = nmu.type_error_str(scale, "scale", "dictionary")
             raise TypeError(e)
         for k, v in scale.items():
             k = k.lower()
@@ -219,16 +220,16 @@ class NMDimension(NMObject):
         quiet: bool = nmp.QUIET
     ) -> None:
         if label is not None and not isinstance(label, str):
-            e = nmu.typeerror(label, "label", "string")
+            e = nmu.type_error_str(label, "label", "string")
             raise TypeError(e)
         if isinstance(label, str):
             label = label.strip()
         if label == self.__label:
             return None  # no change
         self.__label = label
-        # h = nmu.history_change("label", old, label)
+        # h = nmh.history_change_str("label", old, label)
         # self.note = h
-        # self._history(h, quiet=quiet)
+        # nmh.history(h, quiet=quiet)
         return None
 
     @property
@@ -245,16 +246,16 @@ class NMDimension(NMObject):
         quiet: bool = nmp.QUIET
     ) -> None:
         if units is not None and not isinstance(units, str):
-            e = nmu.typeerror(units, "units", "string")
+            e = nmu.type_error_str(units, "units", "string")
             raise TypeError(e)
         if isinstance(units, str):
             units = units.strip()
         if units == self.__units:
             return None  # no change
         self.__units = units
-        # h = nmu.history_change("units", old, units)
+        # h = nmh.history_change_str("units", old, units)
         # self.note = h
-        # self._history(h, quiet=quiet)
+        # nmh.history(h, quiet=quiet)
         return None
 
     @property
@@ -268,12 +269,12 @@ class NMDimension(NMObject):
     def _nparray_set(
         self,
         nparray,
-        # quiet=nmp.QUIET
+        # quiet=False
     ) -> None:
         if nparray is None:
             pass  # ok
         elif not isinstance(nparray, np.ndarray):
-            e = nmu.typeerror(nparray, "nparray", "np.ndarray")
+            e = nmu.type_error_str(nparray, "nparray", "np.ndarray")
             raise TypeError(e)
         self.__nparray = nparray
         return None
@@ -393,7 +394,7 @@ class NMDimensionX(NMDimension):
         quiet: bool = nmp.QUIET
     ) -> None:
         if not isinstance(scale, dict):
-            e = nmu.typeerror(scale, "scale", "dictionary")
+            e = nmu.type_error_str(scale, "scale", "dictionary")
             raise TypeError(e)
         for k, v in scale.items():
             k = k.lower()
@@ -442,14 +443,14 @@ class NMDimensionX(NMDimension):
                 if math.isinf(start) or math.isnan(start):
                     raise ValueError("start: %s" % start)
             elif not (isinstance(start, int) and not isinstance(start, bool)):
-                e = nmu.typeerror(start, "start", "float")
+                e = nmu.type_error_str(start, "start", "float")
                 raise TypeError(e)
         if start == self.__start:
             return None  # no change
         self.__start = start
-        # h = nmu.history_change("start", old, start)
+        # h = nmh.history_change_str("start", old, start)
         # self.note = h
-        # self._history(h, quiet=quiet)
+        # nmh.history(h, quiet=quiet)
         return None
 
     @property
@@ -478,16 +479,16 @@ class NMDimensionX(NMDimension):
                 if math.isinf(delta) or math.isnan(delta):
                     raise ValueError("delta: %s" % delta)
             elif not (isinstance(delta, int) and not isinstance(delta, bool)):
-                e = nmu.typeerror(delta, "delta", "float")
+                e = nmu.type_error_str(delta, "delta", "float")
                 raise TypeError(e)
             if delta == 0:
                 raise ValueError("delta: %s" % delta)
         if delta == self.__delta:
             return None  # no change
         self.__delta = delta
-        # h = nmu.history_change("delta", old, delta)
+        # h = nmh.history_change_str("delta", old, delta)
         # self.note = h
-        # self._history(h, quiet=quiet)
+        # nmh.history(h, quiet=quiet)
         return None
 
     @property
@@ -521,16 +522,16 @@ class NMDimensionX(NMDimension):
             elif isinstance(points, np.integer):
                 points = int(points)
             elif not (isinstance(points, int) and not isinstance(points, bool)):
-                e = nmu.typeerror(points, "points", "integer")
+                e = nmu.type_error_str(points, "points", "integer")
                 raise TypeError(e)
             if points < 0:
                 raise ValueError("points: %s" % points)
         if points == self.__points:
             return None  # no change
         self.__points = points
-        # h = nmu.history_change("points", old, points)
+        # h = nmh.history_change_str("points", old, points)
         # self.note = h
-        # self._history(h, quiet=quiet)
+        # nmh.history(h, quiet=quiet)
         return None
 
     @property
@@ -544,7 +545,7 @@ class NMDimensionX(NMDimension):
     def _ypair_set(
         self,
         nparray,
-        # quiet=nmp.QUIET
+        # quiet=False
     ) -> None:
         if nparray is None:
             pass
@@ -555,7 +556,7 @@ class NMDimensionX(NMDimension):
                          % (self.nparray.size, nparray.size))
                     raise RuntimeError(e)
         else:
-            e = nmu.typeerror(nparray, "nparray", "np.ndarray")
+            e = nmu.type_error_str(nparray, "nparray", "np.ndarray")
             raise TypeError(e)
         self.__ypair = nparray
         return None
@@ -567,7 +568,7 @@ class NMDimensionX(NMDimension):
     ) -> int | None:
 
         if not (isinstance(xvalue, (float, int)) and not isinstance(xvalue, bool)):
-            e = nmu.typeerror(xvalue, "xvalue", "float")
+            e = nmu.type_error_str(xvalue, "xvalue", "float")
             raise TypeError(e)
 
         if isinstance(self.nparray, np.ndarray):
@@ -622,7 +623,7 @@ class NMDimensionX(NMDimension):
         elif isinstance(index, float):
             i = int(index)
         else:
-            e = nmu.typeerror(index, "index", "integer")
+            e = nmu.type_error_str(index, "index", "integer")
             raise TypeError(e)
 
         if i < 0:

--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -79,7 +79,7 @@ class NMEpoch(NMObject):
         self.__thedata: list[NMData] = []  # list of NMData references
 
         if not isinstance(number, int):
-            e = nmu.typeerror(number, "number", "int")
+            e = nmu.type_error_str(number, "number", "int")
             raise TypeError(e)
 
         self.__number: int = number

--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -179,7 +179,7 @@ class NMFolder(NMObject):
     def toolresults_save(self, tool: str, results: Any) -> str:
         imax_keys = 99
         if not isinstance(tool, str):
-            e = nmu.typeerror(tool, "tool", "string")
+            e = nmu.type_error_str(tool, "tool", "string")
             raise TypeError(e)
 
         tp = self.path_str

--- a/pyneuromatic/core/nm_manager.py
+++ b/pyneuromatic/core/nm_manager.py
@@ -27,7 +27,7 @@ import numpy as np
 from pyneuromatic.core.nm_dataseries import NMDataSeries
 from pyneuromatic.core.nm_dimension import NMDimension, NMDimensionX
 from pyneuromatic.core.nm_folder import NMFolder, NMFolderContainer
-from pyneuromatic.core.nm_history import NMHistory
+import pyneuromatic.core.nm_history as nmh
 from pyneuromatic.core.nm_object import NMObject
 import pyneuromatic.core.nm_preferences as nmp
 from pyneuromatic.core.nm_project import NMProject, NMProjectContainer
@@ -71,8 +71,8 @@ class NMManager(NMObject):
         super().__init__(parent=None, name=name)  # NMObject
 
         # initialize centralized history logging
-        self.__history = NMHistory(quiet=quiet)
-        nmu.set_history(self.__history)
+        self.__history = nmh.NMHistory(quiet=quiet)
+        nmh.set_history(self.__history)
 
         # self.__configs = nmp.Configs()
         # self.__configs.quiet = quiet
@@ -80,7 +80,7 @@ class NMManager(NMObject):
         # for now, only one project
         # self.__project_container = NMProjectContainer(parent=self)
         if not isinstance(project_name, str):
-            e = nmu.typeerror(project_name, "project_name", "string")
+            e = nmu.type_error_str(project_name, "project_name", "string")
             raise TypeError(e)
         self.__project = NMProject(parent=self, name=project_name)
 
@@ -105,18 +105,16 @@ class NMManager(NMObject):
             if p:
                 self.__project_container.select_key = project_name
         else:
-            e = nmu.typeerror(project_name, "project_name", "string")
+            e = nmu.type_error_str(project_name, "project_name", "string")
             raise TypeError(e)
         """
 
         tstr = str(datetime.datetime.now())
         h = ("created NM manager '%s' %s"
              % (self.name, tstr))
-        self._history(h, quiet=quiet)
-        self._history("current NM project is '%s'" % self.__project.name,
-                      quiet=quiet)
-        self._history("current NM tool is '%s'" % self.__toolselect,
-                      quiet=quiet)
+        nmh.history(h, quiet=quiet)
+        nmh.history("current NM project is '%s'" % self.__project.name, quiet=quiet)
+        nmh.history("current NM tool is '%s'" % self.__toolselect, quiet=quiet)
 
     def tool_add(
         self,
@@ -125,7 +123,7 @@ class NMManager(NMObject):
         select: bool = False
     ) -> None:
         if not isinstance(toolname, str):
-            e = nmu.typeerror(toolname, "toolname", "string")
+            e = nmu.type_error_str(toolname, "toolname", "string")
             raise TypeError(e)
         tname = toolname.lower()
         if tool is None:  # look for NM tool
@@ -172,7 +170,7 @@ class NMManager(NMObject):
     #     return self.__project_container
 
     @property
-    def history(self) -> NMHistory:
+    def history(self) -> nmh.NMHistory:
         """Access the centralized NM history log."""
         return self.__history
 
@@ -239,16 +237,16 @@ class NMManager(NMObject):
         # quiet
     ) -> None:
         if not isinstance(select, dict):
-            e = nmu.typeerror(select, "select", "dictionary")
+            e = nmu.type_error_str(select, "select", "dictionary")
             raise TypeError(e)
         for key, value in select.items():
             if not isinstance(key, str):
-                e = nmu.typeerror(key, "key", "string")
+                e = nmu.type_error_str(key, "key", "string")
                 raise TypeError(e)
             if value is None or isinstance(value, str):
                 pass  # ok
             else:
-                e = nmu.typeerror(value, "value", "string")
+                e = nmu.type_error_str(value, "value", "string")
                 raise TypeError(e)
         p = self.__project
         if "project" in select:
@@ -339,11 +337,11 @@ class NMManager(NMObject):
         # can specify 'data' or 'dataseries' but not both
 
         if not isinstance(execute, dict):
-            e = nmu.typeerror(execute, "execute", "dictionary")
+            e = nmu.type_error_str(execute, "execute", "dictionary")
             raise TypeError(e)
         for key, value in execute.items():
             if not isinstance(key, str):
-                e = nmu.typeerror(key, "key", "string")
+                e = nmu.type_error_str(key, "key", "string")
                 raise TypeError(e)
             if key not in [
                 "project",
@@ -356,7 +354,7 @@ class NMManager(NMObject):
                 e = "unknown execute key '%s'" % key
                 raise KeyError(e)
             if not isinstance(value, str):
-                e = nmu.typeerror(value, "value", "string")
+                e = nmu.type_error_str(value, "value", "string")
                 raise TypeError(e)
 
         if "data" in execute and "dataseries" in execute:
@@ -533,7 +531,7 @@ class NMManager(NMObject):
             if tname.lower() == "select":
                 tname = self.__toolselect
         else:
-            e = nmu.typeerror(tname, "toolname", "string")
+            e = nmu.type_error_str(tname, "toolname", "string")
             raise TypeError(e)
         if tname is None:
             raise ValueError("no tool selected")
@@ -574,10 +572,10 @@ class NMManager(NMObject):
         return None
 
     """
-    def _quiet(self, quiet=nmp.QUIET):
+    def _quiet(self) -> bool:
         if self.configs.quiet:  # config quiet overrides
             return True
-        return quiet
+        return nmp.QUIET
     """
 
 

--- a/pyneuromatic/core/nm_object.py
+++ b/pyneuromatic/core/nm_object.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from pyneuromatic.core.nm_manager import NMManager
     from pyneuromatic.core.nm_project import NMProject
 
+import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
 
@@ -138,7 +139,7 @@ class NMObject(object):
         self.__copy_of: NMObject | None = None
 
         if not isinstance(name, str):
-            e = nmu.typeerror(name, "name", "string")
+            e = nmu.type_error_str(name, "name", "string")
             raise TypeError(e)
 
         self._name_set(newname=name, quiet=True)
@@ -399,15 +400,15 @@ class NMObject(object):
         :rtype: None
         """
         if not isinstance(newname, str):
-            e = nmu.typeerror(newname, "newname", "string")
+            e = nmu.type_error_str(newname, "newname", "string")
             raise TypeError(e)
         if not newname or not nmu.name_ok(newname):
             raise ValueError("newname: %s" % newname)
         oldname = self.__name
         self.__name = newname
         self.note = "renamed to '%s'" % self.__name
-        h = nmu.history_change("name", oldname, self.__name)
-        self._history(h, path=self.path_str, quiet=quiet)
+        h = nmh.history_change_str("name", oldname, self.__name)
+        nmh.history(h, path=self.path_str, quiet=quiet)
 
     def _rename_fxnref_set(self, rename_fxnref) -> None:
         """Set the rename function reference for this NMObject.
@@ -418,7 +419,7 @@ class NMObject(object):
         See NMObjectContainer.rename(key, newkey)
         """
         if not isinstance(rename_fxnref, types.MethodType):
-            e = nmu.typeerror(rename_fxnref, "rename_fxnref", "MethodType")
+            e = nmu.type_error_str(rename_fxnref, "rename_fxnref", "MethodType")
             raise TypeError(e)
         # TODO: test if function has 2 arguments?
         self.__rename_fxnref = rename_fxnref
@@ -449,7 +450,7 @@ class NMObject(object):
 
     def _notes_append(self, thenote: str) -> bool:
         if not self.__notes_on:
-            # self._alert('notes are off')
+            # nmh.alert('notes are off')
             return False
         if not isinstance(self.__notes, list):
             self.__notes = []
@@ -478,7 +479,7 @@ class NMObject(object):
                 ync = auto_confirm
             else:
                 q = "are you sure you want to delete all notes for '%s'?" % self.__name
-                ync = nmu.input_yesno(q, path=self.path_str)
+                ync = nmu.prompt_yes_no(q, path=self.path_str)
             if not isinstance(ync, str) or (ync.lower() != "y" and ync.lower() != "yes"):
                 print("cancel delete all notes")
                 raise RuntimeError("User cancelled note deletion")
@@ -538,57 +539,3 @@ class NMObject(object):
     def save(self, path: str = "", quiet: bool = nmp.QUIET):
         # TODO
         raise RuntimeError("save under construction")
-
-    def _alert(
-        self,
-        message: str,
-        path: str = "NONE",
-        quiet: bool = False,
-        frame: int = 2,
-    ) -> str:
-        # wrapper, see nmu.history
-        return nmu.history(
-            message,
-            title="ALERT",
-            path=path,
-            frame=frame,
-            red=True,
-            quiet=self._quiet(quiet),
-        )
-
-    def _error(
-        self,
-        message: str,
-        path: str = "NONE",
-        quiet: bool = False,
-        frame: int = 2,
-    ) -> str:
-        # wrapper, see nmu.history
-        return nmu.history(
-            message,
-            title="ERROR",
-            path=path,
-            frame=frame,
-            red=True,
-            quiet=self._quiet(quiet),
-        )
-
-    def _history(
-        self,
-        message: str,
-        path: str = "NONE",
-        quiet: bool = False,
-        frame: int = 2,
-    ) -> str:
-        # wrapper, see nmu.history
-        return nmu.history(
-            message, path=path, frame=frame, red=False, quiet=self._quiet(quiet)
-        )
-
-    def _quiet(self, quiet: bool) -> bool:
-        # m = self._manager
-        # if m and m.__class__.__name__ == "NMManager":
-        #    return m._quiet(quiet)
-        if nmp.QUIET:  # this quiet overrides
-            return True
-        return quiet

--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -24,6 +24,7 @@ from collections.abc import MutableMapping
 from enum import Enum, auto
 
 from pyneuromatic.core.nm_object import NMObject
+import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_preferences as nmp
 from pyneuromatic.core.nm_sets import NMSets
 import pyneuromatic.core.nm_utilities as nmu
@@ -168,7 +169,7 @@ class NMObjectContainer(NMObject, MutableMapping):
         self.__execute_target_name: str | None = None
 
         if not isinstance(rename_on, bool):
-            e = nmu.typeerror(rename_on, "rename_on", "boolean")
+            e = nmu.type_error_str(rename_on, "rename_on", "boolean")
             raise TypeError(e)
 
         self.__rename_on = rename_on
@@ -471,7 +472,7 @@ class NMObjectContainer(NMObject, MutableMapping):
                 ync = auto_confirm
             else:
                 prompt = "are you sure you want to delete '%s'?" % actual_key
-                ync = nmu.input_yesno(prompt, path=self.path_str)
+                ync = nmu.prompt_yes_no(prompt, path=self.path_str)
             if isinstance(ync, str) and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -522,7 +523,7 @@ class NMObjectContainer(NMObject, MutableMapping):
                 q = "are you sure you want to delete the following?\n" + ", ".join(
                     self.__map.keys()
                 )
-                ync = nmu.input_yesno(q, path=self.path_str)
+                ync = nmu.prompt_yes_no(q, path=self.path_str)
             if isinstance(ync, str) and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -553,12 +554,12 @@ class NMObjectContainer(NMObject, MutableMapping):
                 # key is not used, key is NMObject name
                 if not self.content_type_ok(o):
                     e = "nmobjects: '%s' value" % k
-                    e = nmu.typeerror(o, e, self.content_type())
+                    e = nmu.type_error_str(o, e, self.content_type())
                     raise TypeError(e)
                 if k is None:
                     k = o.name
                 if not isinstance(k, str):
-                    e = nmu.typeerror(k, "nmobjects: key", "string")
+                    e = nmu.type_error_str(k, "nmobjects: key", "string")
                     raise TypeError(e)
                 if k.lower() != o.name.lower():
                     raise KeyError("key and name mismatch: '%s' != '%s'" % (k, o.name))
@@ -569,7 +570,7 @@ class NMObjectContainer(NMObject, MutableMapping):
                 + " or list or dictionary or "
                 + self.__class__.__name__
             )
-            e = nmu.typeerror(nmobjects, "nmobjects", e)
+            e = nmu.type_error_str(nmobjects, "nmobjects", e)
             raise TypeError(e)
         update = False
         for o in olist:
@@ -581,7 +582,7 @@ class NMObjectContainer(NMObject, MutableMapping):
                 update = True
             else:
                 e = "nmobjects: list item"
-                e = nmu.typeerror(o, e, self.content_type())
+                e = nmu.type_error_str(o, e, self.content_type())
                 raise TypeError(e)
         if update:
             self.__update_nmobject_references()
@@ -631,7 +632,7 @@ class NMObjectContainer(NMObject, MutableMapping):
         if key is None:
             return None
         if not isinstance(key, str):
-            e = nmu.typeerror(key, "key", "string or None")
+            e = nmu.type_error_str(key, "key", "string or None")
             raise TypeError(e)
         for k in self.__map.keys():
             if k.lower() == key.lower():  # keys are case insensitive
@@ -645,7 +646,7 @@ class NMObjectContainer(NMObject, MutableMapping):
         if newkey is None:
             return self.auto_name_next()
         if not isinstance(newkey, str):
-            e = nmu.typeerror(newkey, "newkey", "string")
+            e = nmu.type_error_str(newkey, "newkey", "string")
             raise TypeError(e)
         if not newkey or not nmu.name_ok(newkey):
             raise ValueError("newkey: %s" % newkey)
@@ -665,7 +666,7 @@ class NMObjectContainer(NMObject, MutableMapping):
         if not self.__rename_on:
             raise RuntimeError("key names are locked.")
         if name is None:
-            e = nmu.typeerror(name, "name", "string")
+            e = nmu.type_error_str(name, "name", "string")
             raise TypeError(e)
         key = self._getkey(name)
         if key is None:
@@ -691,11 +692,11 @@ class NMObjectContainer(NMObject, MutableMapping):
         TODO: order by name, creation date, modified date
         """
         if not isinstance(name_order, list):
-            e = nmu.typeerror(name_order, "newkeyorder", "list")
+            e = nmu.type_error_str(name_order, "newkeyorder", "list")
             raise TypeError(e)
         for name in name_order:
             if not isinstance(name, str):
-                e = nmu.typeerror(name, "newkeyorder: list item", "string")
+                e = nmu.type_error_str(name, "newkeyorder: list item", "string")
                 raise TypeError(e)
         n_new = len(name_order)
         n_old = len(self)
@@ -719,7 +720,7 @@ class NMObjectContainer(NMObject, MutableMapping):
         newname: str | None = None,
     ) -> NMObject | None:
         if name is None:
-            e = nmu.typeerror(name, "name", "string")
+            e = nmu.type_error_str(name, "name", "string")
             raise TypeError(e)
         key = self._getkey(name)
         if key is None:
@@ -756,7 +757,7 @@ class NMObjectContainer(NMObject, MutableMapping):
         # quiet: bool = nmp.QUIET
     ) -> bool:
         if not self.content_type_ok(nmobject):
-            e = nmu.typeerror(nmobject, "nmobject", self.content_type())
+            e = nmu.type_error_str(nmobject, "nmobject", self.content_type())
             raise TypeError(e)
         newkey = self._newkey(nmobject.name)
         if not isinstance(newkey, str) or len(newkey) == 0:
@@ -788,7 +789,7 @@ class NMObjectContainer(NMObject, MutableMapping):
         if prefix is None:
             prefix = ""
         if not isinstance(prefix, str):
-            e = nmu.typeerror(prefix, "prefix", "string")
+            e = nmu.type_error_str(prefix, "prefix", "string")
             raise TypeError(e)
         if not nmu.name_ok(prefix, ok_names=[""]):
             # '' empty string OK for channel names
@@ -801,10 +802,10 @@ class NMObjectContainer(NMObject, MutableMapping):
         if self.__name_prefix is None:
             h = 'prefix = None'
         else:
-            h = "prefix = '%s'" % self.__prefix
+            h = "prefix = '%s'" % self.__auto_name_prefix
         self.note = h
-        h = nmu.history_change('prefix', oldprefix, self.__prefix)
-        self._history(h, quiet=quiet)
+        h = nmh.history_change_str('prefix', oldprefix, self.__auto_name_prefix)
+        nmh.history(h, quiet=quiet)
         """
         return
 
@@ -826,7 +827,7 @@ class NMObjectContainer(NMObject, MutableMapping):
         if isinstance(seq_format, int) and seq_format == 0:
             seq_format = "0"
         elif not isinstance(seq_format, str):
-            e = nmu.typeerror(seq_format, "seq_format", "string")
+            e = nmu.type_error_str(seq_format, "seq_format", "string")
             raise TypeError(e)
         slist = ""
         for char in seq_format:
@@ -953,7 +954,7 @@ class NMObjectContainer(NMObject, MutableMapping):
             self.__selected_name = None
             return
         if not isinstance(name, str):
-            e = nmu.typeerror(name, "key", "string")
+            e = nmu.type_error_str(name, "key", "string")
             raise TypeError(e)
         if name == "" or name.lower() == "none":
             self.__selected_name = None
@@ -1028,7 +1029,7 @@ class NMObjectContainer(NMObject, MutableMapping):
         target_name: str | None = None,
     ) -> None:
         if not isinstance(mode, ExecuteMode):
-            e = nmu.typeerror(mode, "mode", "ExecuteMode")
+            e = nmu.type_error_str(mode, "mode", "ExecuteMode")
             raise TypeError(e)
         if mode in (ExecuteMode.SELECTED, ExecuteMode.ALL):
             self.__execute_mode = mode
@@ -1040,7 +1041,7 @@ class NMObjectContainer(NMObject, MutableMapping):
             self.__execute_target_name = None
             return
         if not isinstance(target_name, str):
-            e = nmu.typeerror(target_name, "target_name", "string")
+            e = nmu.type_error_str(target_name, "target_name", "string")
             raise TypeError(e)
         if mode == ExecuteMode.NAME:
             key = self._getkey(target_name)

--- a/pyneuromatic/core/nm_sets.py
+++ b/pyneuromatic/core/nm_sets.py
@@ -88,11 +88,11 @@ class NMSets(NMObject, MutableMapping):
         elif isinstance(nmobjects, dict):
             for k, v in nmobjects.items():
                 if not isinstance(k, str):
-                    e = nmu.typeerror(k, "nmobjects: key", "string")
+                    e = nmu.type_error_str(k, "nmobjects: key", "string")
                     raise TypeError(e)
                 if not isinstance(v, NMObject):
                     e = "nmobjects: '%s' value" % k
-                    e = nmu.typeerror(v, e, "NMObject")
+                    e = nmu.type_error_str(v, e, "NMObject")
                     raise TypeError(e)
             self.__nmobjects = nmobjects
             # reference to an existing dictionary. DO NOT COPY.
@@ -235,7 +235,7 @@ class NMSets(NMObject, MutableMapping):
             olist_old = self.__map[actual_key]
             if not isinstance(olist_old, list):
                 e = "self.__map['%s']: value" % actual_key
-                e = nmu.typeerror(olist_old, e, "list")
+                e = nmu.type_error_str(olist_old, e, "list")
                 raise TypeError(e)
             if add:
                 if NMSets.list_is_equation(olist_old):
@@ -249,7 +249,7 @@ class NMSets(NMObject, MutableMapping):
         elif isinstance(olist, list):
             items = list(olist)
         else:
-            e = nmu.typeerror(olist, "olist", "string or NMObject or list")
+            e = nmu.type_error_str(olist, "olist", "string or NMObject or list")
             raise TypeError(e)
 
         if NMSets.list_is_equation(items):
@@ -311,7 +311,7 @@ class NMSets(NMObject, MutableMapping):
         obj_items: list[NMObject] = []
         for o in items:
             if not isinstance(o, NMObject):
-                e = nmu.typeerror(o, "olist: list item", "NMObject")
+                e = nmu.type_error_str(o, "olist: list item", "NMObject")
                 raise TypeError(e)
             found = False
             for o2 in self._nmobjects_dict.values():
@@ -520,7 +520,7 @@ class NMSets(NMObject, MutableMapping):
                 ync = auto_confirm
             else:
                 q = "are you sure you want to delete '%s'?" % key
-                ync = nmu.input_yesno(q, path=self.path_str)
+                ync = nmu.prompt_yes_no(q, path=self.path_str)
             if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -562,7 +562,7 @@ class NMSets(NMObject, MutableMapping):
                 q = "are you sure you want to delete the following?\n" + ", ".join(
                     self.__map.keys()
                 )
-                ync = nmu.input_yesno(q, path=self.path_str)
+                ync = nmu.prompt_yes_no(q, path=self.path_str)
             if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -599,7 +599,7 @@ class NMSets(NMObject, MutableMapping):
         if key is None:
             return None
         if not isinstance(key, str):
-            e = nmu.typeerror(key, "key", "string or None")
+            e = nmu.type_error_str(key, "key", "string or None")
             raise TypeError(e)
         for k in self.__map.keys():
             if k.lower() == key.lower():  # keys are case insensitive
@@ -613,7 +613,7 @@ class NMSets(NMObject, MutableMapping):
         if newkey is None:
             return self.auto_name_next()
         if not isinstance(newkey, str):
-            e = nmu.typeerror(newkey, "newkey", "string")
+            e = nmu.type_error_str(newkey, "newkey", "string")
             raise TypeError(e)
         if newkey.strip() == "":
             return self.auto_name_next()
@@ -630,7 +630,7 @@ class NMSets(NMObject, MutableMapping):
         trials: int = 100
     ) -> str:
         if not isinstance(prefix, str):
-            e = nmu.typeerror(prefix, "prefix", "string")
+            e = nmu.type_error_str(prefix, "prefix", "string")
             raise TypeError(e)
         for i in range(trials):
             newkey = prefix + str(i)
@@ -650,7 +650,7 @@ class NMSets(NMObject, MutableMapping):
         # forces keys/names to be case insensitive
         if not isinstance(nmobject_key, str):
             if error1:
-                e = nmu.typeerror(nmobject_key, "nmobject_key", "string")
+                e = nmu.type_error_str(nmobject_key, "nmobject_key", "string")
                 raise TypeError(e)
             return None
         for k in self._nmobjects_dict.keys():
@@ -702,17 +702,17 @@ class NMSets(NMObject, MutableMapping):
         if isinstance(nmobject_keys, str):
             nmobject_keys = [nmobject_keys]
         elif not isinstance(nmobject_keys, list):
-            e = nmu.typeerror(nmobject_keys, "nmobject_keys", "list")
+            e = nmu.type_error_str(nmobject_keys, "nmobject_keys", "list")
             raise TypeError(e)
         klist = []
         finished = nmobject_keys.copy()
         for k1 in self._nmobjects_dict.keys():
             if not isinstance(k1, str):
-                e = nmu.typeerror(k1, "self._nmobjects_dict: key", "string")
+                e = nmu.type_error_str(k1, "self._nmobjects_dict: key", "string")
                 raise TypeError(e)
             for k2 in nmobject_keys:
                 if not isinstance(k2, str):
-                    e = nmu.typeerror(k2, "nmobject_keys: list item", "string")
+                    e = nmu.type_error_str(k2, "nmobject_keys: list item", "string")
                     raise TypeError(e)
                 if k1.lower() == k2.lower():
                     if k1 not in klist:
@@ -810,11 +810,11 @@ class NMSets(NMObject, MutableMapping):
         TODO: order by name, creation date, modified date
         """
         if not isinstance(name_order, list):
-            e = nmu.typeerror(name_order, "newkeyorder", "list")
+            e = nmu.type_error_str(name_order, "newkeyorder", "list")
             raise TypeError(e)
         for name in name_order:
             if not isinstance(name, str):
-                e = nmu.typeerror(name, "newkeyorder: list item", "string")
+                e = nmu.type_error_str(name, "newkeyorder: list item", "string")
                 raise TypeError(e)
         n_new = len(name_order)
         n_old = len(self.__map)
@@ -841,7 +841,7 @@ class NMSets(NMObject, MutableMapping):
                 ync = auto_confirm
             else:
                 q = "are you sure you want to empty '%s'?" % key
-                ync = nmu.input_yesno(q, path=self.path_str)
+                ync = nmu.prompt_yes_no(q, path=self.path_str)
             if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -862,7 +862,7 @@ class NMSets(NMObject, MutableMapping):
                 q = "are you sure you want to empty the following?\n" + ", ".join(
                     self.__map.keys()
                 )
-                ync = nmu.input_yesno(q, path=self.path_str)
+                ync = nmu.prompt_yes_no(q, path=self.path_str)
             if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
                 pass
             else:
@@ -896,7 +896,7 @@ class NMSets(NMObject, MutableMapping):
             items = list(olist)
         else:
             if error:
-                e = nmu.typeerror(olist, "olist", "string or NMObject or list")
+                e = nmu.type_error_str(olist, "olist", "string or NMObject or list")
                 raise TypeError(e)
             return []
         olist_old = self.__map[key]
@@ -914,7 +914,7 @@ class NMSets(NMObject, MutableMapping):
                 if not isinstance(o2, NMObject):
                     if error:
                         e = "self.__map['%s']: list item" % key
-                        e = nmu.typeerror(o2, e, "NMObject")
+                        e = nmu.type_error_str(o2, e, "NMObject")
                         raise TypeError(e)
                     return []
                 if isinstance(o1, str):
@@ -930,7 +930,7 @@ class NMSets(NMObject, MutableMapping):
                 else:
                     if error:
                         e = "olist: list item"
-                        e = nmu.typeerror(o1, e, "string or NMObject")
+                        e = nmu.type_error_str(o1, e, "string or NMObject")
                         raise TypeError(e)
                     return []
             if not found:
@@ -956,14 +956,14 @@ class NMSets(NMObject, MutableMapping):
         elif isinstance(olist, list):
             items = list(olist)
         else:
-            e = nmu.typeerror(olist, "olist", "string or NMObject or list")
+            e = nmu.type_error_str(olist, "olist", "string or NMObject or list")
             raise TypeError(e)
         for o in items:
             if isinstance(o, (str, NMObject)):
                 pass
             else:
                 e = "olist: list item"
-                e = nmu.typeerror(o, e, "string or NMObject")
+                e = nmu.type_error_str(o, e, "string or NMObject")
                 raise TypeError(e)
             for map_key, map_val in self.__map.items():
                 if not NMSets.list_is_equation(map_val):

--- a/tests/test_core/test_nm_history.py
+++ b/tests/test_core/test_nm_history.py
@@ -15,6 +15,7 @@ from pyneuromatic.core.nm_history import (
 )
 from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.core.nm_object import NMObject
+import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_utilities as nmu
 
 QUIET = True
@@ -202,44 +203,42 @@ class NMHistoryIntegrationTest(unittest.TestCase):
 
     def test02_nmu_history_routes_to_buffer(self):
         self.nm.history.clear()
-        nmu.history("test via nmu", path="nm.test", quiet=True)
+        nmh.history("test via nmu", path="nm.test", quiet=True)
         buf = self.nm.history.buffer
         self.assertEqual(len(buf), 1)
         self.assertEqual(buf[0]["message"], "test via nmu")
         self.assertEqual(buf[0]["path"], "nm.test")
 
-    def test03_object_history_routes_to_buffer(self):
+    def test03_history_routes_to_buffer(self):
+        """Test that nmh.history() routes INFO messages to buffer."""
         self.nm.history.clear()
-        o = NMObject(parent=self.nm, name="testobj")
-        self.nm.history.clear()
-        o._history("obj history msg", quiet=True)
+        nmh.history("history msg", path="nm.test", quiet=True)
         buf = self.nm.history.buffer
         self.assertEqual(len(buf), 1)
-        self.assertIn("obj history msg", buf[0]["message"])
+        self.assertIn("history msg", buf[0]["message"])
+        self.assertEqual(buf[0]["level"], "INFO")
 
-    def test04_object_alert_routes_to_buffer(self):
+    def test04_alert_routes_to_buffer(self):
+        """Test that nmh.history() with ALERT title routes to buffer with WARNING level."""
         self.nm.history.clear()
-        o = NMObject(parent=self.nm, name="testobj")
-        self.nm.history.clear()
-        o._alert("alert msg", quiet=True)
+        nmh.history("alert msg", title="ALERT", red=True, quiet=True)
         buf = self.nm.history.buffer
         self.assertEqual(len(buf), 1)
         self.assertEqual(buf[0]["level"], "WARNING")
 
-    def test05_object_error_routes_to_buffer(self):
+    def test05_error_routes_to_buffer(self):
+        """Test that nmh.history() with ERROR title routes to buffer with ERROR level."""
         self.nm.history.clear()
-        o = NMObject(parent=self.nm, name="testobj")
-        self.nm.history.clear()
-        o._error("error msg", quiet=True)
+        nmh.history("error msg", title="ERROR", red=True, quiet=True)
         buf = self.nm.history.buffer
         self.assertEqual(len(buf), 1)
         self.assertEqual(buf[0]["level"], "ERROR")
 
     def test06_buffer_preserves_order(self):
         self.nm.history.clear()
-        nmu.history("first", quiet=True)
-        nmu.history("second", quiet=True)
-        nmu.history("third", quiet=True)
+        nmh.history("first", quiet=True)
+        nmh.history("second", quiet=True)
+        nmh.history("third", quiet=True)
         buf = self.nm.history.buffer
         messages = [e["message"] for e in buf]
         self.assertEqual(messages, ["first", "second", "third"])

--- a/tests/test_core/test_nm_object.py
+++ b/tests/test_core/test_nm_object.py
@@ -291,7 +291,7 @@ class NMObjectTest(unittest.TestCase):
         self.o0.name = "test2"
         self.assertEqual(self.o0.name, "test1")  # name of o0 does not change
 
-    def rename_dummy(self, oldname, newname, quiet=nmp.QUIET):
+    def rename_dummy(self, oldname, newname, quiet=False):
         # dummy function to test NMObject._rename_fxnref_set()
         print("test rename: " + oldname + " -> " + newname)
         return False
@@ -302,7 +302,7 @@ class NMObjectTest(unittest.TestCase):
     def test11_error(self):
         pass
         # alert(), error(), history()
-        # wrappers for nmu.history()
+        # wrappers for history()
         # args: obj, type_expected, tp, quiet, frame
 
     def test12_quiet(self):

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -300,12 +300,12 @@ class NMObjectContainerTest(unittest.TestCase):
             del self.map0["test"]
 
         print("\nanswer NO")
-        with patch('pyneuromatic.core.nm_utilities.input_yesno', return_value='n'):
+        with patch('pyneuromatic.core.nm_utilities.prompt_yes_no', return_value='n'):
             del self.map0[ONLIST0[1]]
         self.assertTrue(ONLIST0[1] in self.map0)
 
         print("\nanswer YES")
-        with patch('pyneuromatic.core.nm_utilities.input_yesno', return_value='y'):
+        with patch('pyneuromatic.core.nm_utilities.prompt_yes_no', return_value='y'):
             del self.map0[ONLIST0[1]]
         self.assertFalse(ONLIST0[1] in self.map0)
         with self.assertRaises(KeyError):

--- a/tests/test_core/test_nm_utilities.py
+++ b/tests/test_core/test_nm_utilities.py
@@ -8,6 +8,7 @@ Created on Mon Jul 17 17:23:44 2023
 import unittest
 
 from pyneuromatic.core.nm_manager import NMManager
+import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_utilities as nmu
 
 QUIET = True
@@ -147,15 +148,15 @@ class NMUtilitiesTest(unittest.TestCase):
         self.assertFalse(nmu.keys_are_equal(klist1, klist2))
 
     def test03_input_yesno(self):
-        self.assertEqual(nmu.input_yesno("test", answer=""), "error")
-        self.assertEqual(nmu.input_yesno("test", answer="YES"), "y")
-        self.assertEqual(nmu.input_yesno("test", answer="Y"), "y")
-        self.assertEqual(nmu.input_yesno("test", answer="NO"), "n")
-        self.assertEqual(nmu.input_yesno("test", answer="N"), "n")
-        self.assertEqual(nmu.input_yesno("test", answer="CANCEL"), "c")
-        self.assertEqual(nmu.input_yesno("test", answer="C"), "c")
-        self.assertEqual(nmu.input_yesno("test", cancel=False, answer="C"), "error")
-        p1 = nmu.input_yesno("testprompt", title='MyTitle', path='my.path')
+        self.assertEqual(nmu.prompt_yes_no("test", answer=""), "error")
+        self.assertEqual(nmu.prompt_yes_no("test", answer="YES"), "y")
+        self.assertEqual(nmu.prompt_yes_no("test", answer="Y"), "y")
+        self.assertEqual(nmu.prompt_yes_no("test", answer="NO"), "n")
+        self.assertEqual(nmu.prompt_yes_no("test", answer="N"), "n")
+        self.assertEqual(nmu.prompt_yes_no("test", answer="CANCEL"), "c")
+        self.assertEqual(nmu.prompt_yes_no("test", answer="C"), "c")
+        self.assertEqual(nmu.prompt_yes_no("test", cancel=False, answer="C"), "error")
+        p1 = nmu.prompt_yes_no("testprompt", title='MyTitle', path='my.path')
         p2 = "MyTitle:" + "\n" + "my.path:" + "\n" + "testprompt" + "\n" + "(y)es (n)o (c)ancel: "
         self.assertEqual(p1, p2)
         # print(p1)
@@ -301,26 +302,26 @@ class NMUtilitiesTest(unittest.TestCase):
         c = 'Test'  # this class
         h = 'history message'
         r = 'nm.' + c + '.' + fxn + ': ' + h
-        self.assertEqual(nmu.history(h, quiet=quiet), r)
+        self.assertEqual(nmh.history(h, quiet=quiet), r)
         tp = 'nm.one.two.three'
         r = tp + ': ' + h
-        self.assertEqual(nmu.history(h, tp=tp, quiet=quiet), r)
+        self.assertEqual(nmh.history(h, tp=tp, quiet=quiet), r)
 
         # get_path
         stack = inspect.stack()
         fxn = 'test_all'  # calling fxn
         r = 'nm.' + c + '.' + fxn
-        self.assertEqual(nmu.get_path(stack), r)
+        self.assertEqual(nmh.get_path(stack), r)
         tp = 'one.two.three'
         r = 'nm.one.two.three.' + fxn
-        self.assertEqual(nmu.get_path(stack, path=tp), r)
+        self.assertEqual(nmh.get_path(stack, path=tp), r)
         # get_class
         stack = inspect.stack()
-        self.assertEqual(nmu.get_class_from_stack(stack), c)
-        self.assertEqual(nmu.get_class_from_stack(stack, module=True), '__main__.' + c)
+        self.assertEqual(nmh.get_class_from_stack(stack), c)
+        self.assertEqual(nmh.get_class_from_stack(stack, module=True), '__main__.' + c)
         # get_method
         stack = inspect.stack()
-        self.assertEqual(nmu.get_method_from_stack(stack), fxn)
+        self.assertEqual(nmh.get_method_from_stack(stack), fxn)
     """
 
 


### PR DESCRIPTION
## Summary
- Move history functions (history, alert, error, get_path, history_change_str) from nm_utilities to nm_history module
- Rename utility functions for PEP 8 compliance: typeerror → type_error_str, input_yesno → prompt_yes_no
- Update all module references to use nmh.* for history functions
- Issue #22 #23 #24

## Test plan
- [x] Run pytest tests/test_core/test_nm_history.py - all pass
- [x] Run pytest tests/test_core/test_nm_object.py - all pass
- [x] Run pytest tests/test_core/test_nm_utilities.py - all pass
- [x] Run pytest tests/test_core/test_nm_object_container.py - all pass
- [x] Run pytest tests/test_core/test_nm_sets.py - all pass
