### PR TITLE
refactor(core): remove NMProjectContainer, simplify to single project (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,18 +192,17 @@ nm.projects.new('MyProject0')
 
 ```
 NMManager (nm)
-    NMProjectContainer
-        NMProject (e.g. 'MyProject0', 'MyProject1'...)
-            NMFolderContainer
-                NMFolder (e.g. 'MyFolder0', 'MyFolder1'...)
-                    NMDataContainer
-                        NMData (e.g. 'RecordA0', 'RecordA1'... 'AvgA0', 'AvgB0')
-                    NMDataSeriesContainer
-                        NMDataSeries (e.g. 'Record', 'Avg'...)
-                            NMChannelContainer
-                                NMChannel ('A', 'B', 'C'...)
-                            NMEpochContainer
-                                NMEpoch ('E0', 'E1', 'E2'...)
+    NMProject (e.g. 'MyProject0')
+        NMFolderContainer
+            NMFolder (e.g. 'MyFolder0', 'MyFolder1'...)
+                NMDataContainer
+                    NMData (e.g. 'RecordA0', 'RecordA1'... 'AvgA0', 'AvgB0')
+                NMDataSeriesContainer
+                    NMDataSeries (e.g. 'Record', 'Avg'...)
+                        NMChannelContainer
+                            NMChannel ('A', 'B', 'C'...)
+                        NMEpochContainer
+                            NMEpoch ('E0', 'E1', 'E2'...)
 ```
 
 ### Selection and Execution (✅ Implemented)

--- a/README.md.old
+++ b/README.md.old
@@ -57,7 +57,7 @@ Current/Future Features
 
     In [1]: nm.projects.new('MyProject0')
 
-NMObjectContainer is the parent class of all NM containers (NMProjectContainer, NMFolderContainer, NMDataContainer...). Each NMObjectContainer holds one or more NMObjects (NMProject, NMFolder, NMData...).
+NMObjectContainer is the parent class of all NM containers (NMFolderContainer, NMDataContainer...). Each NMObjectContainer holds one or more NMObjects (NMProject, NMFolder, NMData...).
 
 Each NMObjectContainer also contains sets (NMSets). NMObjects can be placed in NMSets and these NMSets can then be used to specify what projects, folders and data is to be analysed. NMSets can be functions of each other, for example: 'Set3' = ['Set1', '&', 'Set2'].
 
@@ -68,18 +68,17 @@ A NMDataSeries define data acquired from data acquisition (DAQ) devices, allowin
 NM's container tree hierarchy is as follows:
 
     NMManager (nm)
-        NMProjectContainer
-            NMProject (e.g. 'MyProject0', 'MyProject1'...)
-                NMFolderContainer
-                    NMFolder (e.g. 'MyFolder0', 'MyFolder1'...)
-                        NMDataContainer
-                            NMData (e.g. 'RecordA0', 'RecordA1'... 'AvgA0', 'AvgB0')
-                        NMDataSeriesContainer
-                            NMDataSeries (e.g. 'Record', 'Avg'...)
-                                NMChannelContainer
-                                    NMChannel ('A', 'B', 'C'...)
-                                NMEpochContainer
-                                    NMEpoch ('E0', 'E1', 'E2'...)
+        NMProject (e.g. 'MyProject0', 'MyProject1'...)
+            NMFolderContainer
+                NMFolder (e.g. 'MyFolder0', 'MyFolder1'...)
+                    NMDataContainer
+                        NMData (e.g. 'RecordA0', 'RecordA1'... 'AvgA0', 'AvgB0')
+                    NMDataSeriesContainer
+                        NMDataSeries (e.g. 'Record', 'Avg'...)
+                            NMChannelContainer
+                                NMChannel ('A', 'B', 'C'...)
+                            NMEpochContainer
+                                NMEpoch ('E0', 'E1', 'E2'...)
 
 (2) NM container 'select' items. Each NMObjectContainer has one selected item (e.g. nm.projects.select_key = 'MyProject0'). The selected items in NM's container tree create a unique path through the tree. The selected items are accessible via NM's manager (nm): nm.select_values or nm.select_keys. Here is an example of printing nm.select_keys via CLI:
 

--- a/pip-wheel-metadata/pyNeuroMatic-0.0.1.dist-info/METADATA
+++ b/pip-wheel-metadata/pyNeuroMatic-0.0.1.dist-info/METADATA
@@ -91,7 +91,7 @@ Current/Future Features
 
     In [1]: nm.projects.new('MyProject0')
 
-NMObjectContainer is the parent class of all NM containers (NMProjectContainer, NMFolderContainer, NMDataContainer...). Each NMObjectContainer holds one or more NMObjects (NMProject, NMFolder, NMData...).
+NMObjectContainer is the parent class of all NM containers (NMFolderContainer, NMDataContainer...). Each NMObjectContainer holds one or more NMObjects (NMProject, NMFolder, NMData...).
 
 Each NMObjectContainer also contains sets (NMSets). NMObjects can be placed in NMSets and these NMSets can then be used to specify what projects, folders and data is to be analysed. NMSets can be functions of each other, for example: 'Set3' = ['Set1', '&', 'Set2'].
 
@@ -102,18 +102,17 @@ A NMDataSeries define data acquired from data acquisition (DAQ) devices, allowin
 NM's container tree hierarchy is as follows:
 
     NMManager (nm)
-        NMProjectContainer
-            NMProject (e.g. 'MyProject0', 'MyProject1'...)
-                NMFolderContainer
-                    NMFolder (e.g. 'MyFolder0', 'MyFolder1'...)
-                        NMDataContainer
-                            NMData (e.g. 'RecordA0', 'RecordA1'... 'AvgA0', 'AvgB0')
-                        NMDataSeriesContainer
-                            NMDataSeries (e.g. 'Record', 'Avg'...)
-                                NMChannelContainer
-                                    NMChannel ('A', 'B', 'C'...)
-                                NMEpochContainer
-                                    NMEpoch ('E0', 'E1', 'E2'...)
+        NMProject (e.g. 'MyProject0', 'MyProject1'...)
+            NMFolderContainer
+                NMFolder (e.g. 'MyFolder0', 'MyFolder1'...)
+                    NMDataContainer
+                        NMData (e.g. 'RecordA0', 'RecordA1'... 'AvgA0', 'AvgB0')
+                    NMDataSeriesContainer
+                        NMDataSeries (e.g. 'Record', 'Avg'...)
+                            NMChannelContainer
+                                NMChannel ('A', 'B', 'C'...)
+                            NMEpochContainer
+                                NMEpoch ('E0', 'E1', 'E2'...)
 
 (2) NM container 'select' items. Each NMObjectContainer has one selected item (e.g. nm.projects.select_key = 'MyProject0'). The selected items in NM's container tree create a unique path through the tree. The selected items are accessible via NM's manager (nm): nm.select_values or nm.select_keys. Here is an example of printing nm.select_keys via CLI:
 

--- a/pyneuromatic/core/nm_channel.py
+++ b/pyneuromatic/core/nm_channel.py
@@ -36,18 +36,17 @@ import pyneuromatic.core.nm_utilities as nmu
 NM class tree:
 
 NMManager
-    NMProjectContainer
-        NMProject (project0, project1...)
-            NMFolderContainer
-                NMFolder (folder0, folder1...)
-                    NMDataContainer
-                        NMData (recordA0, recordA1... avgA0, avgB0)
-                    NMDataSeriesContainer
-                        NMDataSeries (record, avg...)
-                            NMChannelContainer
-                                NMChannel (A, B, C...)
-                            NMEpochContainer
-                                NMEpoch (E0, E1, E2...)
+    NMProject (project0)
+        NMFolderContainer
+            NMFolder (folder0, folder1...)
+                NMDataContainer
+                    NMData (recordA0, recordA1... avgA0, avgB0)
+                NMDataSeriesContainer
+                    NMDataSeries (record, avg...)
+                        NMChannelContainer
+                            NMChannel (A, B, C...)
+                        NMEpochContainer
+                            NMEpoch (E0, E1, E2...)
 DataSeries:
       E0  E1  E2... (epochs)
 Ch A  A0  A1  A2...

--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -41,18 +41,17 @@ NP_FILL_VALUE = numpy.nan
 NM class tree:
 
 NMManager
-    NMProjectContainer
-        NMProject (project0, project1...)
-            NMFolderContainer
-                NMFolder (folder0, folder1...)
-                    NMDataContainer
-                        NMData (record0, record1... avg0, avg1)
-                    NMDataSeriesContainer
-                        NMDataSeries (record, avg...)
-                            NMChannelContainer
-                                NMChannel (A, B, C... or 0, 1, 2)
-                            NMSetContainer
-                                NMSet (all, set0, set1...)
+    NMProject (project0)
+        NMFolderContainer
+            NMFolder (folder0, folder1...)
+                NMDataContainer
+                    NMData (recordA0, recordA1... avgA0, avgB0)
+                NMDataSeriesContainer
+                    NMDataSeries (record, avg...)
+                        NMChannelContainer
+                            NMChannel (A, B, C...)
+                        NMEpochContainer
+                            NMEpoch (E0, E1, E2...)
 """
 
 

--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -37,18 +37,17 @@ ALLSTR = "all".upper()
 NM class tree:
 
 NMManager
-    NMProjectContainer
-        NMProject (project0, project1...)
-            NMFolderContainer
-                NMFolder (folder0, folder1...)
-                    NMDataContainer
-                        NMData (recordA0, recordA1... avgA0, avgB0)
-                    NMDataSeriesContainer
-                        NMDataSeries (record, avg...)
-                            NMChannelContainer
-                                NMChannel (A, B, C...)
-                            NMEpochContainer
-                                NMEpoch (E0, E1, E2...)
+    NMProject (project0)
+        NMFolderContainer
+            NMFolder (folder0, folder1...)
+                NMDataContainer
+                    NMData (recordA0, recordA1... avgA0, avgB0)
+                NMDataSeriesContainer
+                    NMDataSeries (record, avg...)
+                        NMChannelContainer
+                            NMChannel (A, B, C...)
+                        NMEpochContainer
+                            NMEpoch (E0, E1, E2...)
 DataSeries:
       E0  E1  E2... (epochs)
 Ch A  A0  A1  A2...

--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -36,18 +36,17 @@ import pyneuromatic.core.nm_utilities as nmu
 NM class tree:
 
 NMManager
-    NMProjectContainer
-        NMProject (project0, project1...)
-            NMFolderContainer
-                NMFolder (folder0, folder1...)
-                    NMDataContainer
-                        NMData (recordA0, recordA1... avgA0, avgB0)
-                    NMDataSeriesContainer
-                        NMDataSeries (record, avg...)
-                            NMChannelContainer
-                                NMChannel (A, B, C...)
-                            NMEpochContainer
-                                NMEpoch (E0, E1, E2...)
+    NMProject (project0)
+        NMFolderContainer
+            NMFolder (folder0, folder1...)
+                NMDataContainer
+                    NMData (recordA0, recordA1... avgA0, avgB0)
+                NMDataSeriesContainer
+                    NMDataSeries (record, avg...)
+                        NMChannelContainer
+                            NMChannel (A, B, C...)
+                        NMEpochContainer
+                            NMEpoch (E0, E1, E2...)
 DataSeries:
       E0  E1  E2... (epochs)
 Ch A  A0  A1  A2...

--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -36,14 +36,17 @@ import pyneuromatic.core.nm_utilities as nmu
 NM class tree:
 
 NMManager
-    NMProjectContainer
-        NMProject (project0, project1...)
-            NMFolderContainer
-                NMFolder (folder0, folder1...)
-                    NMDataContainer
-                        NMData (record0, record1... avg0, avg1)
-                    NMDataSeriesContainer
-                        NMDataSeries (record, avg...)
+    NMProject (project0)
+        NMFolderContainer
+            NMFolder (folder0, folder1...)
+                NMDataContainer
+                    NMData (recordA0, recordA1... avgA0, avgB0)
+                NMDataSeriesContainer
+                    NMDataSeries (record, avg...)
+                        NMChannelContainer
+                            NMChannel (A, B, C...)
+                        NMEpochContainer
+                            NMEpoch (E0, E1, E2...)
 """
 
 

--- a/pyneuromatic/core/nm_manager.py
+++ b/pyneuromatic/core/nm_manager.py
@@ -26,11 +26,11 @@ import numpy as np
 
 from pyneuromatic.core.nm_dataseries import NMDataSeries
 from pyneuromatic.core.nm_dimension import NMDimension, NMDimensionX
-from pyneuromatic.core.nm_folder import NMFolder, NMFolderContainer
+from pyneuromatic.core.nm_folder import NMFolder
 import pyneuromatic.core.nm_history as nmh
 from pyneuromatic.core.nm_object import NMObject
 import pyneuromatic.core.nm_preferences as nmp
-from pyneuromatic.core.nm_project import NMProject, NMProjectContainer
+from pyneuromatic.core.nm_project import NMProject
 from pyneuromatic.analysis.nm_tool import NMTool
 from pyneuromatic.analysis.nm_tool_stats import NMToolStats
 import pyneuromatic.core.nm_utilities as nmu
@@ -41,18 +41,17 @@ nm = None  # holds Manager, accessed via console
 NM class tree:
 
 NMManager
-    NMProjectContainer
-        NMProject (project0, project1...)
-            NMFolderContainer
-                NMFolder (folder0, folder1...)
-                    NMDataContainer
-                        NMData (recordA0, recordA1... avgA0, avgB0)
-                    NMDataSeriesContainer
-                        NMDataSeries (record, avg...)
-                            NMChannelContainer
-                                NMChannel (A, B, C...)
-                            NMEpochContainer
-                                NMEpoch (E0, E1, E2...)
+    NMProject (project0)
+        NMFolderContainer
+            NMFolder (folder0, folder1...)
+                NMDataContainer
+                    NMData (recordA0, recordA1... avgA0, avgB0)
+                NMDataSeriesContainer
+                    NMDataSeries (record, avg...)
+                        NMChannelContainer
+                            NMChannel (A, B, C...)
+                        NMEpochContainer
+                            NMEpoch (E0, E1, E2...)
 """
 
 # TOOL_NAMES = ("Main", "Stats", "Spike", "Event")
@@ -77,8 +76,7 @@ class NMManager(NMObject):
         # self.__configs = nmp.Configs()
         # self.__configs.quiet = quiet
 
-        # for now, only one project
-        # self.__project_container = NMProjectContainer(parent=self)
+        #create project
         if not isinstance(project_name, str):
             e = nmu.type_error_str(project_name, "project_name", "string")
             raise TypeError(e)
@@ -164,10 +162,6 @@ class NMManager(NMObject):
             self.__toolselect = tname
         else:
             raise KeyError("NM tool key '%s' does not exist" % tname)
-
-    # @property
-    # def projects(self) -> NMProjectContainer:
-    #     return self.__project_container
 
     @property
     def history(self) -> nmh.NMHistory:

--- a/pyneuromatic/core/nm_object.py
+++ b/pyneuromatic/core/nm_object.py
@@ -44,18 +44,17 @@ class NMObject(object):
     NM class tree:
 
     NMManager
-        NMProjectContainer
-            NMProject (project0, project1...)
-                NMFolderContainer
-                    NMFolder (folder0, folder1...)
-                        NMDataContainer
-                            NMData (recordA0, recordA1... avgA0, avgB0)
-                        NMDataSeriesContainer
-                            NMDataSeries (record, avg...)
-                                NMChannelContainer
-                                    NMChannel (A, B, C...)
-                                NMEpochContainer
-                                    NMEpoch (E0, E1, E2...)
+        NMProject (project0)
+            NMFolderContainer
+                NMFolder (folder0, folder1...)
+                    NMDataContainer
+                        NMData (recordA0, recordA1... avgA0, avgB0)
+                    NMDataSeriesContainer
+                        NMDataSeries (record, avg...)
+                            NMChannelContainer
+                                NMChannel (A, B, C...)
+                            NMEpochContainer
+                                NMEpoch (E0, E1, E2...)
 
     Each NMObject has a path in the hierarchy:
         - path: list of names, e.g. ['project0', 'folder0', 'recordA0']

--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -45,22 +45,21 @@ class NMObjectContainer(NMObject, MutableMapping):
     NM class tree:
 
     NMManager
-        NMProjectContainer
-            NMProject (project0, project1...)
-                NMFolderContainer
-                    NMFolder (folder0, folder1...)
-                        NMDataContainer
-                            NMData (recordA0, recordA1... avgA0, avgB0)
-                        NMDataSeriesContainer
-                            NMDataSeries (record, avg...)
-                                NMChannelContainer
-                                    NMChannel (A, B, C...)
-                                NMEpochContainer
-                                    NMEpoch (E0, E1, E2...)
+        NMProject (project0)
+            NMFolderContainer
+                NMFolder (folder0, folder1...)
+                    NMDataContainer
+                        NMData (recordA0, recordA1... avgA0, avgB0)
+                    NMDataSeriesContainer
+                        NMDataSeries (record, avg...)
+                            NMChannelContainer
+                                NMChannel (A, B, C...)
+                            NMEpochContainer
+                                NMEpoch (E0, E1, E2...)
 
     Known children of NMObjectContainer:
         NMChannelContainer, NMDataContainer, NMDataSeriesContainer,
-        NMEpochContainer, NMFolderContainer, NMProjectContainer
+        NMEpochContainer, NMFolderContainer
 
     A NMObjectContainer behaves like a Python dictionary, where each
     NMObject is entered with a key (k) and value (v). The NMObject name

--- a/pyneuromatic/core/nm_project.py
+++ b/pyneuromatic/core/nm_project.py
@@ -23,17 +23,22 @@ import copy
 
 from pyneuromatic.core.nm_folder import NMFolderContainer
 from pyneuromatic.core.nm_object import NMObject
-from pyneuromatic.core.nm_object_container import NMObjectContainer
-import pyneuromatic.core.nm_utilities as nmu
 
 """
 NM class tree:
 
 NMManager
-    NMProjectContainer
-        NMProject (project0, project1...)
-            NMFolderContainer
-                NMFolder (folder0, folder1...)
+    NMProject (project0)
+        NMFolderContainer
+            NMFolder (folder0, folder1...)
+                NMDataContainer
+                    NMData (recordA0, recordA1... avgA0, avgB0)
+                NMDataSeriesContainer
+                    NMDataSeries (record, avg...)
+                        NMChannelContainer
+                            NMChannel (A, B, C...)
+                        NMEpochContainer
+                            NMEpoch (E0, E1, E2...)
 """
 
 
@@ -124,42 +129,3 @@ class NMProject(NMObject):
     @property
     def folders(self) -> NMFolderContainer | None:
         return self.__folder_container
-
-
-class NMProjectContainer(NMObjectContainer):
-    """
-    Container of NMProjects
-    """
-
-    def __init__(
-        self,
-        parent: object | None = None,
-        name: str = "NMProjectContainer0",
-        rename_on: bool = True,
-        name_prefix: str = "project",
-        name_seq_format: str = "0",
-    ) -> None:
-        super().__init__(
-            parent=parent,
-            name=name,
-            rename_on=rename_on,
-            auto_name_prefix=name_prefix,
-            auto_name_seq_format=name_seq_format,
-        )  # NMObjectContainer
-
-    # override, no super
-    def content_type(self) -> str:
-        return NMProject.__name__
-
-    # override
-    def new(
-        self,
-        name: str | None = None,
-        select: bool = False,
-        # quiet: bool = nmp.QUIET
-    ) -> NMProject | None:
-        actual_name = self._newkey(name)
-        p = NMProject(parent=self, name=actual_name)
-        if super()._new(p, select=select):
-            return p
-        return None

--- a/tests/test_core/test_nm_manager.py
+++ b/tests/test_core/test_nm_manager.py
@@ -13,7 +13,6 @@ import unittest
 # from pyneuromatic.core.nm_epoch import NMEpochContainer
 # from pyneuromatic.core.nm_folder import NMFolderContainer
 from pyneuromatic.core.nm_manager import NMManager
-# from pyneuromatic.core.nm_project import NMProjectContainer
 from pyneuromatic.core.nm_project import NMProject
 import pyneuromatic.core.nm_utilities as nmu
 
@@ -133,7 +132,6 @@ class NMManagerTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 NMManager(project_name=b, quiet=True)
 
-        # self.assertTrue(isinstance(self.nm.projects, NMProjectContainer))
         self.assertTrue(isinstance(self.nm.project, NMProject))
 
     def test01_parameters(self):

--- a/tests/test_core/test_nm_project.py
+++ b/tests/test_core/test_nm_project.py
@@ -10,7 +10,7 @@ import unittest
 
 from pyneuromatic.core.nm_folder import NMFolder, NMFolderContainer
 from pyneuromatic.core.nm_manager import NMManager
-from pyneuromatic.core.nm_project import NMProject, NMProjectContainer
+from pyneuromatic.core.nm_project import NMProject
 import pyneuromatic.core.nm_utilities as nmu
 
 QUIET = True
@@ -57,16 +57,6 @@ class NMProjectTest(unittest.TestCase):
         self.project1.folders.sets.add(FSETS_NLIST1[1], slist)
         slist = [FSETS_NLIST1[0], "|", FSETS_NLIST1[1]]
         self.project1.folders.sets.add(FSETS_NLIST1[2], slist)
-
-        self.projectcontainer = NMProjectContainer(parent=NM)
-        self.projectcontainer.update([self.project0, self.project1])
-        self.projectcontainer.selected_name = PNAME0
-
-        self.projectcontainer.sets.add(PSETS_NLIST[0], PNAME0)
-        self.projectcontainer.sets.add(PSETS_NLIST[1], PNAME1)
-        self.projectcontainer.sets.add(
-            PSETS_NLIST[2], [PSETS_NLIST[0], "|", PSETS_NLIST[1]]
-        )
 
     def test00_init(self):
         # args: parent, name, copy (see NMObject)
@@ -156,57 +146,3 @@ class NMProjectTest(unittest.TestCase):
         self.assertTrue(isinstance(self.project0.folders, NMFolderContainer))
         with self.assertRaises(AttributeError):
             self.project0.folders = None
-
-    def test05_project_container(self):
-        self.assertEqual(len(self.projectcontainer), 2)
-        p = self.projectcontainer.new("project2")
-        self.assertEqual(len(self.projectcontainer), 3)
-        self.assertTrue(isinstance(p, NMProject))
-        self.assertEqual(p.name, "project2")
-        self.assertTrue(p in self.projectcontainer)
-        self.assertTrue(self.project0 in self.projectcontainer)
-        self.assertTrue(self.project1 in self.projectcontainer)
-        self.assertTrue(PNAME0.upper() in self.projectcontainer)
-        self.assertTrue(PNAME1.upper() in self.projectcontainer)
-        for p in self.projectcontainer.values():
-            self.assertEqual(p._parent, NM)
-        self.assertEqual(self.projectcontainer.content_type(), NMProject.__name__)
-
-        self.projectcontainer.sets.add("set0", "project2")
-        self.projectcontainer.sets.add("set1", "project2")
-
-        c = self.projectcontainer.copy()
-        self.assertTrue(c == self.projectcontainer)
-        self.assertEqual(len(c), 3)
-        self.assertFalse(p in c)
-        self.assertFalse(self.project0 in c)
-        self.assertFalse(self.project1 in c)
-        self.assertTrue(p.name.upper() in c)
-        self.assertTrue(self.project0.name.upper() in c)
-        self.assertTrue(self.project1.name.upper() in c)
-        self.assertEqual(c.selected_name, PNAME0)
-        p = c.get(PNAME0)
-        self.assertFalse(p is self.project0)
-        self.assertTrue(p == self.project0)
-        p = c.get(PNAME1)
-        self.assertFalse(p is self.project1)
-        self.assertTrue(p == self.project1)
-
-        self.assertEqual(len(c.sets), 3)
-        self.assertTrue("set0" in c.sets)
-        self.assertTrue("set1" in c.sets)
-        self.assertTrue("set2" in c.sets)
-        self.assertFalse("set3" in c.sets)
-        self.assertTrue(c.sets.contains("set0", PNAME0))
-        self.assertFalse(c.sets.contains("set0", PNAME1))
-        self.assertTrue(c.sets.contains("set2", PNAME1))
-        self.assertTrue(c.sets.is_equation("set2"))
-
-        self.assertEqual(len(p.folders), len(FNLIST1))
-        for f in FNLIST1:
-            self.assertTrue(f in p.folders)
-        for s in FSETS_NLIST1:
-            self.assertTrue(s in p.folders.sets)
-        self.assertEqual(len(p.folders.sets), len(FSETS_NLIST1))
-        for s in FSETS_NLIST1:
-            self.assertTrue(s in p.folders.sets)


### PR DESCRIPTION
Remove NMProjectContainer class and have NMManager hold a single NMProject directly via the `project` property. This simplifies the class hierarchy by eliminating an unnecessary container layer.

- Remove NMProjectContainer class from nm_project.py
- Update NMManager to create NMProject directly
- Update class tree diagrams in all module docstrings
- Update documentation in README files
- Remove NMProjectContainer tests from test_nm_project.py
- Clean up unused imports
- Issue #28 