### PR TITLE
refactor(core): move notes from NMObject to NMFolder (#30)

### DIFF
--- a/pyneuromatic/analysis/nm_tool_folder.py
+++ b/pyneuromatic/analysis/nm_tool_folder.py
@@ -91,8 +91,6 @@ class NMToolFolder(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -393,8 +393,6 @@ class NMStatsWin(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/pyneuromatic/core/nm_channel.py
+++ b/pyneuromatic/core/nm_channel.py
@@ -148,8 +148,6 @@ class NMChannel(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -159,8 +159,6 @@ class NMData(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -123,8 +123,6 @@ class NMDataSeries(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/pyneuromatic/core/nm_dimension.py
+++ b/pyneuromatic/core/nm_dimension.py
@@ -124,8 +124,6 @@ class NMDimension(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 
@@ -366,8 +364,6 @@ class NMDimensionX(NMDimension):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -127,8 +127,6 @@ class NMEpoch(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -147,7 +147,6 @@ class NMObjectContainer(NMObject, MutableMapping):
         super().__init__(
             parent=parent,
             name=name,
-            notes_on=False,  # turn notes off during __init__
         )  # NMObject
 
         self.__rename_on = True
@@ -187,7 +186,6 @@ class NMObjectContainer(NMObject, MutableMapping):
             nmobjects_fxnref=self._get_map,
         )
 
-        self.notes_on = True
 
     def _get_map(self) -> dict[str, NMObject]:  # see __init__()
         return self.__map
@@ -425,8 +423,6 @@ class NMObjectContainer(NMObject, MutableMapping):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/pyneuromatic/core/nm_project.py
+++ b/pyneuromatic/core/nm_project.py
@@ -100,8 +100,6 @@ class NMProject(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/pyneuromatic/core/nm_sets.py
+++ b/pyneuromatic/core/nm_sets.py
@@ -68,7 +68,6 @@ class NMSets(NMObject, MutableMapping):
         super().__init__(
             parent=parent,
             name=actual_name,
-            notes_on=False,  # turn notes off during __init__
         )  # NMObject
 
         self.__map: dict[str, Any] = {}  # {key: [NMObject]} or {key: [Equation]}
@@ -102,8 +101,6 @@ class NMSets(NMObject, MutableMapping):
                 "neither" % ("nmobjects_fxnref", "nmobjects")
             )
 
-        self.notes_on = True
-
     def __deepcopy__(self, memo: dict) -> NMSets:
         """Support Python's copy.deepcopy() protocol.
 
@@ -134,8 +131,6 @@ class NMSets(NMObject, MutableMapping):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__notes_on = self._NMObject__notes_on
-        result._NMObject__notes = copy.deepcopy(self._NMObject__notes, memo)
         result._NMObject__rename_fxnref = result._name_set
         result._NMObject__copy_of = self
 

--- a/tests/test_core/test_nm_folder.py
+++ b/tests/test_core/test_nm_folder.py
@@ -107,14 +107,58 @@ class NMFolderTest(unittest.TestCase):
         c.data.sets.add(DSETS_NLIST0[0], DNLIST0[0])
         self.assertTrue(c == self.folder0)
 
-    def xtest02_copy(self):
+    def test02_notes(self):
+        # Test notes property
+        self.assertTrue(isinstance(self.folder0.notes, list))
+        self.assertEqual(len(self.folder0.notes), 0)
+
+        # Test note setter and note_add
+        self.folder0.note = "added TTX"
+        self.folder0.note_add("added AP5")
+        self.assertEqual(len(self.folder0.notes), 2)
+        self.assertEqual(self.folder0.notes[0].get("note"), "added TTX")
+        self.assertEqual(self.folder0.notes[1].get("note"), "added AP5")
+
+        # Test note getter (returns last note text)
+        self.assertEqual(self.folder0.note, "added AP5")
+
+        # Test notes have timestamps
+        self.assertIn("date", self.folder0.notes[0])
+        self.assertIn("date", self.folder0.notes[1])
+
+        # Test notes_clear
+        self.folder0.notes_clear()
+        self.assertEqual(len(self.folder0.notes), 0)
+        self.assertEqual(self.folder0.note, "")
+
+        # Test notes_ok validator
+        self.assertTrue(NMFolder.notes_ok([{"note": "hey", "date": "111"}]))
+        self.assertTrue(NMFolder.notes_ok([{"date": "111", "note": "hey"}]))
+        self.assertFalse(NMFolder.notes_ok([{"n": "hey", "date": "111"}]))
+        self.assertFalse(NMFolder.notes_ok([{"note": "hey", "d": "111"}]))
+        self.assertFalse(NMFolder.notes_ok([{"note": "hey", "date": None}]))
+        self.assertTrue(NMFolder.notes_ok([{"note": "hey", "date": "None"}]))
+        self.assertFalse(NMFolder.notes_ok([{"note": "hey"}]))
+        self.assertFalse(NMFolder.notes_ok([{"date": "111"}]))
+        self.assertFalse(
+            NMFolder.notes_ok([{"note": "hey", "date": "111", "more": "1"}])
+        )
+
+        # Test notes equality
+        self.folder0.note_add("test note")
+        c = self.folder0.copy()
+        self.assertTrue(c == self.folder0)
+        c.note_add("another note")
+        self.assertFalse(c == self.folder0)
+
+    def xtest03_copy(self):
         pass
 
-    def xtest03_content(self):
+    def xtest04_content(self):
         pass
 
-    def xtest04_data(self):
+    def xtest05_data(self):
         pass
 
-    def xtest05_folder_container(self):
+    def xtest06_folder_container(self):
         pass

--- a/tests/test_core/test_nm_object.py
+++ b/tests/test_core/test_nm_object.py
@@ -105,20 +105,6 @@ class NMObjectTest(unittest.TestCase):
         o1.myvalue = 2
         self.assertTrue(o0 == o1)
 
-        o0.note = "my note"
-        o1.note = "my note"
-        self.assertTrue(o0 == o1)  # notes not tested
-        # o0._eq_list.append("notes")
-        # self.assertFalse(o0 == o1)  # notes tested, different time stamps
-        o0._notes_delete(auto_confirm="y")
-        o1._notes_delete(auto_confirm="y")
-        self.assertTrue(o0 == o1)
-        o0.note = "my note 0"
-        o0.note = "my note 1"
-        for n in o0.notes:
-            o1._NMObject__notes.append(dict(n))  # notes have same time stamp
-        self.assertTrue(o0 == o1)
-
     def test02_lists_are_equal(self):
         olist0 = []
         for i in range(10):
@@ -229,36 +215,7 @@ class NMObjectTest(unittest.TestCase):
         expected_str = NM0.name + "." + ONAME0 + ".myobject"
         self.assertEqual(o2.myobject.path_str, expected_str)
 
-    def test07_notes(self):
-        self.assertTrue(self.o0.notes_on)
-        self.o0.note = "added TTX"
-        self.assertTrue(self.o0._notes_append("added AP5"))
-        self.o0.notes_on = None
-        self.assertTrue(self.o0.notes_on)
-        self.o0.notes_on = True
-        self.assertTrue(self.o0.notes_on)
-        self.o0.notes_on = False
-        self.assertFalse(self.o0.notes_on)
-        self.assertFalse(self.o0._notes_append("added NBQX"))
-        self.assertTrue(isinstance(self.o0.notes, list))
-        self.assertEqual(len(self.o0.notes), 2)
-        self.assertEqual(self.o0.notes[0].get("note"), "added TTX")
-        self.assertEqual(self.o0.notes[1].get("note"), "added AP5")
-        self.o0._notes_delete(auto_confirm="y")
-        self.assertEqual(len(self.o0.notes), 0)
-        self.assertTrue(NMObject.notes_ok([{"note": "hey", "date": "111"}]))
-        self.assertTrue(NMObject.notes_ok([{"date": "111", "note": "hey"}]))
-        self.assertFalse(NMObject.notes_ok([{"n": "hey", "date": "111"}]))
-        self.assertFalse(NMObject.notes_ok([{"note": "hey", "d": "111"}]))
-        self.assertFalse(NMObject.notes_ok([{"note": "hey", "date": None}]))
-        self.assertTrue(NMObject.notes_ok([{"note": "hey", "date": "None"}]))
-        self.assertFalse(NMObject.notes_ok([{"note": "hey"}]))
-        self.assertFalse(NMObject.notes_ok([{"date": "111"}]))
-        self.assertFalse(
-            NMObject.notes_ok([{"note": "hey", "date": "111", "more": "1"}])
-        )
-
-    def test08_name_set(self):
+    def test07_name_set(self):
         # args: name_notused
         # args: newname
 
@@ -277,7 +234,7 @@ class NMObjectTest(unittest.TestCase):
             self.o0._name_set("notused", n)
             self.assertEqual(n, self.o0.name)
 
-    def test09_rename_fxnref_set(self):
+    def test08_rename_fxnref_set(self):
         # args: rename_fxnref
 
         bad = list(nmu.BADTYPES)
@@ -296,16 +253,16 @@ class NMObjectTest(unittest.TestCase):
         print("test rename: " + oldname + " -> " + newname)
         return False
 
-    def test10_manager(self):
+    def test09_manager(self):
         self.assertEqual(self.o0._manager, NM0)
 
-    def test11_error(self):
+    def test10_error(self):
         pass
         # alert(), error(), history()
         # wrappers for history()
         # args: obj, type_expected, tp, quiet, frame
 
-    def test12_quiet(self):
+    def test11_quiet(self):
         # args: quiet
         # TODO
         """


### PR DESCRIPTION
## Summary
- Move notes functionality from NMObject to NMFolder where it semantically belongs
- Notes represent experiment/recording session data (e.g., "added TTX", "added AP5"), matching original Igor NeuroMatic design where notes are saved within data folders
- Simplify API: remove `notes_on` toggle, rename methods to `note_add()` and `notes_clear()`
- Clean up `__deepcopy__` methods across all NMObject subclasses
- Issue #30

## Test plan
- [x] All 139 existing tests pass
- [x] New `test02_notes` test added to `test_nm_folder.py`
- [x] Notes tests removed from `test_nm_object.py`
- [x] Verified notes equality comparison works in folder copy tests

