### PR TITLE
Remove delete confirmation prompts from container operations (#32)

### DIFF
--- a/pyneuromatic/core/nm_preferences.py
+++ b/pyneuromatic/core/nm_preferences.py
@@ -19,7 +19,6 @@ Website: https://github.com/SilverLabUCL/pyNeuroMatic
 Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 DATASERIES_SET_LIST = ["all", "set1", "set2", "setX"]
-DELETE_CONFIRM = True
 QUIET = False
 GUI = False
 NAN_EQ_NAN = True  # in Python nan != nan, use this flag so that nan == nan

--- a/pyneuromatic/core/nm_sets.py
+++ b/pyneuromatic/core/nm_sets.py
@@ -505,30 +505,17 @@ class NMSets(NMObject, MutableMapping):
     # override MutableMapping mixin method
     def pop(  # type: ignore[override]
         self,
-        key: str,
-        auto_confirm: str | None = None,  # to skip confirm prompt
+        key: str
     ) -> list[NMObject] | None:
         # removed 'default' parameter
         key = self._getkey(key)
-        if nmp.DELETE_CONFIRM:
-            if auto_confirm in nmu.CONFIRM_YNC:
-                ync = auto_confirm
-            else:
-                q = "are you sure you want to delete '%s'?" % key
-                ync = nmu.prompt_yes_no(q, path=self.path_str)
-            if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
-                pass
-            else:
-                print("cancel pop '%s'" % key)
-                return None
         o = self.__map.pop(key)
         return o
 
     # override MutableMapping mixin method
-    def popitem(  # type: ignore[override]  # delete last item
-        self, 
-        auto_confirm: str | None = None  # to skip confirm prompt
-    ) -> tuple[str, list[NMObject]] | None:
+    # type: ignore[override]
+    # # delete last item
+    def popitem(self) -> tuple[str, list[NMObject]] | None:
         """
         Must override, otherwise first item is deleted rather than last.
         Consider deprecating to prevent accidental deletes.
@@ -537,32 +524,16 @@ class NMSets(NMObject, MutableMapping):
             return None
         klist = list(self.__map.keys())
         key = klist[-1]  # last key
-        olist = self.pop(key=key, auto_confirm=auto_confirm)
+        olist = self.pop(key=key)
         if olist:
             return (key, olist)
         return None
 
     # override MutableMapping mixin method
     # override so there is only a single delete confirmation
-    def clear(
-        self, 
-        auto_confirm: str | None = None  # to skip confirm prompt
-    ) -> None:
+    def clear(self) -> None:
         if len(self) == 0:
             return None
-        if nmp.DELETE_CONFIRM:
-            if auto_confirm in nmu.CONFIRM_YNC:
-                ync = auto_confirm
-            else:
-                q = "are you sure you want to delete the following?\n" + ", ".join(
-                    self.__map.keys()
-                )
-                ync = nmu.prompt_yes_no(q, path=self.path_str)
-            if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
-                pass
-            else:
-                print("cancel delete all")
-                return None
         self.__map.clear()
         return None
 
@@ -827,42 +798,14 @@ class NMSets(NMObject, MutableMapping):
 
     def empty(
         self,
-        key: str,
-        auto_confirm: str | None = None,  # to skip confirm prompt
+        key: str
     ) -> None:
         key = self._getkey(key)
-        if nmp.DELETE_CONFIRM:
-            if auto_confirm in nmu.CONFIRM_YNC:
-                ync = auto_confirm
-            else:
-                q = "are you sure you want to empty '%s'?" % key
-                ync = nmu.prompt_yes_no(q, path=self.path_str)
-            if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
-                pass
-            else:
-                print("cancel empty '%s'" % key)
-                return None
         olist = self.__map[key]
         olist.clear()
         return None
 
-    def empty_all(
-        self, 
-        auto_confirm: str | None = None  # to skip confirm prompt
-    ) -> None:
-        if nmp.DELETE_CONFIRM:
-            if auto_confirm in nmu.CONFIRM_YNC:
-                ync = auto_confirm
-            else:
-                q = "are you sure you want to empty the following?\n" + ", ".join(
-                    self.__map.keys()
-                )
-                ync = nmu.prompt_yes_no(q, path=self.path_str)
-            if ync is not None and (ync.lower() == "y" or ync.lower() == "yes"):
-                pass
-            else:
-                print("cancel empty all")
-                return None
+    def empty_all(self) -> None:
         for olist in self.__map.values():
             olist.clear()    
         return None

--- a/tests/test_core/test_nm_data.py
+++ b/tests/test_core/test_nm_data.py
@@ -215,7 +215,7 @@ class NMDataTest(unittest.TestCase):
         self.assertFalse(c0_copy == c0)
         with self.assertRaises(KeyError):
             dnew = c0.new("test")
-        c0.pop("test", auto_confirm="y")
+        c0.pop("test")
         self.assertTrue(c0_copy == c0)
         c0.sets.remove("set0", dnlist0[0])
         self.assertFalse(c0_copy == c0)

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -299,14 +299,7 @@ class NMObjectContainerTest(unittest.TestCase):
         with self.assertRaises(KeyError):
             del self.map0["test"]
 
-        print("\nanswer NO")
-        with patch('pyneuromatic.core.nm_utilities.prompt_yes_no', return_value='n'):
-            del self.map0[ONLIST0[1]]
-        self.assertTrue(ONLIST0[1] in self.map0)
-
-        print("\nanswer YES")
-        with patch('pyneuromatic.core.nm_utilities.prompt_yes_no', return_value='y'):
-            del self.map0[ONLIST0[1]]
+        del self.map0[ONLIST0[1]]
         self.assertFalse(ONLIST0[1] in self.map0)
         with self.assertRaises(KeyError):
             del self.map0[ONLIST0[1]]
@@ -407,10 +400,7 @@ class NMObjectContainerTest(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.map0.pop("test")
 
-        o = self.map0.pop(ONLIST0[1], auto_confirm="n")
-        self.assertIsNone(o)
-        self.assertTrue(ONLIST0[1] in self.map0)
-        o = self.map0.pop(ONLIST0[1], auto_confirm="y")
+        o = self.map0.pop(ONLIST0[1])
         self.assertEqual(o, self.olist0[1])
         self.assertFalse(ONLIST0[1] in self.map0)
 
@@ -418,7 +408,7 @@ class NMObjectContainerTest(unittest.TestCase):
             o = self.map0.pop(ONLIST0[1])
 
         for i, n in enumerate(ONLIST1):
-            o = self.map1.pop(n, auto_confirm="y")
+            o = self.map1.pop(n)
             self.assertEqual(o, self.olist1[i])
             self.assertFalse(n in self.map1)
         self.assertEqual(len(self.map1), 0)
@@ -427,23 +417,17 @@ class NMObjectContainerTest(unittest.TestCase):
         # with self.assertRaises(RuntimeError):
         #    self.map0.popitem()  # NOT ALLOWED
         # popitem returns a tuple
-        o = self.map0.popitem(auto_confirm="n")
-        self.assertEqual(o, ())
-        self.assertTrue(ONLIST0[-1] in self.map0)
-        o = self.map0.popitem(auto_confirm="y")
+        o = self.map0.popitem()
         self.assertFalse(ONLIST0[-1] in self.map0)
         t = (ONLIST0[-1], self.olist0[-1])
         self.assertEqual(o, t)
         for i, n in reversed(list(enumerate(ONLIST1))):
-            o = self.map1.popitem(auto_confirm="y")
+            o = self.map1.popitem()
             self.assertFalse(n in self.map1)
         self.assertEqual(len(self.map1), 0)
 
     def test19_clear(self):
-        o = self.map0.clear(auto_confirm="n")
-        self.assertIsNone(o)
-        self.assertEqual(len(self.map0), len(ONLIST0))
-        o = self.map0.clear(auto_confirm="y")
+        o = self.map0.clear()
         self.assertIsNone(o)
         self.assertEqual(len(self.map0), 0)
 
@@ -591,7 +575,7 @@ class NMObjectContainerTest(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             self.map1.rename(ONLIST0[0], 'test')  # rename_on = False
         
-        self.map0.pop(ONLIST0[3], auto_confirm="y")
+        self.map0.pop(ONLIST0[3])
         self.assertFalse(ONLIST0[3] in self.map0)
         klist = [OPREFIX0 + str(i) for i in [0, 1, 2, 4, 5]]
         self.assertEqual(list(self.map0.keys()), klist)
@@ -882,7 +866,7 @@ class NMObjectContainerTest(unittest.TestCase):
         self.assertIsNone(self.map0.selected_name)
 
         self.map0.selected_name = ONLIST0[3]
-        self.map0.pop(ONLIST0[3], auto_confirm="y")
+        self.map0.pop(ONLIST0[3])
         self.assertIsNone(self.map0.selected_name)
 
         # print((nmu.quotes('test') + ' this' '1'))

--- a/tests/test_core/test_nm_project.py
+++ b/tests/test_core/test_nm_project.py
@@ -127,7 +127,7 @@ class NMProjectTest(unittest.TestCase):
 
         self.assertTrue(self.project0 == project0)
 
-        project0.folders.popitem(auto_confirm="y")
+        project0.folders.popitem()
         self.assertFalse(self.project0 == project0)
 
     def test02_copy(self):

--- a/tests/test_core/test_nm_sets.py
+++ b/tests/test_core/test_nm_sets.py
@@ -345,7 +345,7 @@ class NMSetsTest(unittest.TestCase):
         olist2 = self.sets0.get("set99")
         self.assertEqual(nlist, nlist2)
         self.assertEqual(olist, olist2)
-        self.sets0.pop("set99", auto_confirm="y")
+        self.sets0.pop("set99")
 
         for i, (k, v) in enumerate(self.sets0.items()):
             d = self.sets0_init[i]
@@ -642,17 +642,13 @@ class NMSetsTest(unittest.TestCase):
             self.sets0.pop("test")  # does not exist
 
         self.assertTrue(sname0 in self.sets0)
-        olist = self.sets0.pop(sname0, auto_confirm="n")
-        self.assertTrue(sname0 in self.sets0)
-        self.assertIsNone(olist)
-
-        olist = self.sets0.pop(sname0, auto_confirm="y")
+        olist = self.sets0.pop(sname0)
         self.assertFalse(sname0 in self.sets0)
         self.assertEqual(olist, olist0)
         olist = self.sets0.get(sname0)
         self.assertIsNone(olist)
 
-        olist = self.sets0.pop(sname1, auto_confirm="y")
+        olist = self.sets0.pop(sname1)
         self.assertFalse(sname1 in self.sets0)
         self.assertEqual(olist, olist1)
         olist = self.sets0.get(sname1)
@@ -662,7 +658,6 @@ class NMSetsTest(unittest.TestCase):
         # pop last set
 
         n_sets = len(self.sets0)
-        first = True
         for i in range(n_sets):
             j = -1 * (i + 1)
 
@@ -672,20 +667,13 @@ class NMSetsTest(unittest.TestCase):
 
             self.assertTrue(sname in self.sets0)
 
-            if first:
-                olist2 = self.sets0.popitem(auto_confirm="n")
-                self.assertTrue(sname in self.sets0)
-                self.assertEqual(olist2, ())  # empty tuple
-                first = False
-
-            olist2 = self.sets0.popitem(auto_confirm="y")
+            olist2 = self.sets0.popitem()
             self.assertFalse(sname in self.sets0)
             self.assertEqual(olist2, (sname, olist))  # tuple
 
         self.assertEqual(len(self.sets0), 0)
 
         n_sets = len(self.sets1)
-        first = True
         for i in range(n_sets):
             j = -1 * (i + 1)
 
@@ -696,13 +684,7 @@ class NMSetsTest(unittest.TestCase):
 
             self.assertTrue(sname in self.sets1)
 
-            if first:
-                olist2 = self.sets1.popitem(auto_confirm="n")
-                self.assertTrue(sname in self.sets1)
-                self.assertEqual(olist2, ())  # empty tuple
-                first = False
-
-            olist2 = self.sets1.popitem(auto_confirm="y")
+            olist2 = self.sets1.popitem()
             self.assertFalse(sname in self.sets1)
             if eqlist:
                 self.assertEqual(olist2, (sname, eqlist))  # tuple
@@ -712,17 +694,12 @@ class NMSetsTest(unittest.TestCase):
         self.assertEqual(len(self.sets1), 0)
 
     def xtest16_clear(self):
-        self.sets0.clear(auto_confirm="n")
-        for d in self.sets0_init:
-            sname = d["name"].upper()
-            self.assertTrue(sname in self.sets0)
-
-        self.sets0.clear(auto_confirm="y")
+        self.sets0.clear()
         for d in self.sets0_init:
             sname = d["name"].upper()
             self.assertFalse(sname in self.sets0)
 
-        self.sets1.clear(auto_confirm="y")
+        self.sets1.clear()
         for d in self.sets1_init:
             sname = d["name"].upper()
             self.assertFalse(sname in self.sets1)
@@ -1166,30 +1143,17 @@ class NMSetsTest(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.sets0.empty("test")
 
-        self.sets0.empty(sname0, auto_confirm="n")
-        self.assertTrue(sname0 in self.sets0)
-        self.assertEqual(self.sets0.get(sname0), olist0)
-
-        self.sets0.empty(sname0, auto_confirm="y")
+        self.sets0.empty(sname0)
         self.assertEqual(self.sets0.get(sname0), [])
 
         d = self.sets1_init[-1]
         sname1 = d["name"]
 
-        self.sets1.empty(sname1, auto_confirm="y")
+        self.sets1.empty(sname1)
         self.assertEqual(self.sets1.get(sname1), [])
 
     def xtest32_emptyall(self):
-        # args: confirm
-
-        self.sets0.empty_all(auto_confirm="n")
-
-        for d in self.sets0_init:
-            sname = d["name"]
-            olist = d["olist"]
-            self.assertEqual(self.sets0.get(sname), olist)
-
-        self.sets0.empty_all(auto_confirm="y")
+        self.sets0.empty_all()
 
         for d in self.sets0_init:
             sname = d["name"]
@@ -1383,7 +1347,7 @@ class NMSetsTest(unittest.TestCase):
         eqlist2 = self.sets1.get("select", get_equation=True)
         self.assertEqual(eqlist, eqlist2)
 
-        self.sets1.pop(sname, auto_confirm="y")
+        self.sets1.pop(sname)
         self.assertIsNone(self.sets1.select_key)
 
     def xtest37_equation(self):
@@ -1432,7 +1396,7 @@ class NMSetsTest(unittest.TestCase):
             self.assertTrue(o.name in s3)
 
         self.sets0.update({sname3: eqlist})
-        self.sets0.empty(sname3, auto_confirm="y")
+        self.sets0.empty(sname3)
         self.assertEqual(self.sets0.get(sname3), [])
 
         eqlist = [sname0, "&", sname1]


### PR DESCRIPTION
Remove the DELETE_CONFIRM preference and associated confirmation prompts from delete operations. This simplifies the API by removing the auto_confirm parameter from pop(), popitem(), clear(), empty(), and empty_all() methods in NMObjectContainer and NMSets. Issue #32 

- Remove DELETE_CONFIRM setting from nm_preferences.py
- Remove auto_confirm parameter and confirmation logic from NMObjectContainer (pop, popitem, clear)
- Remove auto_confirm parameter and confirmation logic from NMSets (pop, popitem, clear, empty, empty_all)
- Update all related tests