### PR TITLE
refactor: Simplify hierarchy - project always "root", NMManager not NMObject (#36)

### DIFF
--- a/pyneuromatic/core/nm_channel.py
+++ b/pyneuromatic/core/nm_channel.py
@@ -36,7 +36,7 @@ import pyneuromatic.core.nm_utilities as nmu
 NM class tree:
 
 NMManager
-    NMProject (project0)
+    NMProject (root)
         NMFolderContainer
             NMFolder (folder0, folder1...)
                 NMDataContainer

--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -41,7 +41,7 @@ NP_FILL_VALUE = numpy.nan
 NM class tree:
 
 NMManager
-    NMProject (project0)
+    NMProject (root)
         NMFolderContainer
             NMFolder (folder0, folder1...)
                 NMDataContainer

--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -37,7 +37,7 @@ ALLSTR = "all".upper()
 NM class tree:
 
 NMManager
-    NMProject (project0)
+    NMProject (root)
         NMFolderContainer
             NMFolder (folder0, folder1...)
                 NMDataContainer

--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -36,7 +36,7 @@ import pyneuromatic.core.nm_utilities as nmu
 NM class tree:
 
 NMManager
-    NMProject (project0)
+    NMProject (root)
         NMFolderContainer
             NMFolder (folder0, folder1...)
                 NMDataContainer

--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -36,7 +36,7 @@ import pyneuromatic.core.nm_utilities as nmu
 NM class tree:
 
 NMManager
-    NMProject (project0)
+    NMProject (root)
         NMFolderContainer
             NMFolder (folder0, folder1...)
                 NMDataContainer

--- a/pyneuromatic/core/nm_object.py
+++ b/pyneuromatic/core/nm_object.py
@@ -43,8 +43,8 @@ class NMObject(object):
 
     NM class tree:
 
-    NMManager
-        NMProject (project0)
+    NMManager (not an NMObject)
+        NMProject (root)
             NMFolderContainer
                 NMFolder (folder0, folder1...)
                     NMDataContainer
@@ -57,8 +57,8 @@ class NMObject(object):
                                 NMEpoch (E0, E1, E2...)
 
     Each NMObject has a path in the hierarchy:
-        - path: list of names, e.g. ['project0', 'folder0', 'recordA0']
-        - path_str: dotted string, e.g. 'project0.folder0.recordA0'
+        - path: list of names, e.g. ['root', 'folder0', 'recordA0']
+        - path_str: dotted string, e.g. 'root.folder0.recordA0'
         - path_objects: list of NMObject references
 
     Known children of NMObject:
@@ -290,7 +290,7 @@ class NMObject(object):
     def path(self) -> list[str]:
         """Hierarchy path as list of names.
 
-        Example: ['project0', 'folder0', 'recordA0']
+        Example: ['root', 'folder0', 'recordA0']
 
         Returns:
             List of NMObject names from root to this object.
@@ -305,7 +305,7 @@ class NMObject(object):
     def path_str(self) -> str:
         """Hierarchy path as dotted string.
 
-        Example: 'project0.folder0.recordA0'
+        Example: 'root.folder0.recordA0'
 
         Returns:
             Dotted string path from root to this object.

--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -45,7 +45,7 @@ class NMObjectContainer(NMObject, MutableMapping):
     NM class tree:
 
     NMManager
-        NMProject (project0)
+        NMProject (root)
             NMFolderContainer
                 NMFolder (folder0, folder1...)
                     NMDataContainer

--- a/pyneuromatic/core/nm_project.py
+++ b/pyneuromatic/core/nm_project.py
@@ -28,7 +28,7 @@ from pyneuromatic.core.nm_object import NMObject
 NM class tree:
 
 NMManager
-    NMProject (project0)
+    NMProject (root)
         NMFolderContainer
             NMFolder (folder0, folder1...)
                 NMDataContainer
@@ -56,7 +56,7 @@ class NMProject(NMObject):
     def __init__(
         self,
         parent: object | None = None,
-        name: str = "NMProject0",
+        name: str = "root",
     ) -> None:
         super().__init__(parent=parent, name=name)
 

--- a/tests/test_core/test_nm_dimension.py
+++ b/tests/test_core/test_nm_dimension.py
@@ -131,8 +131,8 @@ class NMDimensionTest(unittest.TestCase):
         plist = self.y0_copy.parameters
         self.assertEqual(klist, list(plist.keys()))
         self.assertEqual(plist["name"], YSNAME0)
-        tp = NM.name + "." + YSNAME0
-        self.assertEqual(plist["copy of"], tp)
+        # NMManager is not an NMObject, so path_str is just the object name
+        self.assertEqual(plist["copy of"], YSNAME0)
         self.assertEqual(plist["label"], YSCALE0["label"])
         self.assertEqual(plist["units"], YSCALE0["units"])
 

--- a/tests/test_core/test_nm_manager.py
+++ b/tests/test_core/test_nm_manager.py
@@ -18,7 +18,7 @@ import pyneuromatic.core.nm_utilities as nmu
 
 QUIET = True
 NUMPROJECTS = 1  # 3 # for now, only one project
-PROJECTNAME = "ManagerTest"
+PROJECTNAME = "root"  # Project is always named "root"
 NUMFOLDERS = 5
 DATASERIES = ["data", "avg", "stim"]
 NUMDATA = [8, 9, 10]
@@ -30,7 +30,7 @@ ISELECT = 0  # 0, 1, -1
 class NMManagerTest(unittest.TestCase):
 
     def setUp(self):
-        self.nm = NMManager(name="NM", project_name=PROJECTNAME, quiet=QUIET)
+        self.nm = NMManager(quiet=QUIET)
         ilast = ISELECT == -1
         self.select_values = {}
         self.select_keys = {}
@@ -110,35 +110,15 @@ class NMManagerTest(unittest.TestCase):
         # self.nm.projects.sets.add("set0", ["project0", "project1"])
 
     def test00_init(self):
-        # args: name, project_name, quiet
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")
-        for b in bad:
-            with self.assertRaises(TypeError):
-                NMManager(name=b, quiet=True)
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")
-        bad.remove(None)
-        for b in bad:
-            with self.assertRaises(TypeError):
-                NMManager(project_name=b, quiet=True)
-
-        bad = list(nmu.BADNAMES)
-        for b in bad:
-            with self.assertRaises(ValueError):
-                NMManager(name=b, quiet=True)
-            with self.assertRaises(ValueError):
-                NMManager(project_name=b, quiet=True)
-
+        # NMManager is a simple controller class (not an NMObject)
         self.assertTrue(isinstance(self.nm.project, NMProject))
+        self.assertEqual(self.nm.project.name, "root")
 
     def test01_parameters(self):
-        d = self.nm.parameters
-        self.assertEqual(d["name"], "NM")
-        keys = ["name", "created", "copy of"]
-        self.assertEqual(list(d.keys()), keys)
+        # NMManager is not an NMObject, so no parameters property
+        # Just verify basic properties work
+        self.assertIsNotNone(self.nm.project)
+        self.assertEqual(self.nm.project.name, "root")
 
     def test02_select(self):
         # select_values

--- a/tests/test_core/test_nm_object.py
+++ b/tests/test_core/test_nm_object.py
@@ -190,29 +190,31 @@ class NMObjectTest(unittest.TestCase):
 
     def test05_content(self):
         self.assertEqual(self.o0.content, {"nmobject": self.o0.name})
-        ct = {"nmmanager": "nm", "nmobject": self.o0.name}
+        # NMManager is not an NMObject, so content_tree only includes the object
+        ct = {"nmobject": self.o0.name}
         self.assertEqual(self.o0.content_tree, ct)
 
     def test06_path(self):
         # Test path property (list of names)
-        expected_path = [NM0.name, self.o0.name]
+        # NMManager is not an NMObject, so path only includes this object
+        expected_path = [self.o0.name]
         self.assertEqual(self.o0.path, expected_path)
 
         # Test path_str property (dotted string)
-        expected_str = NM0.name + "." + self.o0.name
+        expected_str = self.o0.name
         self.assertEqual(self.o0.path_str, expected_str)
 
         # Test path_objects property (list of NMObject references)
         path_objs = self.o0.path_objects
-        self.assertEqual(len(path_objs), 2)
-        self.assertIs(path_objs[0], NM0)
-        self.assertIs(path_objs[1], self.o0)
+        self.assertEqual(len(path_objs), 1)
+        self.assertIs(path_objs[0], self.o0)
 
         # Test nested object
         o2 = NMObject2(parent=NM0, name=ONAME0)
-        expected_path = [NM0.name, ONAME0, "myobject"]
+        # NMManager is not an NMObject, so path starts from o2
+        expected_path = [ONAME0, "myobject"]
         self.assertEqual(o2.myobject.path, expected_path)
-        expected_str = NM0.name + "." + ONAME0 + ".myobject"
+        expected_str = ONAME0 + ".myobject"
         self.assertEqual(o2.myobject.path_str, expected_str)
 
     def test07_name_set(self):

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -180,8 +180,8 @@ class NMObjectContainerTest(unittest.TestCase):
 
         plist = self.map1_copy.parameters
         self.assertEqual(plist["name"], CNAME1)
-        tp = NM1.name + "." + CNAME1
-        self.assertEqual(plist["copy of"], tp)
+        # NMManager is not an NMObject, so path_str is just the container name
+        self.assertEqual(plist["copy of"], CNAME1)
         self.assertEqual(plist["content_type"], "nmobject")
         self.assertFalse(plist["rename_on"])
         self.assertEqual(plist["auto_name_prefix"], OPREFIX1)
@@ -665,15 +665,15 @@ class NMObjectContainerTest(unittest.TestCase):
         o = self.map0.get(ONLIST0[1])
         self.assertFalse(c == o)  # same name
         pc = c.parameters
-        tp = NM0.name + "." + ONLIST0[1]
-        self.assertEqual(pc["copy of"], tp)
+        # NMManager is not an NMObject, so path_str is just the object name
+        self.assertEqual(pc["copy of"], ONLIST0[1])
 
         c = self.map0.duplicate(ONLIST0[0], "test")
         self.assertEqual(c.name, "test")
         self.assertEqual(len(self.map0), len(ONLIST0) + 2)
         pc = c.parameters
-        tp = NM0.name + "." + ONLIST0[0]
-        self.assertEqual(pc["copy of"], tp)
+        # NMManager is not an NMObject, so path_str is just the object name
+        self.assertEqual(pc["copy of"], ONLIST0[0])
 
     def test27_new(self):
         # args: nmobject


### PR DESCRIPTION
## Summary
Simplify the NMObject hierarchy by making NMProject always named "root" and removing NMManager from the NMObject inheritance chain. This mirrors Igor NeuroMatic's root directory structure. #36 

## Changes
- NMManager no longer inherits from NMObject (plain controller class)
- NMManager `name` parameter removed (unnecessary)
- NMProject default name changed from "NMProject0" to "root"
- Paths now start from root: `['root', 'folder0', 'recordA0']`

## Before
Path: ['nm', 'project0', 'folder0', 'recordA0']

## After
Path: ['root', 'folder0', 'recordA0']


## Modified Files
- `pyneuromatic/core/nm_manager.py` - removed NMObject inheritance and name param
- `pyneuromatic/core/nm_project.py` - default name "root"
- `pyneuromatic/core/nm_object.py` - updated docstrings and path examples
- `tests/test_core/test_nm_manager.py` - updated for new NMManager behavior
- `tests/test_core/test_nm_object.py` - updated path expectations
- `tests/test_core/test_nm_object_container.py` - updated path expectations
- `tests/test_core/test_nm_dimension.py` - updated path expectations

## Test Plan
- [x] All 187 tests pass

