### PR TITLE
feat(core): add case-insensitive key handling for NMManager selection methods #46

### DIFF
--- a/pyneuromatic/core/nm_manager.py
+++ b/pyneuromatic/core/nm_manager.py
@@ -313,6 +313,11 @@ class NMManager:
         for key, value in select.items():
             if not isinstance(key, str):
                 raise TypeError(nmu.type_error_str(key, "key", "string"))
+
+        # Normalize keys to lowercase for case-insensitive matching
+        select = {k.lower(): v for k, v in select.items()}
+
+        for key, value in select.items():
             if value is not None and not isinstance(value, str):
                 raise TypeError(nmu.type_error_str(value, "value", "string"))
             if key not in SELECT_LEVELS:
@@ -441,6 +446,11 @@ class NMManager:
         for key, value in execute.items():
             if not isinstance(key, str):
                 raise TypeError(nmu.type_error_str(key, "key", "string"))
+
+        # Normalize keys to lowercase for case-insensitive matching
+        execute = {k.lower(): v for k, v in execute.items()}
+
+        for key, value in execute.items():
             if key not in SELECT_LEVELS:
                 raise KeyError(f"unknown execute key '{key}'")
             if not isinstance(value, str):

--- a/tests/test_core/test_nm_manager.py
+++ b/tests/test_core/test_nm_manager.py
@@ -176,6 +176,32 @@ class TestNMManagerSelect(NMManagerTestBase):
         with self.assertRaises(KeyError):
             self.nm.select_keys = {"epoch": "test"}
 
+    def test_select_keys_case_insensitive(self):
+        # Test with uppercase keys
+        s1 = {
+            "FOLDER": "folder1",
+            "DATA": "data3",
+            "DATASERIES": "data",
+            "CHANNEL": "A",
+            "EPOCH": "E3",
+        }
+        self.nm.select_keys = s1
+        expected = {
+            "folder": "folder1",
+            "data": "data3",
+            "dataseries": "data",
+            "channel": "A",
+            "epoch": "E3",
+        }
+        self.assertEqual(self.nm.select_keys, expected)
+
+    def test_select_keys_mixed_case(self):
+        # Test with mixed case keys
+        s1 = {"Folder": "folder1", "DataSeries": "data", "Channel": "A", "Epoch": "E0"}
+        self.nm.select_keys = s1
+        self.assertEqual(self.nm.select_keys["folder"], "folder1")
+        self.assertEqual(self.nm.select_keys["dataseries"], "data")
+
 
 class TestNMManagerExecuteKeys(NMManagerTestBase):
     """Tests for execute_keys and execute_values methods."""
@@ -361,6 +387,27 @@ class TestNMManagerExecuteKeysSet(NMManagerTestBase):
         }
         elist = self.nm.execute_keys_set(e0)
         self.assertEqual(len(elist), 2)  # set0 has folder0 and folder1
+
+    def test_execute_keys_set_case_insensitive(self):
+        # Test with uppercase keys
+        e0 = {
+            "FOLDER": "folder1",
+            "DATASERIES": "stim",
+            "CHANNEL": "A",
+            "EPOCH": "E0",
+        }
+        elist = self.nm.execute_keys_set(e0)
+        self.assertEqual(len(elist), 1)
+        self.assertEqual(elist[0]["folder"], "folder1")
+        self.assertEqual(elist[0]["dataseries"], "stim")
+
+    def test_execute_keys_set_mixed_case(self):
+        # Test with mixed case keys
+        e0 = {"Folder": "folder1", "Data": "data0"}
+        elist = self.nm.execute_keys_set(e0)
+        self.assertEqual(len(elist), 1)
+        self.assertEqual(elist[0]["folder"], "folder1")
+        self.assertEqual(elist[0]["data"], "data0")
 
 
 class TestNMManagerExecuteMaxTargets(NMManagerTestBase):


### PR DESCRIPTION
## Summary
- Add case-insensitive key matching for SELECT_LEVELS keys (folder, data, dataseries, channel, epoch)
- Applies to both `select_keys` setter and `execute_keys_set()` methods
- Input keys are normalized to lowercase after type validation
- Issue #46 

## Test plan
- [x] Verify uppercase keys work: `{"FOLDER": "folder1", "DATASERIES": "data"}`
- [x] Verify mixed case keys work: `{"Folder": "folder1", "DataSeries": "data"}`
- [x] Verify existing lowercase keys still work
- [x] Verify type validation still rejects non-string keys
- [x] All 48 NMManager tests pass

