### PR TITLE
Simplify NMSets equation feature to tuple format #52

### DIFF
--- a/tests/test_core/test_nm_data.py
+++ b/tests/test_core/test_nm_data.py
@@ -175,8 +175,7 @@ class NMDataTest(unittest.TestCase):
         c0.sets.add("set0", nlist)
         nlist = [dnlist0[i] for i in range(1, ndata, 2)]
         c0.sets.add("set1", nlist)
-        nlist = ["set0", "|", "set1"]
-        c0.sets.add("set2", nlist)
+        c0.sets.define_or("set2", "set0", "set1")
         klist = list(c0.sets.keys())
         self.assertEqual(klist, ["set0", "set1", "set2"])
 
@@ -196,8 +195,7 @@ class NMDataTest(unittest.TestCase):
         c1.sets.add("set0", nlist)
         nlist = [dnlist1[i] for i in range(1, ndata, 2)]
         c1.sets.add("set1", nlist)
-        nlist = ["set0", "|", "set1"]
-        c1.sets.add("set2", nlist)
+        c1.sets.define_or("set2", "set0", "set1")
 
         # eq
         self.assertFalse(c0 == c1)

--- a/tests/test_core/test_nm_dataseries.py
+++ b/tests/test_core/test_nm_dataseries.py
@@ -62,13 +62,13 @@ class NMDataSeriesTest(unittest.TestCase):
             self.ds0.epochs.sets.add("set0", "E" + str(i))
         for i in range(1, num_epochs, 2):
             self.ds0.epochs.sets.add("set1", "E" + str(i))
-        self.ds0.epochs.sets.add("set2", ["set0", "|", "set1"])
+        self.ds0.epochs.sets.define_or("set2", "set0", "set1")
 
         self.ds0.channels.sets.add("set0", "A")
         self.ds0.channels.sets.add("set0", "B")
         self.ds0.channels.sets.add("set1", "C")
         self.ds0.channels.sets.add("set1", "D")
-        self.ds0.channels.sets.add("set2", ["set0", "|", "set1"])
+        self.ds0.channels.sets.define_or("set2", "set0", "set1")
 
     def test00_init(self):
         with self.assertRaises(TypeError):

--- a/tests/test_core/test_nm_folder.py
+++ b/tests/test_core/test_nm_folder.py
@@ -38,8 +38,7 @@ class NMFolderTest(unittest.TestCase):
         self.folder0.data.sets.add(DSETS_NLIST0[0], slist)
         slist = [DNLIST0[i] for i in range(1, n, 2)]
         self.folder0.data.sets.add(DSETS_NLIST0[1], slist)
-        slist = [DSETS_NLIST0[0], "|", DSETS_NLIST0[1]]
-        self.folder0.data.sets.add(DSETS_NLIST0[2], slist)
+        self.folder0.data.sets.define_or(DSETS_NLIST0[2], DSETS_NLIST0[0], DSETS_NLIST0[1])
 
         self.folder1 = NMFolder(parent=NM, name=FNAME1)
 
@@ -54,8 +53,7 @@ class NMFolderTest(unittest.TestCase):
         self.folder1.data.sets.add(DSETS_NLIST1[0], slist)
         slist = [DNLIST1[i] for i in range(3, n, 1)]
         self.folder1.data.sets.add(DSETS_NLIST1[1], slist)
-        slist = [DSETS_NLIST1[0], "|", DSETS_NLIST1[1]]
-        self.folder1.data.sets.add(DSETS_NLIST1[2], slist)
+        self.folder1.data.sets.define_or(DSETS_NLIST1[2], DSETS_NLIST1[0], DSETS_NLIST1[1])
 
         # TODO: dataseries
 

--- a/tests/test_core/test_nm_project.py
+++ b/tests/test_core/test_nm_project.py
@@ -39,8 +39,7 @@ class NMProjectTest(unittest.TestCase):
         self.project0.folders.sets.add(FSETS_NLIST0[0], slist)
         slist = [FNLIST0[i] for i in range(1, n, 2)]
         self.project0.folders.sets.add(FSETS_NLIST0[1], slist)
-        slist = [FSETS_NLIST0[0], "|", FSETS_NLIST0[1]]
-        self.project0.folders.sets.add(FSETS_NLIST0[2], slist)
+        self.project0.folders.sets.define_or(FSETS_NLIST0[2], FSETS_NLIST0[0], FSETS_NLIST0[1])
 
         self.project1 = NMProject(parent=NM, name=PNAME1)
 
@@ -55,8 +54,7 @@ class NMProjectTest(unittest.TestCase):
         self.project1.folders.sets.add(FSETS_NLIST1[0], slist)
         slist = [FNLIST1[i] for i in range(3, n, 1)]
         self.project1.folders.sets.add(FSETS_NLIST1[1], slist)
-        slist = [FSETS_NLIST1[0], "|", FSETS_NLIST1[1]]
-        self.project1.folders.sets.add(FSETS_NLIST1[2], slist)
+        self.project1.folders.sets.define_or(FSETS_NLIST1[2], FSETS_NLIST1[0], FSETS_NLIST1[1])
 
     def test00_init(self):
         # args: parent, name, copy (see NMObject)

--- a/tests/test_core/test_nm_sets.py
+++ b/tests/test_core/test_nm_sets.py
@@ -1,1448 +1,468 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Sun Jul  9 10:56:59 2023
+Tests for NMSets.
 
-@author: jason
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
 """
 import copy
 import unittest
-import random
 
 from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.core.nm_object import NMObject
-from pyneuromatic.core.nm_sets import NMSets
+from pyneuromatic.core.nm_sets import NMSets, EQUATION_OPERATORS
 import pyneuromatic.core.nm_utilities as nmu
-from tests.test_core.test_nm_object import NMObject2
 
 QUIET = True
-NM = NMManager(quiet=QUIET)
-NM0 = NMManager(quiet=QUIET)
-NM1 = NMManager(quiet=QUIET)
-SETS_PREFIX0 = "set"
-SETS_PREFIX1 = "S"
-SETS_NAME0 = "sets0"
-SETS_NAME1 = "sets1"
-NUM_NMOBJECTS0 = 16
-NUM_NMOBJECTS1 = 12
-ONLIST0 = ["TestA" + str(i) for i in range(NUM_NMOBJECTS0)]
-ONLIST1 = ["TestB" + str(i) for i in range(NUM_NMOBJECTS1)]
-ONLIST1.reverse()  # REVERSE names
 
 
-class NMSetsTest(unittest.TestCase):
-    def setUp(self):  # executed before each test
-        self.olist0 = []
-        self.olist1 = []
-        self.odict0 = {}  # NM object dict
-        self.odict1 = {}
-        self.olist0_copy = []
-        self.olist1_copy = []
-        self.odict0_copy = {}
-        self.odict1_copy = {}
+class NMSetsTestBase(unittest.TestCase):
+    """Base class with common setup for NMSets tests."""
 
-        # create NMObjects and put in a dictionary
+    def setUp(self):
+        self.nm = NMManager(quiet=QUIET)
+        # Create NMObjects for testing
+        self.obj_names = [f"obj{i}" for i in range(10)]
+        self.objects = {}
+        for name in self.obj_names:
+            obj = NMObject(parent=self.nm, name=name)
+            self.objects[name] = obj
 
-        for n in ONLIST0:
-            o = NMObject(parent=NM0, name=n)
-            self.olist0.append(o)
-            self.odict0.update({n: o})
-            c = copy.deepcopy(o)
-            self.olist0_copy.append(c)
-            self.odict0_copy.update({n: c})
-
-        for n in ONLIST1:
-            o = NMObject(parent=NM1, name=n)
-            self.olist1.append(o)
-            self.odict1.update({n: o})
-            c = copy.deepcopy(o)
-            self.olist1_copy.append(c)
-            self.odict1_copy.update({n: c})
-
-        # create sets0
-
-        self.sets0 = NMSets(
-            parent=NM0,
-            name=SETS_NAME0,
-            nmobjects=self.odict0
-            # nmobjects_fxnref=self._nmobjects_dict0  # function reference
+        self.sets = NMSets(
+            parent=self.nm,
+            name="TestSets",
+            nmobjects=self.objects,
         )
 
-        self.sets0_init = []
-        num_sets = 2
 
-        for i in range(num_sets):
-            sname = SETS_PREFIX0 + str(i)
+class TestNMSetsInit(NMSetsTestBase):
+    """Tests for NMSets initialization."""
 
-            ilist = NMSetsTest.__ilist_random(NUM_NMOBJECTS0)
-            for i in ilist:
-                self.sets0.add(sname, ONLIST0[i])  # add in random order
+    def test_init_with_nmobjects(self):
+        sets = NMSets(parent=self.nm, name="test", nmobjects=self.objects)
+        self.assertEqual(sets.name, "test")
+        self.assertEqual(sets._parent, self.nm)
 
-            ilist.sort()  # sort according to nmobjects dict
-            nlist = []
-            olist = []
-            eqlist = []
+    def _get_objects_method(self):
+        """Method reference for testing nmobjects_fxnref."""
+        return self.objects
 
-            for i in ilist:
-                nlist.append(ONLIST0[i])
-                olist.append(self.olist0[i])
+    def test_init_with_nmobjects_fxnref(self):
+        sets = NMSets(parent=self.nm, name="test", nmobjects_fxnref=self._get_objects_method)
+        self.assertEqual(sets.name, "test")
 
-            sdict = {}
-            sdict["name"] = sname
-            sdict["ilist"] = ilist
-            sdict["nlist"] = nlist
-            sdict["olist"] = olist
-            sdict["eqlist"] = eqlist
+    def test_init_requires_nmobjects_arg(self):
+        with self.assertRaises(ValueError):
+            NMSets(name="test")
 
-            self.sets0_init.append(sdict)
+    def test_init_rejects_both_args(self):
+        with self.assertRaises(ValueError):
+            NMSets(nmobjects_fxnref=self._get_objects_method, nmobjects=self.objects)
 
-        # create sets1
-
-        self.sets1 = NMSets(
-            parent=NM1,
-            name=SETS_NAME1,
-            # nmobjects=self.odict1
-            nmobjects_fxnref=self._nmobjects_dict1,  # function reference
-        )
-
-        self.sets1_init = []
-        num_sets = 3  # 3 or more
-        oplist = ["&", "|", "-", "^"]
-
-        for i in range(num_sets):
-            sname = SETS_PREFIX1 + str(i + 1)
-
-            if i == num_sets - 1:  # last set is an equation
-                sname0 = self.sets1_init[0]["name"]
-                sname1 = self.sets1_init[1]["name"]
-                s0 = set(self.sets1_init[0]["ilist"])
-                s1 = set(self.sets1_init[1]["ilist"])
-                j = random.randint(0, 3)
-                op = oplist[j]
-                if op == "&":
-                    ilist = list(s0 & s1)
-                elif op == "|":
-                    ilist = list(s0 | s1)
-                elif op == "-":
-                    ilist = list(s0 - s1)
-                elif op == "^":
-                    ilist = list(s0 ^ s1)
-                else:
-                    raise RuntimeError("no op")
-                # ilist.sort()
-                eqlist = [sname0, op, sname1]
-                # print('\nset3 = ' + str(eqlist) + ', ilist = ' + str(ilist))
-            else:
-                ilist = NMSetsTest.__ilist_random(NUM_NMOBJECTS1)
-                eqlist = []
-
-            if eqlist:
-                self.sets1[sname] = eqlist
-            else:
-                for i in ilist:
-                    self.sets1.add(sname, ONLIST1[i])
-
-            ilist.sort()
-            nlist = []
-            olist = []
-
-            for i in ilist:
-                nlist.append(ONLIST1[i])
-                olist.append(self.olist1[i])
-
-            sdict = {}
-            sdict["name"] = sname
-            sdict["ilist"] = ilist
-            sdict["nlist"] = nlist
-            sdict["olist"] = olist
-            sdict["eqlist"] = eqlist
-
-            self.sets1_init.append(sdict)
-
-        # copy sets0 and sets1 using deepcopy
-        self.sets0_copy = copy.deepcopy(self.sets0)
-
-        self.sets1_copy = copy.deepcopy(self.sets1)
-
-    def __ilist_random(irange):
-        icount = irange * 0.5
-        ilist = []
-        for i in range(irange * 2):
-            j = random.randint(0, irange - 1)
-            if j not in ilist:
-                ilist.append(j)
-            if len(ilist) >= icount:
-                break
-        # ilist.sort()
-        return ilist
-
-    def _nmobjects_dict0(self):  # for testing nmobjects_fxnref
-        return self.odict0
-
-    def _nmobjects_dict1(self):  # for testing nmobjects_fxnref
-        return self.odict1
-
-    def test00_init(self):
-        # args: parent, name, copy (see NMObject)
-        # args: nmobjects_fxnref, nmobjects
-
-        bad = list(nmu.BADTYPES)
-        for b in bad:
-            with self.assertRaises(ValueError):
-                NMSets(nmobjects_fxnref=b)
-
-        bad = list(nmu.BADTYPES)
-        bad.remove({})
-        for b in bad:
+    def test_init_rejects_invalid_nmobjects(self):
+        bad_types = [None, 3, 3.14, True, [], (), "string"]
+        for b in bad_types:
             with self.assertRaises(ValueError):
                 NMSets(nmobjects=b)
 
+
+class TestNMSetsBasicOperations(NMSetsTestBase):
+    """Tests for basic set operations."""
+
+    def test_add_single_item(self):
+        self.sets.add("set0", "obj0")
+        self.assertIn("obj0", self.sets.get("set0", get_keys=True))
+
+    def test_add_multiple_items(self):
+        self.sets.add("set0", ["obj0", "obj1", "obj2"])
+        keys = self.sets.get("set0", get_keys=True)
+        self.assertIn("obj0", keys)
+        self.assertIn("obj1", keys)
+        self.assertIn("obj2", keys)
+
+    def test_add_nmobject_directly(self):
+        self.sets.add("set0", self.objects["obj0"])
+        self.assertIn(self.objects["obj0"], self.sets.get("set0"))
+
+    def test_get_returns_nmobjects(self):
+        self.sets.add("set0", ["obj0", "obj1"])
+        result = self.sets.get("set0")
+        self.assertIsInstance(result, list)
+        self.assertTrue(all(isinstance(o, NMObject) for o in result))
+
+    def test_get_keys_returns_strings(self):
+        self.sets.add("set0", ["obj0", "obj1"])
+        result = self.sets.get("set0", get_keys=True)
+        self.assertIsInstance(result, list)
+        self.assertTrue(all(isinstance(k, str) for k in result))
+
+    def test_get_nonexistent_returns_default(self):
+        result = self.sets.get("nonexistent")
+        self.assertIsNone(result)
+        result = self.sets.get("nonexistent", default="default")
+        self.assertEqual(result, "default")
+
+    def test_contains(self):
+        self.sets.add("set0", ["obj0", "obj1"])
+        self.assertTrue("set0" in self.sets)
+        self.assertFalse("nonexistent" in self.sets)
+
+    def test_len(self):
+        self.assertEqual(len(self.sets), 0)
+        self.sets.add("set0", [])
+        self.assertEqual(len(self.sets), 1)
+        self.sets.add("set1", [])
+        self.assertEqual(len(self.sets), 2)
+
+    def test_keys(self):
+        self.sets.add("set0", [])
+        self.sets.add("set1", [])
+        keys = list(self.sets.keys())
+        self.assertEqual(keys, ["set0", "set1"])
+
+    def test_pop(self):
+        self.sets.add("set0", ["obj0"])
+        result = self.sets.pop("set0")
+        self.assertFalse("set0" in self.sets)
+        self.assertEqual(len(result), 1)
+
+    def test_pop_equation(self):
+        self.sets.add("setA", ["obj0", "obj1"])
+        self.sets.add("setB", ["obj1", "obj2"])
+        self.sets.define_and("setC", "setA", "setB")
+        result = self.sets.pop("setC")
+        self.assertFalse("setC" in self.sets)
+        # Should return the equation tuple
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(result[0], "and")
+
+    def test_popitem(self):
+        self.sets.add("set0", ["obj0"])
+        self.sets.add("set1", ["obj1"])
+        key, value = self.sets.popitem()
+        self.assertEqual(key, "set1")  # Last item
+        self.assertFalse("set1" in self.sets)
+
+    def test_popitem_equation(self):
+        self.sets.add("setA", ["obj0", "obj1"])
+        self.sets.add("setB", ["obj1", "obj2"])
+        self.sets.define_and("setC", "setA", "setB")
+        key, value = self.sets.popitem()
+        self.assertEqual(key, "setC")  # Last item
+        # Should return the equation tuple
+        self.assertIsInstance(value, tuple)
+        self.assertEqual(value[0], "and")
+
+    def test_clear(self):
+        self.sets.add("set0", [])
+        self.sets.add("set1", [])
+        self.sets.clear()
+        self.assertEqual(len(self.sets), 0)
+
+    def test_case_insensitive_keys(self):
+        self.sets.add("Set0", ["obj0"])
+        self.assertTrue("set0" in self.sets)
+        self.assertTrue("SET0" in self.sets)
+        result = self.sets.get("SET0", get_keys=True)
+        self.assertIn("obj0", result)
+
+
+class TestNMSetsEquations(NMSetsTestBase):
+    """Tests for equation functionality."""
+
+    def setUp(self):
+        super().setUp()
+        # Create two source sets
+        self.sets.add("setA", ["obj0", "obj1", "obj2", "obj3"])
+        self.sets.add("setB", ["obj2", "obj3", "obj4", "obj5"])
+
+    def test_define_and(self):
+        self.sets.define_and("setC", "setA", "setB")
+        result = self.sets.get("setC", get_keys=True)
+        # AND should give intersection: obj2, obj3
+        self.assertEqual(set(result), {"obj2", "obj3"})
+
+    def test_define_or(self):
+        self.sets.define_or("setC", "setA", "setB")
+        result = self.sets.get("setC", get_keys=True)
+        # OR should give union: obj0, obj1, obj2, obj3, obj4, obj5
+        self.assertEqual(set(result), {"obj0", "obj1", "obj2", "obj3", "obj4", "obj5"})
+
+    def test_equation_via_setitem(self):
+        self.sets["setC"] = ("and", "setA", "setB")
+        result = self.sets.get("setC", get_keys=True)
+        self.assertEqual(set(result), {"obj2", "obj3"})
+
+    def test_equation_get_equation(self):
+        self.sets.define_and("setC", "setA", "setB")
+        eq = self.sets.get("setC", get_equation=True)
+        self.assertIsInstance(eq, tuple)
+        self.assertEqual(eq[0], "and")
+
+    def test_equation_dynamic_evaluation(self):
+        # Define equation first
+        self.sets.define_and("setC", "setA", "setB")
+        result1 = set(self.sets.get("setC", get_keys=True))
+        self.assertEqual(result1, {"obj2", "obj3"})
+
+        # Modify source set
+        self.sets.add("setA", "obj4")
+        result2 = set(self.sets.get("setC", get_keys=True))
+        # Now intersection should include obj4
+        self.assertEqual(result2, {"obj2", "obj3", "obj4"})
+
+    def test_is_equation(self):
+        self.sets.define_and("setC", "setA", "setB")
+        self.assertTrue(self.sets.is_equation("setC"))
+        self.assertFalse(self.sets.is_equation("setA"))
+        self.assertFalse(self.sets.is_equation("nonexistent"))
+
+    def test_equation_rejects_nonexistent_set(self):
+        with self.assertRaises(KeyError):
+            self.sets.define_and("setC", "nonexistent", "setB")
+        with self.assertRaises(KeyError):
+            self.sets.define_and("setC", "setA", "nonexistent")
+
+    def test_cannot_overwrite_non_equation_with_equation(self):
         with self.assertRaises(ValueError):
-            NMSets(name="test")  # no args for nmobjects_fxnref or nmobjects
+            self.sets["setA"] = ("and", "setA", "setB")
 
-        klist = []
-        for d in self.sets0_init:
-            klist.append(d["name"])
+    def test_cannot_add_to_equation(self):
+        self.sets.define_and("setC", "setA", "setB")
+        with self.assertRaises(ValueError):
+            self.sets.add("setC", "obj0")
 
-        self.assertEqual(self.sets0._parent, NM0)
-        self.assertEqual(self.sets0.name, SETS_NAME0)
-        self.assertEqual(list(self.sets0.keys()), klist)
-        self.assertEqual(list(self.sets0._nmobjects_dict.keys()), ONLIST0)
+    def test_cannot_remove_from_equation(self):
+        self.sets.define_and("setC", "setA", "setB")
+        with self.assertRaises(ValueError):
+            self.sets.remove("setC", "obj2")
 
-        self.assertEqual(self.sets0_copy._parent, NM0)
-        self.assertEqual(self.sets0_copy.name, SETS_NAME0)
-        self.assertEqual(list(self.sets0_copy.keys()), klist)
-        # Note: deepcopy creates empty nmobjects dict (by design)
-        # since nmobjects are external references that shouldn't be copied
 
-        for i, o in enumerate(self.olist0):
-            self.assertTrue(o == self.olist0_copy[i])
-            self.assertFalse(o is self.olist0_copy[i])
+class TestNMSetsTupleIsEquation(unittest.TestCase):
+    """Tests for tuple_is_equation static method."""
 
-        klist = []
-        for d in self.sets1_init:
-            klist.append(d["name"])
+    def test_valid_and_equation(self):
+        self.assertTrue(NMSets.tuple_is_equation(("and", "set1", "set2")))
 
-        self.assertEqual(self.sets1._parent, NM1)
-        self.assertEqual(self.sets1.name, SETS_NAME1)
-        self.assertEqual(list(self.sets1.keys()), klist)
-        self.assertEqual(list(self.sets1._nmobjects_dict.keys()), ONLIST1)
+    def test_valid_or_equation(self):
+        self.assertTrue(NMSets.tuple_is_equation(("or", "set1", "set2")))
 
-        self.assertEqual(self.sets1_copy._parent, NM1)
-        self.assertNotEqual(self.sets1_copy.name, "test")
-        self.assertEqual(list(self.sets1_copy.keys()), klist)
-        # Note: deepcopy creates empty nmobjects dict (by design)
+    def test_rejects_list(self):
+        self.assertFalse(NMSets.tuple_is_equation(["and", "set1", "set2"]))
 
-        for i, o in enumerate(self.olist1):
-            self.assertTrue(o == self.olist1_copy[i])
-            self.assertFalse(o is self.olist1_copy[i])
+    def test_rejects_wrong_length(self):
+        self.assertFalse(NMSets.tuple_is_equation(("and", "set1")))
+        self.assertFalse(NMSets.tuple_is_equation(("and", "set1", "set2", "extra")))
 
-    def test01_copy(self):
-        # Test copy() method using deepcopy
-        s0_copy = self.sets0.copy()
+    def test_rejects_invalid_operator(self):
+        self.assertFalse(NMSets.tuple_is_equation(("invalid", "set1", "set2")))
+        self.assertFalse(NMSets.tuple_is_equation(("&", "set1", "set2")))
+        self.assertFalse(NMSets.tuple_is_equation(("|", "set1", "set2")))
 
-        self.assertIsInstance(s0_copy, NMSets)
-        self.assertEqual(self.sets0._parent, s0_copy._parent)
-        self.assertEqual(self.sets0.name, s0_copy.name)
-        p0 = self.sets0.parameters
-        p = s0_copy.parameters
-        # Timestamps may be the same if test runs fast; just verify they exist
-        self.assertIsNotNone(p0.get("created"))
-        self.assertIsNotNone(p.get("created"))
-        self.assertEqual(list(self.sets0.keys()), list(s0_copy.keys()))
+    def test_rejects_non_string_sets(self):
+        self.assertFalse(NMSets.tuple_is_equation(("and", 123, "set2")))
+        self.assertFalse(NMSets.tuple_is_equation(("and", "set1", 456)))
 
-    def test02_parameters(self):
-        klist = ["name", "created", "copy of"]  # # NMObject
-        klist += ["sets"]
+    def test_rejects_non_tuple_types(self):
+        self.assertFalse(NMSets.tuple_is_equation(None))
+        self.assertFalse(NMSets.tuple_is_equation(123))
+        self.assertFalse(NMSets.tuple_is_equation("string"))
+        self.assertFalse(NMSets.tuple_is_equation({}))
 
-        klist2 = []
-        for d in self.sets0_init:
-            klist2.append(d["name"])
 
-        plist = self.sets0.parameters
-        self.assertEqual(list(plist.keys()), klist)
-        self.assertEqual(plist["sets"], klist2)
+class TestNMSetsEquationOperators(unittest.TestCase):
+    """Tests for EQUATION_OPERATORS constant."""
 
-        plist = self.sets0_copy.parameters
-        self.assertEqual(list(plist.keys()), klist)
-        self.assertEqual(plist["sets"], klist2)
+    def test_contains_and(self):
+        self.assertIn("and", EQUATION_OPERATORS)
 
-        klist2 = []
-        for d in self.sets1_init:
-            klist2.append(d["name"])
+    def test_contains_or(self):
+        self.assertIn("or", EQUATION_OPERATORS)
 
-        plist = self.sets1.parameters
-        self.assertEqual(plist["sets"], klist2)
+    def test_only_two_operators(self):
+        self.assertEqual(len(EQUATION_OPERATORS), 2)
 
-        plist = self.sets1_copy.parameters
-        self.assertEqual(plist["sets"], klist2)
 
-    def test03_getitem(self):
-        # args: key
-        # get(), items(), values() and '='
+class TestNMSetsCopy(NMSetsTestBase):
+    """Tests for copy functionality."""
 
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        bad.remove(None)  # ok (returns None)
-        for b in bad:
-            with self.assertRaises(TypeError):
-                olist = self.sets0.get(b)
-            with self.assertRaises(TypeError):
-                olist = self.sets0[b]
+    def test_deepcopy(self):
+        self.sets.add("set0", ["obj0", "obj1"])
+        sets_copy = copy.deepcopy(self.sets)
+        self.assertEqual(self.sets.name, sets_copy.name)
+        self.assertEqual(list(self.sets.keys()), list(sets_copy.keys()))
 
-        olist = self.sets0.get("test")
-        self.assertIsNone(olist)
-        olist = self.sets0.get("test", default="default")
-        self.assertEqual(olist, "default")
-        olist = self.sets0["test"]
-        self.assertIsNone(olist)
+    def test_copy_method(self):
+        self.sets.add("set0", ["obj0", "obj1"])
+        sets_copy = self.sets.copy()
+        self.assertEqual(self.sets.name, sets_copy.name)
+        self.assertEqual(list(self.sets.keys()), list(sets_copy.keys()))
 
-        for d in self.sets0_init:
-            sname = d["name"].upper()  # should be case-insensitive
-            nlist = d["nlist"]
-            olist = d["olist"]
-            eqlist = d["eqlist"]
-            olist_g = self.sets0.get(sname)
-            nlist_g = self.sets0.get(sname, get_keys=True)
-            self.assertEqual(olist, olist_g)
-            self.assertEqual(nlist, nlist_g)
-            olist_g = self.sets0[sname]  # '=' format
-            self.assertEqual(olist, olist_g)
-            if eqlist:
-                eqlist_g = self.sets0.get(sname, get_equation=True)
-                self.assertEqual(eqlist, eqlist_g)
-            else:
-                eqlist_g = self.sets0.get(sname, get_equation=True)
-                self.assertEqual(olist, eqlist_g)
-                eqlist_g = self.sets0.get(sname, default="test", get_equation=True)
-                self.assertEqual(olist, eqlist_g)
+    def test_deepcopy_equation(self):
+        self.sets.add("setA", ["obj0", "obj1"])
+        self.sets.add("setB", ["obj1", "obj2"])
+        self.sets.define_and("setC", "setA", "setB")
 
-        for d in self.sets1_init:
-            sname = d["name"].upper()  # should be case-insensitive
-            nlist = d["nlist"]
-            olist = d["olist"]
-            eqlist = d["eqlist"]
-            olist_g = self.sets1.get(sname)
-            nlist_g = self.sets1.get(sname, get_keys=True)
-            self.assertEqual(olist, olist_g)
-            self.assertEqual(nlist, nlist_g)
-            olist_g = self.sets1[sname]  # '=' format
-            self.assertEqual(olist, olist_g)
-            if eqlist:
-                eqlist_g = self.sets1.get(sname, get_equation=True)
-                self.assertEqual(eqlist, eqlist_g)
-            else:
-                eqlist_g = self.sets1.get(sname, get_equation=True)
-                self.assertEqual(olist, eqlist_g)
+        sets_copy = copy.deepcopy(self.sets)
 
-        # order of NMObjects matches order of self.odict0
-        self.sets0.add("set99", ONLIST0[3])  # add backwards
-        self.sets0.add("set99", ONLIST0[1])
-        self.sets0.add("set99", ONLIST0[5])
-        nlist = [ONLIST0[1], ONLIST0[3], ONLIST0[5]]
-        olist = [self.olist0[1], self.olist0[3], self.olist0[5]]
-        nlist2 = self.sets0.get("set99", get_keys=True)
-        olist2 = self.sets0.get("set99")
-        self.assertEqual(nlist, nlist2)
-        self.assertEqual(olist, olist2)
-        self.sets0.pop("set99")
+        # Check equation is preserved
+        self.assertTrue(sets_copy.is_equation("setC"))
+        eq = sets_copy.get("setC", get_equation=True)
+        self.assertEqual(eq, ("and", "setA", "setB"))
 
-        for i, (k, v) in enumerate(self.sets0.items()):
-            d = self.sets0_init[i]
-            sname = d["name"]
-            olist = d["olist"]
-            self.assertEqual(k, sname)
-            self.assertEqual(v, olist)
 
-        for i, (k, v) in enumerate(self.sets1.items()):
-            d = self.sets1_init[i]
-            sname = d["name"]
-            olist = d["olist"]
-            self.assertEqual(k, sname)
-            self.assertEqual(v, olist)
+class TestNMSetsRemove(NMSetsTestBase):
+    """Tests for remove operations."""
 
-        # keys() and values() should be same as items()
-        # no way to obtain set equation via items() or values()
+    def test_remove_by_name(self):
+        self.sets.add("set0", ["obj0", "obj1", "obj2"])
+        removed = self.sets.remove("set0", "obj1")
+        self.assertEqual(len(removed), 1)
+        self.assertNotIn("obj1", self.sets.get("set0", get_keys=True))
 
-    def xtest04_setitem(self):
-        # args: key, olist, add
-        # update(), add() and '='
-        # see test36_equation()
+    def test_remove_by_object(self):
+        self.sets.add("set0", ["obj0", "obj1", "obj2"])
+        removed = self.sets.remove("set0", self.objects["obj1"])
+        self.assertEqual(len(removed), 1)
 
-        d = self.sets0_init[0]
-        sname0 = d["name"].upper()  # should be case-insensitive
-        d = self.sets0_init[1]
-        sname1 = d["name"].upper()  # should be case-insensitive
+    def test_remove_nonexistent_raises(self):
+        self.sets.add("set0", ["obj0"])
+        with self.assertRaises(ValueError):
+            self.sets.remove("set0", "obj9")
 
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.add(b, "")
-            with self.assertRaises(TypeError):
-                self.sets0.update({b: ""})
-            with self.assertRaises(TypeError):
-                self.sets0[b] = ""
+    def test_remove_nonexistent_error_false(self):
+        self.sets.add("set0", ["obj0"])
+        result = self.sets.remove("set0", "obj9", error=False)
+        self.assertEqual(result, [])
 
-        bad = list(nmu.BADNAMES)
-        bad.remove("select")
-        for b in bad:
-            with self.assertRaises(ValueError):
-                self.sets0.add(b, "")
-            with self.assertRaises(ValueError):
-                self.sets0.update({b: ""})
-            with self.assertRaises(ValueError):
-                self.sets0[b] = ""
+    def test_remove_from_all(self):
+        self.sets.add("set0", ["obj0", "obj1"])
+        self.sets.add("set1", ["obj0", "obj2"])
+        self.sets.remove_from_all("obj0")
+        self.assertNotIn("obj0", self.sets.get("set0", get_keys=True))
+        self.assertNotIn("obj0", self.sets.get("set1", get_keys=True))
 
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        bad.remove([])  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.add(sname0, b)
-            with self.assertRaises(TypeError):
-                self.sets0.update(sname0, b)
-            with self.assertRaises(TypeError):
-                self.sets0[sname0] = b
 
-        with self.assertRaises(KeyError):
-            self.sets0.add(sname0, "test")  # test does not exist
-        with self.assertRaises(KeyError):
-            self.sets0.update({sname0: "test"})
-        with self.assertRaises(KeyError):
-            self.sets0[sname0] = "test"
+class TestNMSetsNew(NMSetsTestBase):
+    """Tests for new and duplicate operations."""
 
-        for o in self.olist0:  # ok to add nmobject multiple times
-            if o in self.sets0[sname0]:
-                self.sets0.add(sname0, o.name.upper())
-                break
+    def test_new_creates_empty_set(self):
+        key, olist = self.sets.new("newset")
+        self.assertEqual(key, "newset")
+        self.assertEqual(olist, [])
+        self.assertTrue("newset" in self.sets)
 
-        for o in self.olist0:  # name case-insensitive
-            if o not in self.sets0[sname0]:
-                self.sets0.add(sname0, o.name.upper())
-                self.assertTrue(o in self.sets0[sname0])
-                break
+    def test_new_auto_name(self):
+        key1, _ = self.sets.new()
+        key2, _ = self.sets.new()
+        self.assertEqual(key1, "set0")
+        self.assertEqual(key2, "set1")
 
-        for o in self.olist0:  # ok to add nmobject
-            if o not in self.sets0[sname0]:
-                self.sets0.add(sname0, o)
-                self.assertTrue(o in self.sets0[sname0])
-                break
-
-        nlist = [ONLIST0[0], ONLIST0[1], ONLIST0[2]]
-        self.sets0[sname0] = nlist  # replace with 3 items
-        self.assertEqual(len(self.sets0[sname0]), len(nlist))
-        self.sets0.add(sname0, ONLIST0[2])
-        self.assertEqual(len(self.sets0[sname0]), len(nlist))
-        self.sets0.add(sname0, ONLIST0[3])
-        self.assertEqual(len(self.sets0[sname0]), len(nlist) + 1)
-
-        self.sets0.update({sname0: ONLIST0[0], sname0: ONLIST0[1]})
-        # repeated key
-        self.assertEqual(len(self.sets0[sname0]), 1)
+    def test_duplicate(self):
+        self.sets.add("set0", ["obj0", "obj1"])
+        key, olist = self.sets.duplicate("set0", "set0_copy")
+        self.assertEqual(key, "set0_copy")
         self.assertEqual(
-            self.sets0.get(sname0, get_keys=True), [ONLIST0[1]]
-        )  # last item overwrites
-
-        self.sets0.update({sname0: ONLIST0[0], sname1: ONLIST0[1]})
-
-        # change NMObjects and dictionary
-
-        odict0 = {}  # NM object dict
-        for n in ONLIST0:
-            o = NMObject(parent=NM0, name=n)
-            odict0.update({n: o})  # different NMObject with same name
-            with self.assertRaises(ValueError):
-                self.sets0.add(sname0, o)
-
-        # now change reference of NMObject dict
-        self.sets0._NMSets__nmobjects = odict0
-        self.sets0[sname0] = []  # empty
-
-        for o in odict0.values():
-            self.sets0.add(sname0, o)  # ok now
-            self.assertTrue(o in self.sets0[sname0])
-
-        self.sets0[sname0] = []  # empty
-
-        for o in odict0.values():
-            self.sets0.add(sname0, [o, o])  # double objects ok
-            self.sets0.add(sname0, o)
-
-        d = self.sets1_init[-1]
-        sname1 = d["name"].upper()  # should be case-insensitive
-        eqlist1 = d["eqlist"]
-
-        self.assertTrue(NMSets.list_is_equation(eqlist1))
-
-        with self.assertRaises(ValueError):
-            self.sets1.add(sname1, "test")  # cannot add to an equation
-
-    def xtest05_delitem(self):
-        # args: key
-        # see pop()
-        for d in self.sets0_init:
-            sname = d["name"].upper()
-            print("\nanswer YES")
-            del self.sets0[sname]
-        self.assertEqual(len(self.sets0), 0)
-
-    def xtest06_iter(self):
-        s_iter = iter(self.sets0)
-        for d in self.sets0_init:
-            sname = d["name"]
-            s = next(s_iter)
-            self.assertEqual(s, sname)
-
-    def xtest07_len(self):
-        self.assertEqual(len(self.sets0), len(self.sets0_init))
-        self.assertEqual(len(self.sets1), len(self.sets1_init))
-
-    def xtest08_contains(self):
-        for d in self.sets0_init:
-            sname = d["name"]
-            self.assertTrue(sname in self.sets0)
-        self.assertFalse("test" in self.sets0)
-        for d in self.sets1_init:
-            sname = d["name"]
-            self.assertTrue(sname in self.sets1)
-        self.assertFalse("test" in self.sets1)
-
-    def xtest09_eq(self):
-        # args: other
-
-        bad = list(nmu.BADTYPES)
-        for b in bad:
-            self.assertFalse(self.sets0 == b)
-
-        self.assertTrue(self.sets0 is self.sets0)
-        self.assertFalse(self.sets0 is self.sets1)
-        self.assertTrue(self.sets0 == self.sets0)
-        self.assertFalse(self.sets0 == self.sets1)
-        self.assertFalse(self.sets0 != self.sets0)
-        self.assertTrue(self.sets0 != self.sets1)
-        self.assertTrue(self.sets0 == self.sets0_copy)
-        self.assertTrue(self.sets1 == self.sets1_copy)
-
-        # recreate self.sets0
-
-        odict0 = {}
-        for n in ONLIST0:
-            o = NMObject(parent=NM0, name=n)
-            odict0.update({n: o})
-
-        s0 = NMSets(parent=NM0, name=SETS_NAME0, nmobjects=odict0)
-
-        for d in self.sets0_init:
-            sname = d["name"]
-            olist = d["olist"]
-            for o in olist:
-                with self.assertRaises(ValueError):
-                    s0.add(sname, o)  # different objects
-                s0.add(sname, o.name)  # but name is ok
-
-        self.assertTrue(s0 == self.sets0)
-
-        # name
-        s0.name = SETS_NAME1
-        self.assertFalse(s0 == self.sets0)
-        s0.name = SETS_NAME0
-        self.assertTrue(s0 == self.sets0)
-
-        # NMObjects {}
-        # s0._NMSets__nmobjects = self.odict1
-        # self.assertTrue(s0 == self.sets0)  # nmobjects {} not compared
-        # s0._eq_list.append("nmobjects")
-        # self.assertFalse(s0 == self.sets0)  # nmobjects {} compared
-        # s0._NMSets__nmobjects = self.odict0
-        # self.assertTrue(s0 == self.sets0)
-
-        save_fxnref = s0._NMSets__nmobjects_fxnref
-        s0._NMSets__nmobjects = {}
-        s0._NMSets__nmobjects_fxnref = self._nmobjects_dict1
-        self.assertFalse(s0 == self.sets0)
-        s0._NMSets__nmobjects_fxnref = self._nmobjects_dict0
-        self.assertTrue(s0 == self.sets0)
-        s0._NMSets__nmobjects_fxnref = save_fxnref
-        s0._NMSets__nmobjects = odict0
-        self.assertTrue(s0 == self.sets0)
-
-        # add another NMObject to odict0
-        o = NMObject(parent=NM0, name="test")
-        odict0.update({"test": o})
-
-        self.assertFalse(s0 == self.sets0)
-        s0._eq_list.remove("nmobjects")
-        self.assertTrue(s0 == self.sets0)
-
-        # different object types but with same names
-
-        odict0 = {}
-        for n in ONLIST0:
-            o = NMObject2(parent=NM0, name=n)  # NMObject2
-            odict0.update({n: o})
-
-        s0 = NMSets(  # recreate self.sets0
-            parent=NM0, name=SETS_NAME0, nmobjects=odict0
+            self.sets.get("set0", get_keys=True),
+            self.sets.get("set0_copy", get_keys=True)
         )
 
-        for d in self.sets0_init:
-            sname = d["name"]
-            olist = d["olist"]
-            for o in olist:
-                s0.add(sname, o.name)
-
-        self.assertFalse(self.sets0 == s0)
-
-    def xtest10_keys(self):
-        klist1 = []
-        for d in self.sets0_init:
-            klist1.append(d["name"])
-        klist2 = list(self.sets0.keys())
-        self.assertEqual(klist1, klist2)
-        klist2 = list(self.sets0_copy.keys())
-        self.assertEqual(klist1, klist2)
-        klist1 = []
-        for d in self.sets1_init:
-            klist1.append(d["name"])
-        klist2 = list(self.sets1.keys())
-        self.assertEqual(klist1, klist2)
-        klist2 = list(self.sets1_copy.keys())
-        self.assertEqual(klist1, klist2)
-
-    def xtest11_items(self):
-        # see test03_getitem()
-        pass
-
-    def xtest12_values(self):
-        # see test03_getitem()
-        pass
-
-    def xtest13_get(self):
-        # see test03_getitem()
-        pass
-
-    def xtest14_pop(self):
-        # args: key
-
-        d = self.sets0_init[0]
-        sname0 = d["name"].upper()  # should be case-insensitive
-        olist0 = d["olist"]
-        d = self.sets0_init[1]
-        sname1 = d["name"].upper()  # should be case-insensitive
-        olist1 = d["olist"]
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.pop(b)
-
-        with self.assertRaises(KeyError):
-            self.sets0.pop("test")  # does not exist
-
-        self.assertTrue(sname0 in self.sets0)
-        olist = self.sets0.pop(sname0)
-        self.assertFalse(sname0 in self.sets0)
-        self.assertEqual(olist, olist0)
-        olist = self.sets0.get(sname0)
-        self.assertIsNone(olist)
-
-        olist = self.sets0.pop(sname1)
-        self.assertFalse(sname1 in self.sets0)
-        self.assertEqual(olist, olist1)
-        olist = self.sets0.get(sname1)
-        self.assertIsNone(olist)
-
-    def xtest15_popitem(self):
-        # pop last set
-
-        n_sets = len(self.sets0)
-        for i in range(n_sets):
-            j = -1 * (i + 1)
-
-            d = self.sets0_init[j]  # last item
-            sname = d["name"]
-            olist = d["olist"]
-
-            self.assertTrue(sname in self.sets0)
-
-            olist2 = self.sets0.popitem()
-            self.assertFalse(sname in self.sets0)
-            self.assertEqual(olist2, (sname, olist))  # tuple
-
-        self.assertEqual(len(self.sets0), 0)
-
-        n_sets = len(self.sets1)
-        for i in range(n_sets):
-            j = -1 * (i + 1)
-
-            d = self.sets1_init[j]  # last item
-            sname = d["name"]
-            olist = d["olist"]
-            eqlist = d["eqlist"]
-
-            self.assertTrue(sname in self.sets1)
-
-            olist2 = self.sets1.popitem()
-            self.assertFalse(sname in self.sets1)
-            if eqlist:
-                self.assertEqual(olist2, (sname, eqlist))  # tuple
-            else:
-                self.assertEqual(olist2, (sname, olist))  # tuple
-
-        self.assertEqual(len(self.sets1), 0)
-
-    def xtest16_clear(self):
-        self.sets0.clear()
-        for d in self.sets0_init:
-            sname = d["name"].upper()
-            self.assertFalse(sname in self.sets0)
-
-        self.sets1.clear()
-        for d in self.sets1_init:
-            sname = d["name"].upper()
-            self.assertFalse(sname in self.sets1)
-
-    def xtest17_update(self):
-        # see test04_setitem()
-        pass
-
-    def xtest18_setdefault(self):
-        # args: key, default
-        # see get() and __setitem__()
-        """
-        test = {'one': 1, 'two': 2, 'three': 3}
-        print(test)
-        print(test.get('one', 'missing'))
-        print(test.get('onex', 'missing'))  # does not add new element
-        print(test)
-        print(test.setdefault('one', 'missing'))
-        print(test.setdefault('onex', 'missing'))  # adds new element
-        print(test)
-        """
-        d = self.sets0_init[0]
-        sname = d["name"].upper()
-        olist = d["olist"]
-
-        olist2 = self.sets0.setdefault(sname)  # like get()
-        self.assertEqual(olist, olist2)
-
-        olist2 = self.sets0.setdefault("test")  # like get()
-        self.assertIsNone(olist2)
-        self.assertFalse("test" in self.sets0)
-
-        olist2 = self.sets0.setdefault("test", [])
-        self.assertEqual(olist2, [])
-        self.assertTrue("test" in self.sets0)
-        olist2 = self.sets0.get("test")
-        self.assertEqual(olist2, [])
-
-    def xtest19_getkey(self):
-        # args: key, error1, error2
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")
-        for b in bad:
-            with self.assertRaises(TypeError):
-                key = self.sets0._getkey(b)
-            key = self.sets0._getkey(b, error1=False)
-            self.assertIsNone(key)
-
-        bad = list(nmu.BADNAMES)
-        bad.remove("select")
-        for b in bad:
-            with self.assertRaises(KeyError):
-                key = self.sets0._getkey(b)
-            key = self.sets0._getkey(b, error2=False)
-            self.assertIsNone(key)
-
-        # test keys are case insensitive
-        for d in self.sets0_init:
-            sname = d["name"]
-            key = self.sets0._getkey(sname.upper())
-            self.assertEqual(key, sname)
-
-        sname1 = self.sets0._getkey("select")
-        sname2 = self.sets0._NMSets__select_key
-        self.assertEqual(sname1, sname2)
-
-    def xtest20_newkey(self):
-        # args: newkey
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")
-        for b in bad:
-            with self.assertRaises(TypeError):
-                key = self.sets0._newkey(b)
-
-        bad = list(nmu.BADNAMES)
-        for b in bad:
-            with self.assertRaises(ValueError):
-                key = self.sets0._newkey(b)
-
-        for d in self.sets0_init:
-            sname = d["name"].upper()
-            with self.assertRaises(KeyError):
-                key = self.sets0._newkey(sname)
-            with self.assertRaises(KeyError):
-                key = self.sets0._newkey(sname.upper())
-            key = self.sets0._newkey(sname + "x")
-            self.assertEqual(key, sname + "x")
-
-        # test key = None
-        nn = self.sets0.auto_name_next()
-        key = self.sets0._newkey(None)
-        self.assertEqual(key, nn)
-
-    def xtest21_namenext(self):
-        nn = self.sets0.auto_name_next()
-        n = len(self.sets0)
-        self.assertEqual(nn, SETS_PREFIX0 + str(n))
-        nn = self.sets0.add(None, [])
-        nn = self.sets0.auto_name_next()
-        self.assertEqual(nn, SETS_PREFIX0 + str(len(self.sets0)))
-        nn = self.sets0.auto_name_next(prefix="test")
-        self.assertEqual(nn, "test0")
-
-    def xtest22__getnmobjectkey(self):
-        # args: nmobject_key, error1, error2
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")
-        for b in bad:
-            with self.assertRaises(TypeError):
-                key = self.sets0._get_nmobject_key(b)
-            key = self.sets0._get_nmobject_key(b, error1=False)
-            self.assertIsNone(key)
-
-        bad = list(nmu.BADNAMES)
-        for b in bad:
-            with self.assertRaises(KeyError):
-                key = self.sets0._get_nmobject_key(b)
-            key = self.sets0._get_nmobject_key(b, error2=False)
-            self.assertIsNone(key)
-
-        # test keys are case insensitive
-        for o in self.olist0:
-            key = self.sets0._get_nmobject_key(o.name.upper())
-            self.assertEqual(key, o.name)
-
-    def xtest23_contains(self):
-        # args: key, olist
-
-        d = self.sets0_init[0]
-        sname = d["name"].upper()
-        nlist = d["nlist"]
-        olist = d["olist"]
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")
-        for b in bad:
-            self.assertFalse(self.sets0.contains(b, "test"))
-
-        self.assertFalse(self.sets0.contains(sname, "test"))
-
-        for n in nlist:
-            self.assertTrue(self.sets0.contains(sname, n.upper()))
-
-        for o in olist:
-            self.assertTrue(self.sets0.contains(sname, o))
-
-        d = self.sets1_init[0]
-        sname = d["name"].upper()
-        nlist = d["nlist"]
-        olist = d["olist"]
-
-        for n in nlist:
-            self.assertTrue(self.sets1.contains(sname, n.upper()))
-
-        for o in olist:
-            self.assertTrue(self.sets1.contains(sname, o))
-
-        d = self.sets1_init[-1]
-        sname = d["name"].upper()
-        nlist = d["nlist"]
-        olist = d["olist"]
-        eqlist = d["eqlist"]
-
-        self.assertTrue(NMSets.list_is_equation(eqlist))
-
-        for n in nlist:
-            self.assertTrue(self.sets1.contains(sname, n.upper()))
-
-        for o in olist:
-            self.assertTrue(self.sets1.contains(sname, o))
-
-    def xtest24_nmobject_keys_match_order(self):
-        # args: nmobject_keys
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")
-        bad.remove([])
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0._NMSets__match_to_nmobject_keys(b)
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0._NMSets__match_to_nmobject_keys([b])
-
-        with self.assertRaises(KeyError):
-            self.sets0._NMSets__match_to_nmobject_keys(["test"])
-
-        klist = list(self.sets0._nmobjects_dict.keys())
-
-        nlist0 = ONLIST0.copy()
-        nlist0.reverse()
-
-        with self.assertRaises(KeyError):  # wrong {}
-            nlist1 = self.sets1._NMSets__match_to_nmobject_keys(nlist0)
-
-        nlist1 = self.sets0._NMSets__match_to_nmobject_keys(nlist0)
-        self.assertEqual(nlist1, klist)
-
-    def xtest25_isequation(self):
-        # args: key
-
-        bad = list(nmu.BADTYPES)
-        bad.remove([])
-        for b in bad:
-            self.assertFalse(self.sets0.is_equation(b))
-
-        self.assertFalse(self.sets0.is_equation("test"))
-
-        for d in self.sets0_init:
-            sname = d["name"]
-            self.assertFalse(self.sets0.is_equation(sname))
-
-        for d in self.sets1_init:
-            sname = d["name"]
-            eqlist = d["eqlist"]
-            if eqlist:
-                self.assertTrue(self.sets1.is_equation(sname))
-            else:
-                self.assertFalse(self.sets1.is_equation(sname))
-
-    def xtest26_listisequation(self):
-        # args: equation
-        # ['&', '|', '-', '^']
-        # tests only string format, not whether sets exist
-
-        bad = list(nmu.BADTYPES)
-        bad.remove([])
-        for b in bad:
-            self.assertFalse(NMSets.list_is_equation(b))
-
-        self.assertFalse(NMSets.list_is_equation([]))
-        self.assertFalse(NMSets.list_is_equation(["set1", "+", "SET2"]))
-        self.assertFalse(NMSets.list_is_equation(["set1", "|", 222]))
-
-        self.assertFalse(NMSets.list_is_equation(["set1", "SET2", "|"]))
-        self.assertTrue(NMSets.list_is_equation(["set1", "|", "SET2"]))
-
-        self.assertFalse(NMSets.list_is_equation(["set1", "|", "SET2", "+", "set3"]))
-        self.assertTrue(NMSets.list_is_equation(["set1", "|", "SET2", "^", "set3"]))
-        self.assertFalse(
-            NMSets.list_is_equation(["set1", "|", "SET2", "^", "set3", "set4"])
+    def test_duplicate_equation(self):
+        self.sets.add("setA", ["obj0", "obj1"])
+        self.sets.add("setB", ["obj1", "obj2"])
+        self.sets.define_and("setC", "setA", "setB")
+        key, value = self.sets.duplicate("setC", "setC_copy")
+        self.assertEqual(key, "setC_copy")
+        # Should duplicate the equation, not the evaluated result
+        self.assertTrue(self.sets.is_equation("setC_copy"))
+        self.assertEqual(
+            self.sets.get("setC", get_equation=True),
+            self.sets.get("setC_copy", get_equation=True)
         )
-        self.assertTrue(NMSets.list_is_equation(["set1", "|", "SET2", "^", "S3", "&"]))
-
-    def xtest27_new(self):
-        # args: key
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.new(b)
-
-        bad = list(nmu.BADNAMES)
-        for b in bad:
-            with self.assertRaises(ValueError):
-                self.sets0.new(b)
-
-        for d in self.sets0_init:
-            with self.assertRaises(KeyError):
-                self.sets0.new(d["name"])
-
-        for d in self.sets1_init:
-            with self.assertRaises(KeyError):
-                self.sets1.new(d["name"])
-
-        klist0 = list(self.sets0.keys())
-        nn = self.sets0.auto_name_next()
-        rtuple = self.sets0.new()
-        newkey = rtuple[0]
-        new_olist = rtuple[1]
-        self.assertEqual(newkey, nn)
-        self.assertTrue(newkey in self.sets0)
-        klist0.append(newkey)
-        self.assertEqual(klist0, list(self.sets0.keys()))
-        olist = self.sets0.get(newkey)
-        self.assertEqual(olist, [])
-        self.assertEqual(new_olist, [])
-
-        self.sets0.add(newkey, [ONLIST0[0], ONLIST0[1]])
-        self.assertEqual(new_olist, [self.olist0[0], self.olist0[1]])
-        olist = self.sets0.get(newkey)
-        self.assertEqual(olist, [self.olist0[0], self.olist0[1]])
-
-        nn = self.sets1.auto_name_next()
-        rtuple = self.sets1.new()
-        newkey = rtuple[0]
-        self.assertEqual(newkey, nn)
-
-    def xtest28_duplicate(self):
-        # args: key, newkey
-
-        d = self.sets0_init[0]
-        sname0 = d["name"]
-        olist0 = d["olist"]
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.duplicate(b, "test")
-
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.duplicate(sname0, b)
-
-        bad = list(nmu.BADNAMES)
-        for b in bad:
-            with self.assertRaises(ValueError):
-                self.sets0.duplicate(sname0, b)
-
-        with self.assertRaises(KeyError):
-            self.sets0.duplicate(sname0, sname0)
-
-        klist0 = list(self.sets0.keys())
-        newkey = sname0 + "_c"
-        rtuple = self.sets0.duplicate(sname0, newkey)
-        newkey = rtuple[0]
-        new_olist = rtuple[1]
-        self.assertTrue(newkey in self.sets0)
-        self.assertEqual(self.sets0.get(sname0), olist0)
-        self.assertEqual(self.sets0.get(newkey), olist0)
-        self.assertEqual(new_olist, olist0)
-        klist0.append(newkey)
-        self.assertEqual(klist0, list(self.sets0.keys()))
-
-        # remove item from new set
-        # should not effect original set
-        new_olist.pop()
-        self.assertNotEqual(self.sets0.get(newkey), olist0)
-        self.assertEqual(self.sets0.get(sname0), olist0)
-
-        nn = self.sets0.auto_name_next()
-        rtuple = self.sets0.duplicate(sname0)  # default newkey
-        newkey = rtuple[0]
-        new_olist = rtuple[1]
-        self.assertEqual(newkey, nn)
-        self.assertTrue(nn in self.sets0)
-        self.assertEqual(self.sets0.get(nn), olist0)
-        self.assertEqual(new_olist, olist0)
-
-    def xtest29_rename(self):
-        # args: key, newkey
-
-        d = self.sets0_init[0]
-        sname0 = d["name"]
-        olist0 = d["olist"]
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.rename(b, "test")
-
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.rename(sname0, b)
-
-        bad = list(nmu.BADNAMES)
-        for b in bad:
-            with self.assertRaises(ValueError):
-                self.sets0.rename(sname0, b)
-
-        with self.assertRaises(KeyError):
-            self.sets0.rename(sname0, sname0)
-
-        newkey = sname0 + "_c"
-        rname = self.sets0.rename(sname0, newkey)
-        self.assertEqual(rname, newkey)
-        self.assertFalse(sname0 in self.sets0)
-        self.assertTrue(newkey in self.sets0)
-        self.assertEqual(self.sets0.get(newkey), olist0)
-
-        nn = self.sets1.auto_name_next()
-        rname = self.sets0.rename(newkey)  # default newkey
-        self.assertEqual(rname, nn)
-        self.assertFalse(newkey in self.sets0)
-        self.assertTrue(nn in self.sets0)
-        self.assertEqual(self.sets0.get(nn), olist0)
-
-    def xtest30_reorder(self):
-        # args: newkeyorder
-
-        bad = list(nmu.BADTYPES)
-        bad.remove([])  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.reorder(b)
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.reorder([b])
-
-        with self.assertRaises(KeyError):
-            self.sets0.reorder(["test1", "test2"])
-
-        klist0 = list(self.sets0.keys())
-        newkeyorder = klist0.copy()
-        newkeyorder.reverse()
-        self.sets0.reorder(newkeyorder)
-        klist0_new = list(self.sets0.keys())
-        self.assertEqual(klist0_new, newkeyorder)
-
-        # remove one key
-        klist1 = list(self.sets1.keys())
-        newkeyorder = klist1.copy()
-        newkeyorder.reverse()
-        newkeyorder.pop()
-        with self.assertRaises(KeyError):
-            self.sets1.reorder(newkeyorder)
-
-        # add extra key
-        nn = self.sets1.auto_name_next()
-        klist1 = list(self.sets1.keys())
-        newkeyorder = klist1.copy()
-        newkeyorder.append(nn)
-        with self.assertRaises(KeyError):
-            self.sets1.reorder(newkeyorder)
-
-    def xtest31_empty(self):
-        # args: key, confirm
-
-        d = self.sets0_init[0]
-        sname0 = d["name"]
-        olist0 = d["olist"]
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.empty(b)
-
-        with self.assertRaises(KeyError):
-            self.sets0.empty("test")
-
-        self.sets0.empty(sname0)
-        self.assertEqual(self.sets0.get(sname0), [])
-
-        d = self.sets1_init[-1]
-        sname1 = d["name"]
-
-        self.sets1.empty(sname1)
-        self.assertEqual(self.sets1.get(sname1), [])
-
-    def xtest32_emptyall(self):
-        self.sets0.empty_all()
-
-        for d in self.sets0_init:
-            sname = d["name"]
-            olist = d["olist"]
-            self.assertEqual(self.sets0.get(sname), [])
-
-    def xtest33_add(self):
-        # args: key, olist
-        # see __setitem__()
-        pass
-
-    def xtest34_remove(self):
-        # args: key, nmobject_keys
-
-        d = self.sets0_init[0]
-        sname0 = d["name"]
-        nlist0 = d["nlist"]
-        olist0 = d["olist"]
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.remove(b, "")
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        bad.remove([])
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.remove(sname0, b)
-
-        with self.assertRaises(KeyError):
-            self.sets0.remove("test", "")
-
-        with self.assertRaises(ValueError):
-            self.sets0.remove(sname0, "test")  # default error=True
-
-        olist = self.sets0.remove(sname0, "test", error=False)
-        self.assertEqual(olist, [])
-
-        self.assertTrue(self.sets0.contains(sname0, nlist0[0].lower()))
-        olist = self.sets0.remove(sname0, nlist0[0])
-        self.assertEqual(olist, [olist0[0]])
-        self.assertFalse(self.sets0.contains(sname0, nlist0[0].lower()))
-
-        self.assertTrue(self.sets0.contains(sname0, olist0[1]))
-        olist = self.sets0.remove(sname0, olist0[1])
-        self.assertEqual(olist, [olist0[1]])
-        self.assertFalse(self.sets0.contains(sname0, olist0[1]))
-
-        self.assertTrue(self.sets0.contains(sname0, olist0[2]))
-        self.assertTrue(self.sets0.contains(sname0, olist0[3]))
-        olist = self.sets0.remove(sname0, [nlist0[2], nlist0[3]])
-        self.assertEqual(olist, [olist0[2], olist0[3]])
-        self.assertFalse(self.sets0.contains(sname0, olist0[2]))
-        self.assertFalse(self.sets0.contains(sname0, olist0[3]))
-
-        d = self.sets1_init[-1]
-        sname1 = d["name"]
-        nlist1 = d["nlist"]
-        olist1 = d["olist"]
-        eqlist1 = d["eqlist"]
-
-        self.assertTrue(NMSets.list_is_equation(eqlist1))
-        self.assertTrue(self.sets1.contains(sname1, nlist1[0]))
-
-        with self.assertRaises(ValueError):
-            olist = self.sets1.remove(sname1, nlist1[0])
-
-        with self.assertRaises(ValueError):
-            olist = self.sets1.remove(sname1, olist1[0])
-
-    def xtest35_removefromall(self):
-        # args: nmobject_keys
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        bad.remove([])  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0.remove_from_all(b)
-
-        with self.assertRaises(ValueError):
-            self.sets0.remove_from_all("test", error=True)
-
-        self.sets0.remove_from_all("test")  # default error=False
-
-        nlist = [ONLIST0[0], ONLIST0[1], ONLIST0[2], ONLIST0[3]]
-
-        for d in self.sets0_init:
-            sname = d["name"]
-            self.sets0.add(sname, nlist)
-            self.assertTrue(self.sets0.contains(sname, nlist))
-
-        self.sets0.remove_from_all(nlist)
-
-        for d in self.sets0_init:
-            sname = d["name"]
-            self.assertFalse(self.sets0.contains(sname, nlist))
-
-        nlist = [ONLIST1[0], ONLIST1[1], ONLIST1[2], ONLIST1[3]]
-
-        for d in self.sets1_init:
-            sname = d["name"]
-            eqlist = d["eqlist"]
-            if not eqlist:
-                self.sets1.add(sname, nlist)
-                self.assertTrue(self.sets1.contains(sname, nlist))
-
-        self.sets1.remove_from_all(nlist)
-
-        for d in self.sets1_init:
-            sname = d["name"]
-            self.assertFalse(self.sets1.contains(sname, nlist))
-
-    def xtest36_select(self):
-        # args: key
-
-        bad = list(nmu.BADTYPES)
-        bad.remove("string")  # ok
-        bad.remove(None)  # ok
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.sets0._select_key_set(b)
-            self.assertFalse(self.sets0.is_select_key(b))
-
-        with self.assertRaises(KeyError):
-            self.sets0._select_key_set("SELECT")
-        self.assertFalse(self.sets0.is_select_key("SELECT"))
-
-        with self.assertRaises(KeyError):
-            self.sets0._select_key_set("test")
-        self.assertFalse(self.sets0.is_select_key("test"))
-
-        d = self.sets0_init[-1]
-        sname = d["name"]
-        nlist = d["nlist"]
-        olist = d["olist"]
-        eqlist = d["eqlist"]
-        self.assertEqual(sname, self.sets0.select_key)
-        self.assertTrue(self.sets0.is_select_key(sname))
-
-        olist2 = self.sets0.get("select")
-        self.assertEqual(olist, olist2)
-        nlist2 = self.sets0.get("select", get_keys=True)
-        self.assertEqual(nlist, nlist2)
-        eqlist2 = self.sets0.get("select", get_equation=True)
-        self.assertEqual(olist, eqlist2)
-
-        self.sets0.select_key = None
-        self.assertIsNone(self.sets0.select_key)
-        olist2 = self.sets0.get("select")
-        self.assertIsNone(olist2)
-        nlist2 = self.sets0.get("select", get_keys=True)
-        self.assertIsNone(nlist2)
-        eqlist2 = self.sets0.get("select", get_equation=True)
-        self.assertIsNone(eqlist2)
-        self.assertTrue(self.sets0.is_select_key(None))
-
-        self.sets0.select_key = sname
-        self.assertEqual(self.sets0.select_key, sname)
-        self.assertTrue(self.sets0.is_select_key(sname))
-
-        for i, n in enumerate(ONLIST0):
-            if n not in nlist:
-                o = self.olist0[i]
-                self.assertFalse(n in self.sets0.get(sname, get_keys=True))
-                self.assertFalse(n in self.sets0.get("select", get_keys=True))
-                self.assertFalse(o in self.sets0.get(sname))
-                self.assertFalse(o in self.sets0.get("select"))
-                self.sets0.add(sname, n)
-                self.assertFalse(n in nlist)
-                self.assertTrue(n in self.sets0.get(sname, get_keys=True))
-                self.assertTrue(n in self.sets0.get("select", get_keys=True))
-                self.assertTrue(o in self.sets0.get(sname))
-                self.assertTrue(o in self.sets0.get("select"))
-
-        d = self.sets1_init[-1]
-        sname = d["name"]
-        nlist = d["nlist"]
-        olist = d["olist"]
-        eqlist = d["eqlist"]
-        self.assertEqual(sname, self.sets1.select_key)
-        self.assertTrue(self.sets1.is_select_key(sname))
-
-        olist2 = self.sets1.get("select")
-        self.assertEqual(olist, olist2)
-        nlist2 = self.sets1.get("select", get_keys=True)
-        self.assertEqual(nlist, nlist2)
-        eqlist2 = self.sets1.get("select", get_equation=True)
-        self.assertEqual(eqlist, eqlist2)
-
-        self.sets1.pop(sname)
-        self.assertIsNone(self.sets1.select_key)
-
-    def xtest37_equation(self):
-        # args: key, eq_list
-        # see __setitem__()
-        # ['&', '|', '-', '^']
-
-        d = self.sets0_init[0]
-        sname0 = d["name"]
-
-        with self.assertRaises(TypeError):
-            self.sets0.add(sname0, [1, 2, "set1"])
-
-        s0 = set(self.sets0.get(sname0, get_keys=True))
-        d = self.sets0_init[1]
-        sname1 = d["name"]
-        s1 = set(self.sets0.get(sname1, get_keys=True))
-
-        self.assertFalse(self.sets0.is_equation(sname0.upper()))
-        self.assertFalse(self.sets0.is_equation(sname1.upper()))
-
-        nlist = [ONLIST0[0], ONLIST0[4], ONLIST0[7], ONLIST0[11]]
-        s2 = set(nlist)
-        sname2 = self.sets0.auto_name_next()
-        self.sets0.add(sname2, nlist)
-
-        sname3 = self.sets0.auto_name_next()
-        eqlist = [sname0, "%", sname1]
-        with self.assertRaises(KeyError):
-            self.sets0.update({sname3: eqlist})  # bad equation
-
-        eqlist = [sname0, "|", sname1]
-        with self.assertRaises(ValueError):
-            self.sets0.update({sname0: eqlist})  # already exists
-
-        self.assertFalse(sname3 in self.sets0)
-        self.sets0.update({sname3: eqlist})
-        self.assertTrue(sname3.upper() in self.sets0)
-        self.assertTrue(self.sets0.is_equation(sname3.upper()))
-        eqlist2 = self.sets0.get(sname3.upper(), get_equation=True)
-        self.assertEqual(eqlist, eqlist2)
-        s3 = set(self.sets0.get(sname3, get_keys=True))
-        self.assertEqual(s3, s0 | s1)
-        olist = self.sets0.get(sname3)
-        for o in olist:
-            self.assertTrue(o.name in s3)
-
-        self.sets0.update({sname3: eqlist})
-        self.sets0.empty(sname3)
-        self.assertEqual(self.sets0.get(sname3), [])
-
-        eqlist = [sname0, "&", sname1]
-        self.sets0.update({sname3: eqlist})
-        eqlist2 = self.sets0.get(sname3.upper(), get_equation=True)
-        self.assertEqual(eqlist, eqlist2)
-        s3 = set(self.sets0.get(sname3, get_keys=True))
-        self.assertEqual(s3, s0 & s1)
-        olist = self.sets0.get(sname3)
-        for o in olist:
-            self.assertTrue(o.name in s3)
-
-        eqlist = [sname0, "-", sname1]
-        self.sets0.update({sname3: eqlist})
-        eqlist2 = self.sets0.get(sname3.upper(), get_equation=True)
-        self.assertEqual(eqlist, eqlist2)
-        s3 = set(self.sets0.get(sname3, get_keys=True))
-        self.assertEqual(s3, s0 - s1)
-        olist = self.sets0.get(sname3)
-        for o in olist:
-            self.assertTrue(o.name in s3)
-
-        eqlist = [sname0, "^", sname1]
-        self.sets0.update({sname3: eqlist})
-        eqlist2 = self.sets0.get(sname3.upper(), get_equation=True)
-        self.assertEqual(eqlist, eqlist2)
-        s3 = set(self.sets0.get(sname3, get_keys=True))
-        self.assertEqual(s3, s0 ^ s1)
-        olist = self.sets0.get(sname3)
-        for o in olist:
-            self.assertTrue(o.name in s3)
-
-        eqlist = [sname0, "|", sname1, "^", sname2]
-        self.sets0.update({sname3: eqlist})
-        eqlist2 = self.sets0.get(sname3.upper(), get_equation=True)
-        self.assertEqual(eqlist, eqlist2)
-        s3 = set(self.sets0.get(sname3, get_keys=True))
-        self.assertEqual(s3, (s0 | s1) ^ s2)
-        olist = self.sets0.get(sname3)
-        for o in olist:
-            self.assertTrue(o.name in s3)
-
-        rtuple = self.sets0.duplicate(sname3)
-        sname4 = rtuple[0]
-        s4 = set(self.sets0.get(sname4, get_keys=True))
-        self.assertEqual(s3, s4)
-        eqlist2 = self.sets0.get(sname4, get_equation=True)
-        self.assertEqual(eqlist2, eqlist)
-        self.assertEqual(self.sets0.get(sname3), self.sets0.get(sname4))
+
+
+class TestNMSetsRename(NMSetsTestBase):
+    """Tests for rename and reorder operations."""
+
+    def test_rename(self):
+        self.sets.add("set0", ["obj0"])
+        self.sets.rename("set0", "renamed")
+        self.assertFalse("set0" in self.sets)
+        self.assertTrue("renamed" in self.sets)
+
+    def test_reorder(self):
+        self.sets.add("set0", [])
+        self.sets.add("set1", [])
+        self.sets.add("set2", [])
+        self.sets.reorder(["set2", "set1", "set0"])
+        keys = list(self.sets.keys())
+        self.assertEqual(keys, ["set2", "set1", "set0"])
+
+
+class TestNMSetsEmpty(NMSetsTestBase):
+    """Tests for empty operations."""
+
+    def test_empty(self):
+        self.sets.add("set0", ["obj0", "obj1"])
+        self.sets.empty("set0")
+        self.assertEqual(self.sets.get("set0"), [])
+
+    def test_empty_equation(self):
+        self.sets.add("setA", ["obj0", "obj1"])
+        self.sets.add("setB", ["obj1", "obj2"])
+        self.sets.define_and("setC", "setA", "setB")
+        self.assertTrue(self.sets.is_equation("setC"))
+        self.sets.empty("setC")
+        # After emptying, it should no longer be an equation
+        self.assertFalse(self.sets.is_equation("setC"))
+        self.assertEqual(self.sets.get("setC"), [])
+
+    def test_empty_all(self):
+        self.sets.add("set0", ["obj0"])
+        self.sets.add("set1", ["obj1"])
+        self.sets.empty_all()
+        self.assertEqual(self.sets.get("set0"), [])
+        self.assertEqual(self.sets.get("set1"), [])
+
+    def test_empty_all_with_equation(self):
+        self.sets.add("setA", ["obj0", "obj1"])
+        self.sets.add("setB", ["obj1", "obj2"])
+        self.sets.define_and("setC", "setA", "setB")
+        self.sets.empty_all()
+        self.assertEqual(self.sets.get("setA"), [])
+        self.assertEqual(self.sets.get("setB"), [])
+        self.assertEqual(self.sets.get("setC"), [])
+        self.assertFalse(self.sets.is_equation("setC"))
+
+
+class TestNMSetsEquality(NMSetsTestBase):
+    """Tests for equality comparison."""
+
+    def test_equal_empty_sets(self):
+        sets2 = NMSets(parent=self.nm, name="TestSets", nmobjects=self.objects)
+        self.assertEqual(self.sets, sets2)
+
+    def test_equal_with_items(self):
+        sets2 = NMSets(parent=self.nm, name="TestSets", nmobjects=self.objects)
+        self.sets.add("set0", ["obj0", "obj1"])
+        sets2.add("set0", ["obj0", "obj1"])
+        self.assertEqual(self.sets, sets2)
+
+    def test_not_equal_different_items(self):
+        sets2 = NMSets(parent=self.nm, name="TestSets", nmobjects=self.objects)
+        self.sets.add("set0", ["obj0"])
+        sets2.add("set0", ["obj1"])
+        self.assertNotEqual(self.sets, sets2)
+
+    def test_equal_with_equations(self):
+        sets2 = NMSets(parent=self.nm, name="TestSets", nmobjects=self.objects)
+        for s in [self.sets, sets2]:
+            s.add("setA", ["obj0", "obj1"])
+            s.add("setB", ["obj1", "obj2"])
+            s.define_and("setC", "setA", "setB")
+        self.assertEqual(self.sets, sets2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Refactors NMSets equation syntax from list format `['set1', '&', 'set2']` to tuple format `('and', 'set1', 'set2')` for cleaner, more explicit operator handling
- Adds `EQUATION_OPERATORS` constant (`"and"`, `"or"`) for easy extensibility to future operators (difference, symmetric_difference)
- Introduces `define_and()` and `define_or()` convenience methods for creating equation sets
- Fixes all MutableMapping override methods (`pop`, `popitem`, `empty`, `empty_all`, `duplicate`) to correctly handle tuple equations
- Completely rewrites test_nm_sets.py with 12 focused test classes (62 tests) matching test_nm_workspace.py style
- Issue #52 

## Test plan
- [ ] Run `python -m pytest tests/test_core/test_nm_sets.py -v` (62 tests)
- [ ] Run `python -m pytest tests/test_core/ -v` (475 tests)
- [ ] Verify equation sets evaluate dynamically when source sets change
- [ ] Verify `define_and()` and `define_or()` create correct equation tuples
- [ ] Verify MutableMapping methods handle both list and tuple values correctly

