### PR TITLE
refactor(dataseries): simplify NMDataSeries by removing dimension management

### DIFF
--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -267,7 +267,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.xdim.start = value
+                data.x.start = value
                 count += 1
         return count
 
@@ -291,7 +291,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.xdim.delta = value
+                data.x.delta = value
                 count += 1
         return count
 
@@ -315,7 +315,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.xdim.label = label
+                data.x.label = label
                 count += 1
         return count
 
@@ -339,7 +339,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.xdim.units = units
+                data.x.units = units
                 count += 1
         return count
 
@@ -363,7 +363,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.ydim.label = label
+                data.y.label = label
                 count += 1
         return count
 
@@ -387,7 +387,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.ydim.units = units
+                data.y.units = units
                 count += 1
         return count
 
@@ -411,11 +411,11 @@ class NMDataSeries(NMObject):
             starts: set = set()
             deltas: set = set()
             for data in channel.data:
-                if hasattr(data, 'xdim'):
-                    if data.xdim.start is not None:
-                        starts.add(data.xdim.start)
-                    if data.xdim.delta is not None:
-                        deltas.add(data.xdim.delta)
+                if hasattr(data, 'x'):
+                    if data.x.start is not None:
+                        starts.add(data.x.start)
+                    if data.x.delta is not None:
+                        deltas.add(data.x.delta)
             result[ch_name] = {
                 "start": starts,
                 "delta": deltas,
@@ -440,11 +440,11 @@ class NMDataSeries(NMObject):
             labels: set = set()
             units: set = set()
             for data in channel.data:
-                if hasattr(data, 'ydim'):
-                    if data.ydim.label:
-                        labels.add(data.ydim.label)
-                    if data.ydim.units:
-                        units.add(data.ydim.units)
+                if hasattr(data, 'y'):
+                    if data.y.label:
+                        labels.add(data.y.label)
+                    if data.y.units:
+                        units.add(data.y.units)
             result[ch_name] = {
                 "label": labels,
                 "units": units,

--- a/tests/test_core/test_nm_dataseries.py
+++ b/tests/test_core/test_nm_dataseries.py
@@ -1,96 +1,427 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-Created on Tue Aug  8 21:36:01 2023
+Tests for NMDataSeries and NMDataSeriesContainer.
 
-@author: jason
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
 """
+import copy
 import unittest
 
 from pyneuromatic.core.nm_channel import NMChannel, NMChannelContainer
-from pyneuromatic.core.nm_data import NMData, NMDataContainer
+from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_dataseries import NMDataSeries, NMDataSeriesContainer
 from pyneuromatic.core.nm_dimension import NMDimension, NMDimensionX
+from pyneuromatic.core.nm_epoch import NMEpoch, NMEpochContainer
 from pyneuromatic.core.nm_manager import NMManager
-import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
 
-NM = NMManager(quiet=True)
 
-YSCALE = [
-    {"label": "current", "units": "pA"},
-    {"label": "voltage", "units": "mV"},
-    {"label": "TTL1", "units": "V"},
-    {"label": "TTL2", "units": "V"},
-]
-XSCALE = {"label": "sample", "units": "#", "start": 0, "delta": 0.01}
+class NMDataSeriesTestBase(unittest.TestCase):
+    """Base class with common setUp for NMDataSeries tests."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=True)
+        self.ds = NMDataSeries(parent=self.nm, name="Record")
 
 
-class NMDataSeriesTest(unittest.TestCase):
-    def setUp(self):  # executed before each test
-        self.dataprefix = "data"
+class TestNMDataSeriesInit(NMDataSeriesTestBase):
+    """Tests for NMDataSeries initialization."""
 
-        xdim = NMDimensionX(NM, "x", scale=XSCALE)
+    def test_init_with_defaults(self):
+        ds = NMDataSeries()
+        self.assertEqual(ds.name, "NMDataSeries0")
+        self.assertIsInstance(ds.channels, NMChannelContainer)
+        self.assertIsInstance(ds.epochs, NMEpochContainer)
 
-        num_epochs = 10
-        num_chans = len(YSCALE)
+    def test_init_with_name(self):
+        ds = NMDataSeries(parent=self.nm, name="Record")
+        self.assertEqual(ds.name, "Record")
+        self.assertEqual(ds._parent, self.nm)
 
-        self.ds0 = NMDataSeries(parent=NM, name=self.dataprefix)
-
-        chanlist = []
-        for j in range(num_chans):
-            c = self.ds0.channels.new(yscale=YSCALE[j], xscale=XSCALE)
-            chanlist.append(c)
-
-        for i in range(num_epochs):
-            e = self.ds0.epochs.new()
-            for j in range(num_chans):
-                c = chanlist[j]
-                n = self.dataprefix + nmu.CHANNEL_CHARS[j] + str(i)
-                ydim = NMDimension(NM, "y", scale=YSCALE[j])
-                d = NMData(parent=NM, name=n, ydim=ydim, xdim=xdim)
-                e.data.append(d)
-                c.data.append(d)
-
-        self.ds0.channels.selected_name = "B"
-        self.ds0.epochs.selected_name = "E2"
-        print(self.ds0.get_selected(get_keys=True))
-
-        # create sets
-
-        for i in range(0, num_epochs, 2):
-            self.ds0.epochs.sets.add("set0", "E" + str(i))
-        for i in range(1, num_epochs, 2):
-            self.ds0.epochs.sets.add("set1", "E" + str(i))
-        self.ds0.epochs.sets.define_or("set2", "set0", "set1")
-
-        self.ds0.channels.sets.add("set0", "A")
-        self.ds0.channels.sets.add("set0", "B")
-        self.ds0.channels.sets.add("set1", "C")
-        self.ds0.channels.sets.add("set1", "D")
-        self.ds0.channels.sets.define_or("set2", "set0", "set1")
-
-    def test00_init(self):
+    def test_init_rejects_invalid_copy_arg(self):
         with self.assertRaises(TypeError):
-            NMDataSeries(copy=NM)
+            NMDataSeries(copy=self.nm)
 
-    def test01_eq(self):
-        pass
+    def test_channels_property(self):
+        self.assertIsInstance(self.ds.channels, NMChannelContainer)
 
-    def test02_copy(self):
-        pass
+    def test_epochs_property(self):
+        self.assertIsInstance(self.ds.epochs, NMEpochContainer)
 
-    def test03_parameters(self):
-        pass
 
-    def test04_content(self):
-        pass
+class TestNMDataSeriesEquality(NMDataSeriesTestBase):
+    """Tests for NMDataSeries equality comparison."""
 
-    def test05_channels(self):
-        pass
+    def test_equal_empty(self):
+        ds1 = NMDataSeries(parent=self.nm, name="Record")
+        ds2 = NMDataSeries(parent=self.nm, name="Record")
+        self.assertEqual(ds1, ds2)
 
-    def test06_epochs(self):
-        pass
+    def test_not_equal_different_name(self):
+        ds1 = NMDataSeries(parent=self.nm, name="Record")
+        ds2 = NMDataSeries(parent=self.nm, name="Avg")
+        self.assertNotEqual(ds1, ds2)
 
-    def test07_get_select(self):
-        pass
+    def test_not_equal_different_channels(self):
+        ds1 = NMDataSeries(parent=self.nm, name="Record")
+        ds2 = NMDataSeries(parent=self.nm, name="Record")
+        ds1.channels.new()  # Add channel to ds1
+        self.assertNotEqual(ds1, ds2)
+
+    def test_not_equal_different_epochs(self):
+        ds1 = NMDataSeries(parent=self.nm, name="Record")
+        ds2 = NMDataSeries(parent=self.nm, name="Record")
+        ds1.epochs.new()  # Add epoch to ds1
+        self.assertNotEqual(ds1, ds2)
+
+    def test_equal_with_same_channels_epochs(self):
+        ds1 = NMDataSeries(parent=self.nm, name="Record")
+        ds2 = NMDataSeries(parent=self.nm, name="Record")
+        ds1.channels.new()
+        ds1.epochs.new()
+        ds2.channels.new()
+        ds2.epochs.new()
+        self.assertEqual(ds1, ds2)
+
+    def test_not_equal_to_non_dataseries(self):
+        result = self.ds.__eq__("not a dataseries")
+        self.assertEqual(result, NotImplemented)
+
+
+class TestNMDataSeriesWithData(unittest.TestCase):
+    """Tests for NMDataSeries with actual data populated."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=True)
+        self.ds = NMDataSeries(parent=self.nm, name="Record")
+
+        # Create channels A and B
+        self.chan_a = self.ds.channels.new()
+        self.chan_b = self.ds.channels.new()
+
+        # Create epochs E0, E1, E2
+        self.epoch_0 = self.ds.epochs.new()
+        self.epoch_1 = self.ds.epochs.new()
+        self.epoch_2 = self.ds.epochs.new()
+
+        # Create data and link to channels/epochs
+        self.data = {}
+        for ch_name, channel in [("A", self.chan_a), ("B", self.chan_b)]:
+            for i, epoch in enumerate([self.epoch_0, self.epoch_1, self.epoch_2]):
+                name = f"Record{ch_name}{i}"
+                d = NMData(parent=self.nm, name=name)
+                self.data[name] = d
+                channel.data.append(d)
+                epoch.data.append(d)
+
+        # Select channel B, epoch E1
+        self.ds.channels.selected_name = "B"
+        self.ds.epochs.selected_name = "E1"
+
+    def test_get_selected_returns_data(self):
+        result = self.ds.get_selected()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "RecordB1")
+
+    def test_get_selected_with_keys(self):
+        result = self.ds.get_selected(get_keys=True)
+        self.assertEqual(result, ["RecordB1"])
+
+    def test_get_selected_no_channel_selected(self):
+        self.ds.channels.selected_name = None
+        result = self.ds.get_selected()
+        self.assertEqual(result, [])
+
+    def test_get_selected_no_epoch_selected(self):
+        self.ds.epochs.selected_name = None
+        result = self.ds.get_selected()
+        self.assertEqual(result, [])
+
+    def test_get_data_with_explicit_channel_epoch(self):
+        result = self.ds.get_data(channel="A", epoch="E2")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, "RecordA2")
+
+    def test_get_data_uses_selected_when_none(self):
+        result = self.ds.get_data()
+        self.assertIsNotNone(result)
+        self.assertEqual(result.name, "RecordB1")
+
+    def test_get_data_invalid_channel(self):
+        result = self.ds.get_data(channel="Z", epoch="E0")
+        self.assertIsNone(result)
+
+    def test_get_data_invalid_epoch(self):
+        result = self.ds.get_data(channel="A", epoch="E99")
+        self.assertIsNone(result)
+
+
+class TestNMDataSeriesBulkDimensions(unittest.TestCase):
+    """Tests for bulk dimension setting methods."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=True)
+        self.ds = NMDataSeries(parent=self.nm, name="Record")
+
+        # Create channels with data that has dimensions
+        self.chan_a = self.ds.channels.new()
+        self.chan_b = self.ds.channels.new()
+
+        xscale = {"start": 0, "delta": 0.01, "label": "time", "units": "ms"}
+        yscale_a = {"label": "current", "units": "pA"}
+        yscale_b = {"label": "voltage", "units": "mV"}
+
+        # Create data with dimensions
+        for i in range(3):
+            xdim = NMDimensionX(parent=self.nm, name="x", scale=xscale)
+            ydim_a = NMDimension(parent=self.nm, name="y", scale=yscale_a)
+            d_a = NMData(parent=self.nm, name=f"RecordA{i}", xdim=xdim, ydim=ydim_a)
+            self.chan_a.data.append(d_a)
+
+            xdim = NMDimensionX(parent=self.nm, name="x", scale=xscale)
+            ydim_b = NMDimension(parent=self.nm, name="y", scale=yscale_b)
+            d_b = NMData(parent=self.nm, name=f"RecordB{i}", xdim=xdim, ydim=ydim_b)
+            self.chan_b.data.append(d_b)
+
+    def test_set_xstart_all_channels(self):
+        count = self.ds.set_xstart(0.5)
+        self.assertEqual(count, 6)  # 3 data per channel * 2 channels
+        for d in self.chan_a.data:
+            self.assertEqual(d.x.start, 0.5)
+        for d in self.chan_b.data:
+            self.assertEqual(d.x.start, 0.5)
+
+    def test_set_xstart_single_channel(self):
+        count = self.ds.set_xstart(0.5, channel="A")
+        self.assertEqual(count, 3)
+        for d in self.chan_a.data:
+            self.assertEqual(d.x.start, 0.5)
+        # Channel B unchanged
+        for d in self.chan_b.data:
+            self.assertEqual(d.x.start, 0)
+
+    def test_set_xdelta_all_channels(self):
+        count = self.ds.set_xdelta(0.02)
+        self.assertEqual(count, 6)
+        for d in self.chan_a.data:
+            self.assertEqual(d.x.delta, 0.02)
+
+    def test_set_xlabel_all_channels(self):
+        count = self.ds.set_xlabel("Time")
+        self.assertEqual(count, 6)
+        for d in self.chan_a.data:
+            self.assertEqual(d.x.label, "Time")
+
+    def test_set_xunits_single_channel(self):
+        count = self.ds.set_xunits("s", channel="B")
+        self.assertEqual(count, 3)
+        for d in self.chan_b.data:
+            self.assertEqual(d.x.units, "s")
+        # Channel A unchanged
+        for d in self.chan_a.data:
+            self.assertEqual(d.x.units, "ms")
+
+    def test_set_ylabel_single_channel(self):
+        count = self.ds.set_ylabel("Current", channel="A")
+        self.assertEqual(count, 3)
+        for d in self.chan_a.data:
+            self.assertEqual(d.y.label, "Current")
+
+    def test_set_yunits_all_channels(self):
+        count = self.ds.set_yunits("nA")
+        self.assertEqual(count, 6)
+        for d in self.chan_a.data:
+            self.assertEqual(d.y.units, "nA")
+
+    def test_set_xstart_invalid_channel(self):
+        with self.assertRaises(KeyError):
+            self.ds.set_xstart(0.5, channel="Z")
+
+    def test_set_xstart_rejects_non_number(self):
+        with self.assertRaises(TypeError):
+            self.ds.set_xstart("invalid")
+
+    def test_set_xlabel_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            self.ds.set_xlabel(123)
+
+
+class TestNMDataSeriesScalesSummary(unittest.TestCase):
+    """Tests for scale summary diagnostic methods."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=True)
+        self.ds = NMDataSeries(parent=self.nm, name="Record")
+
+        self.chan_a = self.ds.channels.new()
+        self.chan_b = self.ds.channels.new()
+
+        # Create data with uniform scales for channel A
+        for i in range(3):
+            xdim = NMDimensionX(parent=self.nm, name="x", scale={"start": 0, "delta": 0.01})
+            ydim = NMDimension(parent=self.nm, name="y", scale={"label": "current", "units": "pA"})
+            d = NMData(parent=self.nm, name=f"RecordA{i}", xdim=xdim, ydim=ydim)
+            self.chan_a.data.append(d)
+
+        # Create data with non-uniform scales for channel B
+        for i in range(3):
+            xdim = NMDimensionX(parent=self.nm, name="x", scale={"start": i * 0.1, "delta": 0.01 + i * 0.001})
+            ydim = NMDimension(parent=self.nm, name="y", scale={"label": "voltage", "units": "mV"})
+            d = NMData(parent=self.nm, name=f"RecordB{i}", xdim=xdim, ydim=ydim)
+            self.chan_b.data.append(d)
+
+    def test_get_xscales_summary_uniform(self):
+        summary = self.ds.get_xscales_summary()
+        self.assertIn("A", summary)
+        self.assertTrue(summary["A"]["uniform"])
+        self.assertEqual(summary["A"]["start"], {0})
+        self.assertEqual(summary["A"]["delta"], {0.01})
+
+    def test_get_xscales_summary_non_uniform(self):
+        summary = self.ds.get_xscales_summary()
+        self.assertIn("B", summary)
+        self.assertFalse(summary["B"]["uniform"])
+        self.assertEqual(len(summary["B"]["start"]), 3)  # 3 different values
+        self.assertEqual(len(summary["B"]["delta"]), 3)
+
+    def test_get_yscales_summary(self):
+        summary = self.ds.get_yscales_summary()
+        self.assertIn("A", summary)
+        self.assertEqual(summary["A"]["label"], {"current"})
+        self.assertEqual(summary["A"]["units"], {"pA"})
+        self.assertIn("B", summary)
+        self.assertEqual(summary["B"]["label"], {"voltage"})
+        self.assertEqual(summary["B"]["units"], {"mV"})
+
+
+class TestNMDataSeriesDeepCopy(unittest.TestCase):
+    """Tests for NMDataSeries deep copy."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=True)
+        self.ds = NMDataSeries(parent=self.nm, name="Record")
+        self.ds.channels.new()
+        self.ds.epochs.new()
+
+    def test_deepcopy_creates_new_instance(self):
+        ds_copy = copy.deepcopy(self.ds)
+        self.assertIsNot(ds_copy, self.ds)
+
+    def test_deepcopy_preserves_name(self):
+        ds_copy = copy.deepcopy(self.ds)
+        self.assertEqual(ds_copy.name, self.ds.name)
+
+    def test_deepcopy_creates_new_containers(self):
+        ds_copy = copy.deepcopy(self.ds)
+        self.assertIsNot(ds_copy.channels, self.ds.channels)
+        self.assertIsNot(ds_copy.epochs, self.ds.epochs)
+
+    def test_deepcopy_preserves_channel_count(self):
+        ds_copy = copy.deepcopy(self.ds)
+        self.assertEqual(len(ds_copy.channels), len(self.ds.channels))
+
+    def test_deepcopy_preserves_epoch_count(self):
+        ds_copy = copy.deepcopy(self.ds)
+        self.assertEqual(len(ds_copy.epochs), len(self.ds.epochs))
+
+    def test_deepcopy_sets_copy_of(self):
+        ds_copy = copy.deepcopy(self.ds)
+        self.assertIs(ds_copy._NMObject__copy_of, self.ds)
+
+
+class TestNMDataSeriesContent(NMDataSeriesTestBase):
+    """Tests for NMDataSeries content and parameters."""
+
+    def test_content_includes_channels(self):
+        self.ds.channels.new()
+        content = self.ds.content
+        self.assertIn("nmchannelcontainer", content)
+
+    def test_content_includes_epochs(self):
+        self.ds.epochs.new()
+        content = self.ds.content
+        self.assertIn("nmepochcontainer", content)
+
+    def test_parameters_returns_dict(self):
+        params = self.ds.parameters
+        self.assertIsInstance(params, dict)
+
+
+class TestNMDataSeriesContainer(unittest.TestCase):
+    """Tests for NMDataSeriesContainer."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=True)
+        self.container = NMDataSeriesContainer(parent=self.nm)
+
+    def test_content_type(self):
+        self.assertEqual(self.container.content_type(), "NMDataSeries")
+
+    def test_new_creates_dataseries(self):
+        ds = self.container.new(name="Record")
+        self.assertIsInstance(ds, NMDataSeries)
+        self.assertEqual(ds.name, "Record")
+
+    def test_new_with_select(self):
+        ds = self.container.new(name="Record", select=True)
+        self.assertEqual(self.container.selected_name, "Record")
+
+    def test_new_sets_correct_parent(self):
+        # Parent should be container's parent (NMManager), not container itself
+        ds = self.container.new(name="Record")
+        self.assertEqual(ds._parent, self.nm)
+
+    def test_duplicate_raises_error(self):
+        with self.assertRaises(RuntimeError):
+            self.container.duplicate()
+
+    def test_multiple_dataseries(self):
+        ds1 = self.container.new(name="Record")
+        ds2 = self.container.new(name="Avg")
+        self.assertEqual(len(self.container), 2)
+        self.assertIn("Record", self.container)
+        self.assertIn("Avg", self.container)
+
+
+class TestNMDataSeriesSets(unittest.TestCase):
+    """Tests for NMDataSeries with channel and epoch sets."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=True)
+        self.ds = NMDataSeries(parent=self.nm, name="Record")
+
+        # Create channels A, B, C, D
+        for _ in range(4):
+            self.ds.channels.new()
+
+        # Create epochs E0-E9
+        for _ in range(10):
+            self.ds.epochs.new()
+
+    def test_channel_sets(self):
+        self.ds.channels.sets.add("set0", ["A", "B"])
+        self.ds.channels.sets.add("set1", ["C", "D"])
+        self.ds.channels.sets.define_or("set2", "set0", "set1")
+
+        result = self.ds.channels.sets.get("set2", get_keys=True)
+        self.assertEqual(set(result), {"A", "B", "C", "D"})
+
+    def test_epoch_sets(self):
+        # Even epochs
+        for i in range(0, 10, 2):
+            self.ds.epochs.sets.add("even", f"E{i}")
+        # Odd epochs
+        for i in range(1, 10, 2):
+            self.ds.epochs.sets.add("odd", f"E{i}")
+
+        even_result = self.ds.epochs.sets.get("even", get_keys=True)
+        self.assertEqual(len(even_result), 5)
+
+        odd_result = self.ds.epochs.sets.get("odd", get_keys=True)
+        self.assertEqual(len(odd_result), 5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Remove dimension properties from NMDataSeries (NMData is source of truth for dimensions)
- Add bulk utility methods for setting dimension properties across multiple data objects
- Add `get_data()` convenience method for retrieving data at channel/epoch intersection
- Fix hasattr checks in scale summary methods (`xdim`/`ydim` → `x`/`y`)
- Rewrite tests to match focused test class pattern (test_nm_workspace.py style)
- Issue #54 

## Test plan
- [x] Verify all 49 tests pass in test_nm_dataseries.py
- [x] Verify bulk dimension methods work for single and all channels
- [x] Verify scale summary methods return correct data
- [x] Verify deepcopy preserves channels and epochs

