### PR TITLE
Add make_dataseries to create dataseries from data naming patterns (#56)

### DIFF
--- a/pyneuromatic/core/nm_utilities.py
+++ b/pyneuromatic/core/nm_utilities.py
@@ -502,6 +502,65 @@ def channel_char_search(
     return -1
 
 
+def parse_data_name(
+    name: str,
+    char_list: tuple[str] = CHANNEL_CHARS
+) -> tuple[str, str, int] | None:
+    """Parse a data name into prefix, channel, and epoch.
+
+    Parses from the end of the string to detect the NeuroMatic naming pattern:
+    {prefix}{channel}{epoch} where channel is a single uppercase letter and
+    epoch is a sequence of digits.
+
+    Args:
+        name: Data name like "RecordA0", "avgB12", "WaveC100".
+        char_list: Valid channel characters (default: A-Z).
+
+    Returns:
+        Tuple of (prefix, channel_char, epoch_num) if pattern found,
+        or None if name doesn't match the pattern.
+
+    Examples:
+        >>> parse_data_name("RecordA0")
+        ('Record', 'A', 0)
+        >>> parse_data_name("avgB12")
+        ('avg', 'B', 12)
+        >>> parse_data_name("nopattern")
+        None
+    """
+    if not name or not isinstance(name, str):
+        return None
+
+    # Find trailing digits (epoch) - parse from end
+    i = len(name) - 1
+    while i >= 0 and name[i].isdigit():
+        i -= 1
+
+    # Must have at least one trailing digit
+    if i == len(name) - 1:
+        return None
+
+    epoch_str = name[i + 1:]
+    epoch_num = int(epoch_str)
+
+    # Check for channel character (single uppercase letter from char_list)
+    if i < 0:
+        return None
+
+    potential_channel = name[i].upper()
+    if potential_channel not in char_list:
+        return None
+
+    channel_char = potential_channel
+    prefix = name[:i]
+
+    # Prefix cannot be empty
+    if not prefix:
+        return None
+
+    return (prefix, channel_char, epoch_num)
+
+
 def type_error_str(
     obj: object, 
     obj_name: str, 

--- a/tests/test_core/test_nm_utilities.py
+++ b/tests/test_core/test_nm_utilities.py
@@ -325,5 +325,64 @@ class NMUtilitiesTest(unittest.TestCase):
     """
 
 
+class TestParseDataName(unittest.TestCase):
+    """Tests for nmu.parse_data_name() utility function."""
+
+    def test_standard_name(self):
+        result = nmu.parse_data_name("RecordA0")
+        self.assertEqual(result, ("Record", "A", 0))
+
+    def test_multi_digit_epoch(self):
+        result = nmu.parse_data_name("RecordB123")
+        self.assertEqual(result, ("Record", "B", 123))
+
+    def test_lowercase_prefix(self):
+        result = nmu.parse_data_name("avgC5")
+        self.assertEqual(result, ("avg", "C", 5))
+
+    def test_long_prefix(self):
+        result = nmu.parse_data_name("MyLongPrefixD99")
+        self.assertEqual(result, ("MyLongPrefix", "D", 99))
+
+    def test_no_trailing_digits(self):
+        result = nmu.parse_data_name("RecordA")
+        self.assertIsNone(result)
+
+    def test_no_channel_char(self):
+        # "test_123" has underscore before digits, not a channel letter
+        result = nmu.parse_data_name("test_123")
+        self.assertIsNone(result)
+
+    def test_record123_parses_d_as_channel(self):
+        # "Record123" actually has "D" as channel (Recor-D-123)
+        result = nmu.parse_data_name("Record123")
+        self.assertEqual(result, ("Recor", "D", 123))
+
+    def test_empty_prefix(self):
+        result = nmu.parse_data_name("A0")
+        self.assertIsNone(result)
+
+    def test_empty_string(self):
+        result = nmu.parse_data_name("")
+        self.assertIsNone(result)
+
+    def test_none_input(self):
+        result = nmu.parse_data_name(None)
+        self.assertIsNone(result)
+
+    def test_only_digits(self):
+        result = nmu.parse_data_name("12345")
+        self.assertIsNone(result)
+
+    def test_channel_z(self):
+        result = nmu.parse_data_name("WaveZ42")
+        self.assertEqual(result, ("Wave", "Z", 42))
+
+    def test_lowercase_channel_normalized(self):
+        # Channel should be uppercase in result
+        result = nmu.parse_data_name("Recorda0")
+        self.assertEqual(result, ("Record", "A", 0))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Add `NMFolder.make_dataseries()` to automatically create NMDataSeries from existing data by parsing NeuroMatic naming patterns (`{prefix}{channel}{epoch}`)
- Add `NMFolder.detect_prefixes()` to find unique prefixes in data names
- Add `nmu.parse_data_name()` utility to parse data names into prefix/channel/epoch components
- Issue #56 

## Features
- Supports partial prefix matching (e.g., "Rec" matches "RecordA0")
- Case-insensitive prefix matching
- Automatically creates channels (A, B, C...) and epochs (E0, E1...) and links data

## Test plan
- [x] TestParseDataName: 13 tests for name parsing edge cases
- [x] TestDetectPrefixes: 4 tests for prefix detection
- [x] TestMakeDataSeries: 14 tests for dataseries creation
- [x] TestMakeDataSeriesMultiplePrefixes: 2 tests for multiple prefixes
- [x] All 69 tests pass in test_nm_folder.py
