### PR TITLE
Replace __rename_fxnref function pointer with _container reference for NMObject renaming

### DIFF
--- a/pyneuromatic/analysis/nm_tool_folder.py
+++ b/pyneuromatic/analysis/nm_tool_folder.py
@@ -91,7 +91,7 @@ class NMToolFolder(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__rename_fxnref = result._name_set
+        result._container = None
         result._NMObject__copy_of = self
 
         # Now handle NMToolFolder's special attributes

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -390,7 +390,7 @@ class NMStatsWin(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__rename_fxnref = result._name_set
+        result._container = None
         result._NMObject__copy_of = self
 
         return result

--- a/pyneuromatic/core/nm_channel.py
+++ b/pyneuromatic/core/nm_channel.py
@@ -133,7 +133,7 @@ class NMChannel(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__rename_fxnref = result._name_set
+        result._container = None
         result._NMObject__copy_of = self
 
         # __thedata: copy list of references

--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -166,7 +166,7 @@ class NMData(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__rename_fxnref = result._name_set
+        result._container = None
         result._NMObject__copy_of = self
 
         # Now handle NMData's special attributes

--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -130,7 +130,7 @@ class NMDataSeries(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__rename_fxnref = result._name_set
+        result._container = None
         result._NMObject__copy_of = self
 
         # Now handle NMDataSeries's special attributes

--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -127,7 +127,7 @@ class NMEpoch(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__rename_fxnref = result._name_set
+        result._container = None
         result._NMObject__copy_of = self
 
         # Now handle NMEpoch's special attributes

--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -130,7 +130,7 @@ class NMFolder(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__rename_fxnref = result._name_set
+        result._container = None
         result._NMObject__copy_of = self
 
         # Now handle NMFolder's special attributes

--- a/pyneuromatic/core/nm_project.py
+++ b/pyneuromatic/core/nm_project.py
@@ -100,7 +100,7 @@ class NMProject(NMObject):
         result._NMObject__created = datetime.datetime.now().isoformat(" ", "seconds")
         result._NMObject__parent = self._NMObject__parent
         result._NMObject__name = self._NMObject__name
-        result._NMObject__rename_fxnref = result._name_set
+        result._container = None
         result._NMObject__copy_of = self
 
         # Now handle NMProject's special attributes

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -375,15 +375,13 @@ class TestNMObjectContainerSetItem(NMObjectContainerTestBase):
         self.assertFalse(o1 is self.olist0[1])
         self.assertTrue(o1 is o2)
 
-    def test_updates_rename_fxnref(self):
+    def test_updates_container_ref(self):
         n = ONLIST0[1]
         o2 = NMObject(parent=NM0, name=n)
-        rfr_before = o2._NMObject__rename_fxnref
+        self.assertIsNone(o2._container)
         self.map0[n.upper()] = o2
         o1 = self.map0.get(n)
-        rfr_after = o1._NMObject__rename_fxnref
-        self.assertNotEqual(rfr_before, rfr_after)
-        self.assertEqual(rfr_after, self.map0.rename)
+        self.assertIs(o1._container, self.map0)
 
     def test_length_unchanged_when_replacing(self):
         n = ONLIST0[1]
@@ -642,14 +640,12 @@ class TestNMObjectContainerUpdate(NMObjectContainerTestBase):
         self.map0.update(o1)
         self.assertEqual(len(self.map0), len(ONLIST0) + 1)
 
-    def test_update_sets_rename_fxnref(self):
+    def test_update_sets_container_ref(self):
         n1 = "test_new"
         o1 = NMObject(parent=NM0, name=n1)
-        rfr_before = o1._NMObject__rename_fxnref
+        self.assertIsNone(o1._container)
         self.map0.update(o1)
-        rfr_after = o1._NMObject__rename_fxnref
-        self.assertNotEqual(rfr_before, rfr_after)
-        self.assertEqual(rfr_after, self.map0.rename)
+        self.assertIs(o1._container, self.map0)
 
     def test_update_replaces_same_name(self):
         n1 = "test"


### PR DESCRIPTION
## Summary
- Replace the `__rename_fxnref` strategy pattern with a simple `_container` attribute on NMObject
- NMObject's `name` setter now checks `_container` to dispatch between standalone `_name_set()` and `container.rename()`
- Remove the dummy `name_notused` parameter from `_name_set()` that existed only to match the function pointer signature
- Remove `_rename_fxnref_set()` method and `import types` no longer needed
- Simplify `__deepcopy__` in 10 classes — each now sets `_container = None` instead of resetting a bound method reference
- Reset `_container = None` on `pop()` and `clear()` so removed objects revert to standalone renaming
- Issue #67 

## Motivation
The `__rename_fxnref` pattern stored a bound method reference that swapped between `_name_set` and `container.rename`. This added complexity across 12 files: every `__deepcopy__` had to reset the function pointer, `_name_set` needed a dummy parameter to match signatures, and bound methods required special handling in `_DEEPCOPY_SPECIAL_ATTRS`. A direct `_container` reference achieves the same dispatch with less indirection.

## Test plan
- [x] All 720 existing tests pass
- [x] New tests verify `_container` dispatch: standalone rename, mock container dispatch, container reset on removal
