### PR TITLE
Extract NMNotes class for reusable notes in NMFolder and NMData

### DIFF
--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -26,6 +26,7 @@ import numpy
 from pyneuromatic.core.nm_channel import NMChannel
 from pyneuromatic.core.nm_dataseries import NMDataSeries, NMDataSeriesContainer
 from pyneuromatic.core.nm_epoch import NMEpoch
+from pyneuromatic.core.nm_notes import NMNotes
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
 import pyneuromatic.core.nm_preferences as nmp
@@ -118,6 +119,8 @@ class NMData(NMObject):
             e = nmu.type_error_str(yscale, "yscale", "dictionary")
             raise TypeError(e)
 
+        self.__notes = NMNotes()
+
         self._dataseries_set(dataseries_channel, dataseries_epoch)
 
     # override
@@ -141,6 +144,8 @@ class NMData(NMObject):
         if self._dataseries_channel != other._dataseries_channel:
             return False
         if self._dataseries_epoch != other._dataseries_epoch:
+            return False
+        if self.__notes != other.__notes:
             return False
 
         return True
@@ -234,6 +239,11 @@ class NMData(NMObject):
         else:
             k.update({"dataseries epoch": None})
         return k
+
+    @property
+    def notes(self) -> NMNotes:
+        """Return notes for this data."""
+        return self.__notes
 
     # =========================================================================
     # Data array properties

--- a/pyneuromatic/core/nm_notes.py
+++ b/pyneuromatic/core/nm_notes.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+"""
+NMNotes module.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import datetime
+
+
+class NMNotes:
+    """Timestamped append-only notes.
+
+    Each note is stored as a dict with 'date' (ISO timestamp) and 'note' (text).
+    Used by NMFolder (session notes) and NMData (transformation logs).
+    """
+
+    def __init__(self) -> None:
+        self._entries: list[dict] = []
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, NMNotes):
+            return NotImplemented
+        return self._entries == other._entries
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def __getitem__(self, index):
+        return self._entries[index]
+
+    @property
+    def note(self) -> str:
+        """Return the text of the most recent note, or empty string if none."""
+        if self._entries:
+            return self._entries[-1].get("note", "")
+        return ""
+
+    @note.setter
+    def note(self, text: str) -> None:
+        """Add a new note with the given text."""
+        self.add(text)
+
+    def add(self, text: str) -> None:
+        """Add a timestamped note.
+
+        :param text: The note text to add
+        :type text: str
+        """
+        if text is None:
+            return
+        if not isinstance(text, str):
+            text = str(text)
+        entry = {
+            "date": datetime.datetime.now().isoformat(" ", "seconds"),
+            "note": text,
+        }
+        self._entries.append(entry)
+
+    def clear(self) -> None:
+        """Clear all notes."""
+        self._entries = []
+
+    def print_all(self) -> None:
+        """Print all notes to stdout."""
+        for n in self._entries:
+            date = n.get("date", "")
+            text = n.get("note", "")
+            print(f"{date}  {text}")
+
+    @staticmethod
+    def ok(notes: list[dict]) -> bool:
+        """Validate notes format.
+
+        :param notes: List of note dicts to validate
+        :type notes: list[dict]
+        :return: True if format is valid
+        :rtype: bool
+        """
+        if not isinstance(notes, list):
+            return False
+        for n in notes:
+            if not isinstance(n, dict):
+                return False
+            keys = n.keys()
+            if len(keys) != 2 or "date" not in keys or "note" not in keys:
+                return False
+            if not isinstance(n["date"], str) or not isinstance(n["note"], str):
+                return False
+        return True

--- a/tests/test_core/test_nm_data.py
+++ b/tests/test_core/test_nm_data.py
@@ -12,6 +12,7 @@ import unittest
 from pyneuromatic.core.nm_data import NMData, NMDataContainer
 from pyneuromatic.core.nm_dataseries import NMDataSeries
 from pyneuromatic.core.nm_manager import NMManager
+from pyneuromatic.core.nm_notes import NMNotes
 import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
 
@@ -212,6 +213,44 @@ class NMDataTest(unittest.TestCase):
         self.assertFalse(c0_copy == c0)
         c0.sets.add("set0", dnlist0[0])
         self.assertTrue(c0_copy == c0)
+
+class TestNMDataNotes(unittest.TestCase):
+    """Tests for NMData notes integration with NMNotes."""
+
+    def setUp(self):
+        self.d0 = NMData(
+            parent=NM, name=DNAME0, nparray=NPARRAY0,
+            xscale=XSCALE0, yscale=YSCALE0
+        )
+
+    def test_notes_returns_nmnotes(self):
+        self.assertIsInstance(self.d0.notes, NMNotes)
+
+    def test_notes_initially_empty(self):
+        self.assertEqual(len(self.d0.notes), 0)
+
+    def test_notes_add(self):
+        self.d0.notes.add("filtered with 1kHz lowpass")
+        self.d0.notes.add("baseline subtracted")
+        self.assertEqual(len(self.d0.notes), 2)
+        self.assertEqual(self.d0.notes[0].get("note"), "filtered with 1kHz lowpass")
+
+    def test_notes_affect_equality(self):
+        c = copy.deepcopy(self.d0)
+        self.assertTrue(c == self.d0)
+        c.notes.add("transformed")
+        self.assertFalse(c == self.d0)
+
+    def test_deepcopy_preserves_notes(self):
+        self.d0.notes.add("test note")
+        c = copy.deepcopy(self.d0)
+        self.assertEqual(len(c.notes), 1)
+        self.assertEqual(c.notes[0].get("note"), "test note")
+        # Verify independence
+        c.notes.add("new note")
+        self.assertEqual(len(self.d0.notes), 1)
+        self.assertEqual(len(c.notes), 2)
+
 
     """
     def _test_data(self):

--- a/tests/test_core/test_nm_folder.py
+++ b/tests/test_core/test_nm_folder.py
@@ -12,6 +12,7 @@ import unittest
 from pyneuromatic.core.nm_data import NMDataContainer
 from pyneuromatic.core.nm_dataseries import NMDataSeriesContainer
 from pyneuromatic.core.nm_folder import NMFolder, NMFolderContainer
+from pyneuromatic.core.nm_notes import NMNotes
 from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.core.nm_project import NMProject
 import pyneuromatic.core.nm_utilities as nmu
@@ -105,69 +106,25 @@ class TestNMFolderEquality(NMFolderTestBase):
 
 
 class TestNMFolderNotes(NMFolderTestBase):
-    """Tests for NMFolder notes functionality."""
+    """Tests for NMFolder notes integration with NMNotes."""
+
+    def test_notes_returns_nmnotes(self):
+        self.assertIsInstance(self.folder.notes, NMNotes)
 
     def test_notes_initially_empty(self):
-        self.assertIsInstance(self.folder.notes, list)
         self.assertEqual(len(self.folder.notes), 0)
 
-    def test_note_getter_empty(self):
-        self.assertEqual(self.folder.note, "")
-
-    def test_note_setter(self):
-        self.folder.note = "added TTX"
-        self.assertEqual(len(self.folder.notes), 1)
-        self.assertEqual(self.folder.notes[0].get("note"), "added TTX")
-
-    def test_note_add(self):
-        self.folder.note_add("first note")
-        self.folder.note_add("second note")
+    def test_notes_add(self):
+        self.folder.notes.add("first note")
+        self.folder.notes.add("second note")
         self.assertEqual(len(self.folder.notes), 2)
         self.assertEqual(self.folder.notes[0].get("note"), "first note")
-        self.assertEqual(self.folder.notes[1].get("note"), "second note")
-
-    def test_note_getter_returns_last(self):
-        self.folder.note_add("first")
-        self.folder.note_add("last")
-        self.assertEqual(self.folder.note, "last")
-
-    def test_notes_have_timestamps(self):
-        self.folder.note_add("test note")
-        self.assertIn("date", self.folder.notes[0])
-
-    def test_notes_clear(self):
-        self.folder.note_add("note1")
-        self.folder.note_add("note2")
-        self.folder.notes_clear()
-        self.assertEqual(len(self.folder.notes), 0)
-        self.assertEqual(self.folder.note, "")
-
-    def test_notes_ok_valid(self):
-        self.assertTrue(NMFolder.notes_ok([{"note": "hey", "date": "111"}]))
-        self.assertTrue(NMFolder.notes_ok([{"date": "111", "note": "hey"}]))
-
-    def test_notes_ok_invalid_keys(self):
-        self.assertFalse(NMFolder.notes_ok([{"n": "hey", "date": "111"}]))
-        self.assertFalse(NMFolder.notes_ok([{"note": "hey", "d": "111"}]))
-
-    def test_notes_ok_invalid_values(self):
-        self.assertFalse(NMFolder.notes_ok([{"note": "hey", "date": None}]))
-        self.assertTrue(NMFolder.notes_ok([{"note": "hey", "date": "None"}]))
-
-    def test_notes_ok_missing_keys(self):
-        self.assertFalse(NMFolder.notes_ok([{"note": "hey"}]))
-        self.assertFalse(NMFolder.notes_ok([{"date": "111"}]))
-
-    def test_notes_ok_extra_keys(self):
-        self.assertFalse(
-            NMFolder.notes_ok([{"note": "hey", "date": "111", "more": "1"}])
-        )
 
     def test_notes_affect_equality(self):
-        self.folder.note_add("test note")
+        self.folder.notes.add("test note")
         c = self.folder.copy()
         self.assertTrue(c == self.folder)
-        c.note_add("another note")
+        c.notes.add("another note")
         self.assertFalse(c == self.folder)
 
 
@@ -211,7 +168,7 @@ class TestNMFolderDeepCopy(NMFolderTestBase):
         super().setUp()
         for i in range(3):
             self.folder.data.new(f"data{i}")
-        self.folder.note_add("test note")
+        self.folder.notes.add("test note")
 
     def test_deepcopy_creates_new_instance(self):
         c = copy.deepcopy(self.folder)

--- a/tests/test_core/test_nm_notes.py
+++ b/tests/test_core/test_nm_notes.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+import copy
+import unittest
+
+from pyneuromatic.core.nm_notes import NMNotes
+
+
+class TestNMNotes(unittest.TestCase):
+    """Tests for NMNotes class."""
+
+    def setUp(self):
+        self.notes = NMNotes()
+
+    def test_initially_empty(self):
+        self.assertIsInstance(self.notes, NMNotes)
+        self.assertEqual(len(self.notes), 0)
+
+    def test_note_getter_empty(self):
+        self.assertEqual(self.notes.note, "")
+
+    def test_add(self):
+        self.notes.add("first note")
+        self.notes.add("second note")
+        self.assertEqual(len(self.notes), 2)
+        self.assertEqual(self.notes[0].get("note"), "first note")
+        self.assertEqual(self.notes[1].get("note"), "second note")
+
+    def test_note_getter_returns_last(self):
+        self.notes.add("first")
+        self.notes.add("last")
+        self.assertEqual(self.notes.note, "last")
+
+    def test_note_setter(self):
+        self.notes.note = "added TTX"
+        self.assertEqual(len(self.notes), 1)
+        self.assertEqual(self.notes[0].get("note"), "added TTX")
+
+    def test_timestamps(self):
+        self.notes.add("test note")
+        self.assertIn("date", self.notes[0])
+        self.assertIsInstance(self.notes[0]["date"], str)
+
+    def test_clear(self):
+        self.notes.add("note1")
+        self.notes.add("note2")
+        self.notes.clear()
+        self.assertEqual(len(self.notes), 0)
+        self.assertEqual(self.notes.note, "")
+
+    def test_add_none_ignored(self):
+        self.notes.add(None)
+        self.assertEqual(len(self.notes), 0)
+
+    def test_add_non_string_converted(self):
+        self.notes.add(42)
+        self.assertEqual(len(self.notes), 1)
+        self.assertEqual(self.notes[0].get("note"), "42")
+
+    def test_len(self):
+        self.assertEqual(len(self.notes), 0)
+        self.notes.add("a")
+        self.assertEqual(len(self.notes), 1)
+        self.notes.add("b")
+        self.assertEqual(len(self.notes), 2)
+
+    def test_iter(self):
+        self.notes.add("a")
+        self.notes.add("b")
+        texts = [n.get("note") for n in self.notes]
+        self.assertEqual(texts, ["a", "b"])
+
+    def test_getitem(self):
+        self.notes.add("first")
+        self.notes.add("second")
+        self.assertEqual(self.notes[0].get("note"), "first")
+        self.assertEqual(self.notes[1].get("note"), "second")
+        self.assertEqual(self.notes[-1].get("note"), "second")
+
+    def test_ok_valid(self):
+        self.assertTrue(NMNotes.ok([{"note": "hey", "date": "111"}]))
+        self.assertTrue(NMNotes.ok([{"date": "111", "note": "hey"}]))
+        self.assertFalse(NMNotes.ok(None))
+        self.assertFalse(NMNotes.ok([{"note": 123, "date": "111"}]))
+
+    def test_ok_empty_list(self):
+        self.assertTrue(NMNotes.ok([]))
+
+    def test_ok_invalid_keys(self):
+        self.assertFalse(NMNotes.ok([{"n": "hey", "date": "111"}]))
+        self.assertFalse(NMNotes.ok([{"note": "hey", "d": "111"}]))
+
+    def test_ok_invalid_values(self):
+        self.assertFalse(NMNotes.ok([{"note": "hey", "date": None}]))
+        self.assertTrue(NMNotes.ok([{"note": "hey", "date": "None"}]))
+
+    def test_ok_missing_keys(self):
+        self.assertFalse(NMNotes.ok([{"note": "hey"}]))
+        self.assertFalse(NMNotes.ok([{"date": "111"}]))
+
+    def test_ok_extra_keys(self):
+        self.assertFalse(
+            NMNotes.ok([{"note": "hey", "date": "111", "more": "1"}])
+        )
+
+    def test_ok_not_list(self):
+        self.assertFalse(NMNotes.ok("not a list"))
+        self.assertFalse(NMNotes.ok({"note": "hey", "date": "111"}))
+
+    def test_equality(self):
+        other = NMNotes()
+        self.assertEqual(self.notes, other)
+        self.notes.add("test")
+        self.assertNotEqual(self.notes, other)
+
+    def test_equality_after_deepcopy(self):
+        self.notes.add("test")
+        copied = copy.deepcopy(self.notes)
+        self.assertEqual(self.notes, copied)
+
+    def test_equality_not_nmnotes(self):
+        self.assertNotEqual(self.notes, "not NMNotes")
+        self.assertNotEqual(self.notes, [])
+
+    def test_deepcopy(self):
+        self.notes.add("original note")
+        copied = copy.deepcopy(self.notes)
+        self.assertEqual(len(copied), 1)
+        self.assertEqual(copied[0].get("note"), "original note")
+        # Verify independence
+        copied.add("new note")
+        self.assertEqual(len(self.notes), 1)
+        self.assertEqual(len(copied), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Create standalone `NMNotes` class in `nm_notes.py` — lightweight wrapper around `list[dict]` with `add()`, `clear()`, `print_all()`, `ok()`, `note` property, and support for `len`/iteration/indexing/equality/deepcopy
- Refactor `NMFolder` to use `NMNotes` via composition, replacing ~70 lines of inline notes code
- Add `notes` property to `NMData` so analysis functions can record transformation parameters (e.g., filter settings, baseline subtraction)
- API change: `folder.note_add("x")` → `folder.notes.add("x")`, `folder.note` → `folder.notes.note`, `folder.notes_clear()` → `folder.notes.clear()`
- Issue #69 

## Test plan
- [x] 23 unit tests for NMNotes class (`test_nm_notes.py`)
- [x] 4 integration tests for NMFolder notes delegation (`test_nm_folder.py`)
- [x] 5 integration tests for NMData notes (`test_nm_data.py`)
- [x] All 739 tests pass