### PR TITLE
Add history logging to NMSets mutations

### DIFF
--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -182,6 +182,7 @@ class NMObjectContainer(NMObject, MutableMapping):
 
         self.__sets = NMSets(
             name="NMObjectContainerSets",
+            parent=self,
             nmobjects_fxnref=self._get_map,
         )
 
@@ -440,6 +441,7 @@ class NMObjectContainer(NMObject, MutableMapping):
             self._NMObjectContainer__sets, memo
         )
         result._NMObjectContainer__sets._resolve_fxn = result._get_map
+        result._NMObjectContainer__sets._parent = result
 
         return result
 


### PR DESCRIPTION
## Summary

- Add _parent reference and path_str property to NMSets for history path resolution
- Log all 11 mutation methods: new, add, remove, pop, clear, rename, duplicate, reorder, empty, define_and, define_or
- Pass parent=self from NMObjectContainer to NMSets and restore it in __deepcopy__
- Skip logging for no-op cases (empty clear, same-order reorder)
- Delegate methods (popitem, remove_from_all, empty_all, etc.) rely on inner calls to avoid double-logging
- Issue #73 

## Test plan

- 14 new history tests in TestNMSetsHistory verify each method logs the expected message
- 3 new TestNMSetsPathStr tests verify path resolution with/without parent and after deepcopy
- All 769 existing tests pass