### PR TITLE
Add history logging to NMObjectContainer.update()

### DIFF
--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -508,7 +508,8 @@ class NMObjectContainer(NMObject, MutableMapping):
     # add/update NMObject to map
     def update(  # type: ignore[override]
         self,
-        nmobjects: NMObject | list[NMObject] | dict[str, NMObject] | NMObjectContainer | None = None
+        nmobjects: NMObject | list[NMObject] | dict[str, NMObject] | NMObjectContainer | None = None,
+        quiet: bool = nmp.QUIET,
     ) -> None:
         olist: list[NMObject]
         if nmobjects is None:
@@ -543,20 +544,23 @@ class NMObjectContainer(NMObject, MutableMapping):
             )
             e = nmu.type_error_str(nmobjects, "nmobjects", e)
             raise TypeError(e)
-        update = False
+        updated: list[str] = []
         for o in olist:
             if self.content_type_ok(o):
                 key = self._getkey(o.name)
                 if key is None:
                     key = self._newkey(o.name)
                 self.__map[key] = o
-                update = True
+                updated.append(key)
             else:
                 e = "nmobjects: list item"
                 e = nmu.type_error_str(o, e, self.content_type())
                 raise TypeError(e)
-        if update:
+        if updated:
             self.__update_nmobject_references()
+            nmh.history(
+                "updated %s" % updated, path=self.path_str, quiet=quiet
+            )
 
     def __update_nmobject_references(self):
         for o in self.__map.values():

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -1301,6 +1301,26 @@ class TestNMObjectContainerHistory(unittest.TestCase):
         self.assertIn("0", msg)
         self.assertIn("A", msg)
 
+    def test_update_logs(self):
+        o = NMObject(parent=self.nm, name="itemX")
+        self.container.update(o, quiet=False)
+        msg = self._last_message()
+        self.assertIn("updated", msg)
+        self.assertIn("itemX", msg)
+
+    def test_update_multiple_logs(self):
+        objs = [NMObject(parent=self.nm, name="a%d" % i) for i in range(3)]
+        self.container.update(objs, quiet=False)
+        msg = self._last_message()
+        self.assertIn("updated", msg)
+        self.assertIn("a0", msg)
+        self.assertIn("a1", msg)
+        self.assertIn("a2", msg)
+
+    def test_update_none_no_log(self):
+        self.container.update(None, quiet=False)
+        self.assertEqual(len(self.nm.history.buffer), 0)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Add quiet parameter and nmh.history() call to update(), logging names of added/updated items
- Skip logging when no items are updated (e.g. update(None))
- Delegates (__setitem__, setdefault) log through update() — no double-logging

## Test plan

- 3 new tests: single object, multiple objects, None no-op
- All 772 existing tests pass

Closes #75 