### PR TITLE
Add NMScaleX/NMScaleY wrapper classes for xscale/yscale metadata

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -1772,8 +1772,8 @@ def stats(
     # results["func"] = f
     results["data"] = data.path_str
 
-    xunits = data.xscale.get("units")
-    yunits = data.yscale.get("units")
+    xunits = data.xscale.units
+    yunits = data.yscale.units
 
     i0 = data.get_xindex(x0, clip=xclip)
     i1 = data.get_xindex(x1, clip=xclip)
@@ -1818,7 +1818,7 @@ def stats(
         if found_xarray:
             xarray = data.xarray
         else:
-            xstart = data.xscale.get("start")
+            xstart = data.xscale.start
     else:  # slice
         yarray = data.nparray[i0:i1+1]
         if found_xarray:
@@ -1860,7 +1860,7 @@ def stats(
         i = int(index) + int(i0)  # shift due to slicing
         results["i"] = i
         results["x"] = data.get_xvalue(i)
-        results["xunits"] = data.xscale.get("units")
+        results["xunits"] = data.xscale.units
 
         imean = 0
 
@@ -1908,7 +1908,7 @@ def stats(
             )
         else:
             xstart_val = xstart if isinstance(xstart, float) else 0.0
-            xdelta_val = data.xscale.get("delta") if isinstance(data.xscale.get("delta"), float) else 1.0
+            xdelta_val = float(data.xscale.delta)
             i_x = find_level_crossings(
                             yarray,
                             ylevel,
@@ -1943,7 +1943,7 @@ def stats(
             )
         else:
             xstart_val = xstart if isinstance(xstart, float) else 0.0
-            xdelta_val = data.xscale.get("delta") if isinstance(data.xscale.get("delta"), float) else 1.0
+            xdelta_val = float(data.xscale.delta)
             mb = linear_regression(
                             yarray,
                             xstart=xstart_val,
@@ -2043,7 +2043,7 @@ def stats(
             dy2 = np.square(np.diff(yarray))
             h = np.sqrt(np.add(dx2, dy2))
         else:
-            dx = data.xscale.get("delta") if isinstance(data.xscale.get("delta"), float) else 1.0
+            dx = float(data.xscale.delta)
             dx2 = dx**2
             dy2 = np.square(np.diff(yarray))
             h = np.sqrt(dx2 + dy2)
@@ -2067,7 +2067,7 @@ def stats(
                 sum_y = np.nansum(yarray)
             else:
                 sum_y = np.sum(yarray)
-            results["s"] = sum_y * data.xscale.get("delta")
+            results["s"] = sum_y * data.xscale.delta
         if isinstance(xunits, str) and isinstance(yunits, str):
             if xunits == yunits:
                 results["sunits"] = xunits + "**2"

--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -270,7 +270,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.xscale["start"] = value
+                data.xscale._set_start(value, quiet=True)
                 count += 1
         if count > 0:
             ch_str = channel if channel else "all"
@@ -302,7 +302,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.xscale["delta"] = value
+                data.xscale._set_delta(value, quiet=True)
                 count += 1
         if count > 0:
             ch_str = channel if channel else "all"
@@ -334,7 +334,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.xscale["label"] = label
+                data.xscale._set_label(label, quiet=True)
                 count += 1
         if count > 0:
             ch_str = channel if channel else "all"
@@ -366,7 +366,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.xscale["units"] = units
+                data.xscale._set_units(units, quiet=True)
                 count += 1
         if count > 0:
             ch_str = channel if channel else "all"
@@ -398,7 +398,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.yscale["label"] = label
+                data.yscale._set_label(label, quiet=True)
                 count += 1
         if count > 0:
             ch_str = channel if channel else "all"
@@ -430,7 +430,7 @@ class NMDataSeries(NMObject):
         count = 0
         for ch in self._iter_channels(channel):
             for data in ch.data:
-                data.yscale["units"] = units
+                data.yscale._set_units(units, quiet=True)
                 count += 1
         if count > 0:
             ch_str = channel if channel else "all"
@@ -461,11 +461,8 @@ class NMDataSeries(NMObject):
             starts: set = set()
             deltas: set = set()
             for data in channel.data:
-                xscale = data.xscale
-                if xscale.get("start") is not None:
-                    starts.add(xscale["start"])
-                if xscale.get("delta") is not None:
-                    deltas.add(xscale["delta"])
+                starts.add(data.xscale.start)
+                deltas.add(data.xscale.delta)
             result[ch_name] = {
                 "start": starts,
                 "delta": deltas,
@@ -490,11 +487,10 @@ class NMDataSeries(NMObject):
             labels: set = set()
             units: set = set()
             for data in channel.data:
-                yscale = data.yscale
-                if yscale.get("label"):
-                    labels.add(yscale["label"])
-                if yscale.get("units"):
-                    units.add(yscale["units"])
+                if data.yscale.label:
+                    labels.add(data.yscale.label)
+                if data.yscale.units:
+                    units.add(data.yscale.units)
             result[ch_name] = {
                 "label": labels,
                 "units": units,

--- a/pyneuromatic/core/nm_scale.py
+++ b/pyneuromatic/core/nm_scale.py
@@ -1,0 +1,295 @@
+# -*- coding: utf-8 -*-
+"""
+NMScale module — lightweight wrappers for x/y scale metadata.
+
+Provides NMScaleY (label, units) and NMScaleX (label, units, start, delta)
+with property-based access, validation, and history logging.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import copy
+import math
+
+import pyneuromatic.core.nm_history as nmh
+import pyneuromatic.core.nm_preferences as nmp
+import pyneuromatic.core.nm_utilities as nmu
+
+
+class NMScaleY:
+    """Y-scale metadata: label and units.
+
+    Provides property-based access with validation and optional history
+    logging. Used by NMData and NMChannel for y-axis scale parameters.
+    """
+
+    _path_suffix: str = "yscale"
+
+    def __init__(
+        self,
+        parent: object | None = None,
+        label: str = "",
+        units: str = "",
+    ) -> None:
+        self._parent = parent
+        self._label: str = str(label) if label else ""
+        self._units: str = str(units) if units else ""
+
+    def __repr__(self) -> str:
+        return "NMScaleY(label='%s', units='%s')" % (self._label, self._units)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, NMScaleY):
+            return (
+                self._label == other._label
+                and self._units == other._units
+            )
+        if isinstance(other, dict):
+            return self.to_dict() == other
+        return NotImplemented
+
+    def __deepcopy__(self, memo: dict) -> NMScaleY:
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for attr, value in self.__dict__.items():
+            if attr == "_parent":
+                setattr(result, attr, None)
+            else:
+                setattr(result, attr, copy.deepcopy(value, memo))
+        return result
+
+    def __getitem__(self, key: str) -> object:
+        d = self.to_dict()
+        if key in d:
+            return d[key]
+        raise KeyError(key)
+
+    @property
+    def path_str(self) -> str:
+        if self._parent is not None and hasattr(self._parent, "path_str"):
+            return self._parent.path_str + "." + self._path_suffix
+        return self._path_suffix
+
+    # --- label ---
+
+    @property
+    def label(self) -> str:
+        return self._label
+
+    @label.setter
+    def label(self, value: str) -> None:
+        self._set_label(value)
+
+    def _set_label(
+        self,
+        value: str,
+        log: bool = True,
+        quiet: bool = nmp.QUIET,
+    ) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "label", "string"))
+        value = value.strip()
+        if value == self._label:
+            return
+        self._label = value
+        if log:
+            nmh.history(
+                "set label='%s'" % value,
+                path=self.path_str,
+                quiet=quiet,
+            )
+
+    # --- units ---
+
+    @property
+    def units(self) -> str:
+        return self._units
+
+    @units.setter
+    def units(self, value: str) -> None:
+        self._set_units(value)
+
+    def _set_units(
+        self,
+        value: str,
+        log: bool = True,
+        quiet: bool = nmp.QUIET,
+    ) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "units", "string"))
+        value = value.strip()
+        if value == self._units:
+            return
+        self._units = value
+        if log:
+            nmh.history(
+                "set units='%s'" % value,
+                path=self.path_str,
+                quiet=quiet,
+            )
+
+    # --- serialization ---
+
+    def to_dict(self) -> dict:
+        return {"label": self._label, "units": self._units}
+
+
+class NMScaleX(NMScaleY):
+    """X-scale metadata: label, units, start, and delta.
+
+    Extends NMScaleY with start (x-axis origin) and delta (sample interval).
+    Used by NMData and NMChannel for x-axis scale parameters.
+    """
+
+    _path_suffix: str = "xscale"
+
+    def __init__(
+        self,
+        parent: object | None = None,
+        label: str = "",
+        units: str = "",
+        start: float | int = 0,
+        delta: float | int = 1,
+    ) -> None:
+        super().__init__(parent=parent, label=label, units=units)
+        self._start: float | int = start
+        self._delta: float | int = delta
+
+    def __repr__(self) -> str:
+        return (
+            "NMScaleX(label='%s', units='%s', start=%s, delta=%s)"
+            % (self._label, self._units, self._start, self._delta)
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, NMScaleX):
+            return (
+                self._label == other._label
+                and self._units == other._units
+                and self._start == other._start
+                and self._delta == other._delta
+            )
+        if isinstance(other, dict):
+            return self.to_dict() == other
+        return NotImplemented
+
+    # --- start ---
+
+    @property
+    def start(self) -> float | int:
+        return self._start
+
+    @start.setter
+    def start(self, value: float | int) -> None:
+        self._set_start(value)
+
+    def _set_start(
+        self,
+        value: float | int,
+        log: bool = True,
+        quiet: bool = nmp.QUIET,
+    ) -> None:
+        if not isinstance(value, (float, int)) or isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "start", "number"))
+        if isinstance(value, float) and (math.isinf(value) or math.isnan(value)):
+            raise ValueError("start: %s" % value)
+        if value == self._start:
+            return
+        self._start = value
+        if log:
+            nmh.history(
+                "set start=%s" % value,
+                path=self.path_str,
+                quiet=quiet,
+            )
+
+    # --- delta ---
+
+    @property
+    def delta(self) -> float | int:
+        return self._delta
+
+    @delta.setter
+    def delta(self, value: float | int) -> None:
+        self._set_delta(value)
+
+    def _set_delta(
+        self,
+        value: float | int,
+        log: bool = True,
+        quiet: bool = nmp.QUIET,
+    ) -> None:
+        if not isinstance(value, (float, int)) or isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "delta", "number"))
+        if isinstance(value, float) and (math.isinf(value) or math.isnan(value)):
+            raise ValueError("delta: %s" % value)
+        if value == 0:
+            raise ValueError("delta cannot be zero")
+        if value == self._delta:
+            return
+        self._delta = value
+        if log:
+            nmh.history(
+                "set delta=%s" % value,
+                path=self.path_str,
+                quiet=quiet,
+            )
+
+    # --- serialization ---
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d["start"] = self._start
+        d["delta"] = self._delta
+        return d
+
+
+# --- Helper functions for constructors ---
+
+
+def _xscale_from_dict(
+    d: dict | None,
+    parent: object | None = None,
+) -> NMScaleX:
+    if d is None:
+        return NMScaleX(parent=parent)
+    if not isinstance(d, dict):
+        raise TypeError(nmu.type_error_str(d, "xscale", "dict"))
+    return NMScaleX(
+        parent=parent,
+        label=d.get("label", ""),
+        units=d.get("units", ""),
+        start=d.get("start", 0),
+        delta=d.get("delta", 1),
+    )
+
+
+def _yscale_from_dict(
+    d: dict | None,
+    parent: object | None = None,
+) -> NMScaleY:
+    if d is None:
+        return NMScaleY(parent=parent)
+    if not isinstance(d, dict):
+        raise TypeError(nmu.type_error_str(d, "yscale", "dict"))
+    return NMScaleY(
+        parent=parent,
+        label=d.get("label", ""),
+        units=d.get("units", ""),
+    )

--- a/pyneuromatic/io/abf.py
+++ b/pyneuromatic/io/abf.py
@@ -102,23 +102,22 @@ def read_abf(
 
             name = make_data_name(prefix, channel, sweep)
 
-            data = folder.data.new(name)
+            # Build scale dicts
+            xscale = {"start": x_start, "delta": x_delta, "units": x_units}
+            yscale = {}
+            if channel < len(abf.adcNames):
+                yscale["label"] = abf.adcNames[channel]
+            if channel < len(abf.adcUnits):
+                yscale["units"] = abf.adcUnits[channel]
+
+            data = folder.data.new(
+                name, xscale=xscale, yscale=yscale if yscale else None
+            )
             if data is None:
                 continue
 
             # Set y data
             data.nparray = abf.sweepY.copy()
-
-            # Set y label/units from ADC info
-            if channel < len(abf.adcNames):
-                data.yscale["label"] = abf.adcNames[channel]
-            if channel < len(abf.adcUnits):
-                data.yscale["units"] = abf.adcUnits[channel]
-
-            # Set x scaling
-            data.xscale["start"] = x_start
-            data.xscale["delta"] = x_delta
-            data.xscale["units"] = x_units
 
     # Optionally create dataseries
     if make_dataseries:

--- a/pyneuromatic/io/axograph.py
+++ b/pyneuromatic/io/axograph.py
@@ -110,12 +110,7 @@ def read_axograph(
         epoch = col["epoch"]
         name = make_data_name(prefix, channel, epoch)
 
-        # Create NMData
-        data = folder.data.new(name)
-        if data is None:
-            continue
-
-        # Set y data
+        # Build y data and scale
         y_data = col["data"]
         parsed = parse_units_from_label(col["title"])
 
@@ -123,14 +118,15 @@ def read_axograph(
         if parsed.scale != 1.0:
             y_data = y_data * parsed.scale
 
-        data.nparray = y_data
-        data.yscale["label"] = parsed.label
-        data.yscale["units"] = parsed.units
+        xscale = {"start": x_start, "delta": x_delta, "units": x_units}
+        yscale = {"label": parsed.label, "units": parsed.units}
 
-        # Set x scale
-        data.xscale["start"] = x_start
-        data.xscale["delta"] = x_delta
-        data.xscale["units"] = x_units
+        # Create NMData
+        data = folder.data.new(name, xscale=xscale, yscale=yscale)
+        if data is None:
+            continue
+
+        data.nparray = y_data
 
     # Optionally create dataseries
     if make_dataseries:

--- a/pyneuromatic/io/igor_text.py
+++ b/pyneuromatic/io/igor_text.py
@@ -44,16 +44,16 @@ def write_itx(
             f.write("END\n")
 
             # x scaling: SetScale/P x, offset, delta, "units", waveName
-            x_start = nmdata.xscale.get("start") or 0
-            x_delta = nmdata.xscale.get("delta") or 1
-            x_units = nmdata.xscale.get("units") or ""
+            x_start = nmdata.xscale.start
+            x_delta = nmdata.xscale.delta
+            x_units = nmdata.xscale.units
             f.write(
                 f'X SetScale/P x, {x_start}, {x_delta},'
                 f' "{x_units}", {name}\n'
             )
 
             # y units: SetScale d, 0, 0, "units", waveName
-            y_units = nmdata.yscale.get("units") or ""
+            y_units = nmdata.yscale.units
             f.write(
                 f'X SetScale d, 0, 0,'
                 f' "{y_units}", {name}\n'

--- a/pyneuromatic/io/pxp.py
+++ b/pyneuromatic/io/pxp.py
@@ -150,24 +150,24 @@ def read_pxp(
         # Build the data name using the requested prefix
         name = make_data_name(prefix, channel_num, epoch_num)
 
+        # Build scale dicts
+        xscale = {
+            "start": float(wave_header.get("hsB", 0.0)),
+            "delta": float(wave_header.get("hsA", 1.0)),
+            "units": x_units,
+        }
+        yscale = None
+        if channel_num < len(y_labels):
+            y_parsed = parse_units_from_label(y_labels[channel_num])
+            yscale = {"label": y_parsed.label, "units": y_parsed.units}
+
         # Create NMData
-        data = folder.data.new(name)
+        data = folder.data.new(name, xscale=xscale, yscale=yscale)
         if data is None:
             continue
 
         # Set y data
         data.nparray = wave["wData"]
-
-        # Set y label/units from yLabel config wave
-        if channel_num < len(y_labels):
-            y_parsed = parse_units_from_label(y_labels[channel_num])
-            data.yscale["label"] = y_parsed.label
-            data.yscale["units"] = y_parsed.units
-
-        # Set x scaling from wave header
-        data.xscale["start"] = float(wave_header.get("hsB", 0.0))
-        data.xscale["delta"] = float(wave_header.get("hsA", 1.0))
-        data.xscale["units"] = x_units
 
     # Optionally create dataseries
     if make_dataseries:

--- a/tests/test_analysis/test_nm_stats.py
+++ b/tests/test_analysis/test_nm_stats.py
@@ -543,8 +543,8 @@ class NMStatsTest(unittest.TestCase):
         self.assertEqual(r["i0"], 0)  # xclip = True
         pnts = len(self.datanan.nparray)
         self.assertEqual(r["i1"], pnts-1)  # xclip = True
-        self.assertEqual(r["sunits"], self.datanan.yscale.get("units", ""))
-        self.assertEqual(r["xunits"], self.datanan.xscale.get("units", ""))
+        self.assertEqual(r["sunits"], self.datanan.yscale.units)
+        self.assertEqual(r["xunits"], self.datanan.xscale.units)
         r = nms.stats(self.datanan, func, x0=-100, xclip=False)
         keys = ['data', 'i0', 'i1', 'error']
         self.assertEqual(list(r.keys()), keys)

--- a/tests/test_core/test_nm_channel.py
+++ b/tests/test_core/test_nm_channel.py
@@ -11,6 +11,7 @@ import unittest
 from pyneuromatic.core.nm_channel import NMChannel, NMChannelContainer
 from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_manager import NMManager
+from pyneuromatic.core.nm_scale import NMScaleX, NMScaleY
 import pyneuromatic.core.nm_utilities as nmu
 
 NM = NMManager(quiet=True)
@@ -61,10 +62,8 @@ class NMChannelTest(unittest.TestCase):
         self.assertEqual(self.c0._parent, NM)
         self.assertEqual(self.c0.name, CNAME0)
 
-        for key in XSCALE0.keys():
-            self.assertEqual(self.c0.xscale[key], XSCALE0[key])
-        for key in YSCALE0.keys():
-            self.assertEqual(self.c0.yscale[key], YSCALE0[key])
+        self.assertEqual(self.c0.xscale, XSCALE0)
+        self.assertEqual(self.c0.yscale, YSCALE0)
 
         for i, o in enumerate(self.c0.data):
             self.assertEqual(o.name, DNLIST0[i])
@@ -73,8 +72,8 @@ class NMChannelTest(unittest.TestCase):
         self.assertEqual(self.c0_copy.name, CNAME0)
         self.assertEqual(self.c0_copy.xscale, self.c0.xscale)
         self.assertEqual(self.c0_copy.yscale, self.c0.yscale)
-        self.assertIsInstance(self.c0_copy.xscale, dict)
-        self.assertIsInstance(self.c0_copy.yscale, dict)
+        self.assertIsInstance(self.c0_copy.xscale, NMScaleX)
+        self.assertIsInstance(self.c0_copy.yscale, NMScaleY)
 
         for i, o in enumerate(self.c0_copy.data):
             self.assertEqual(o.name, DNLIST0[i])

--- a/tests/test_core/test_nm_data.py
+++ b/tests/test_core/test_nm_data.py
@@ -76,13 +76,13 @@ class NMDataTest(unittest.TestCase):
             parent=None, name=DNAME0, nparray=NPARRAY0, xscale=x, yscale=YSCALE0
         )
         self.assertTrue(d0 == self.d0)
-        d0.xscale["delta"] = 0.05
+        d0.xscale.delta = 0.05
         self.assertFalse(d0 == self.d0)
-        d0.xscale["delta"] = XSCALE0["delta"]
+        d0.xscale.delta = XSCALE0["delta"]
         self.assertTrue(d0 == self.d0)
-        d0.yscale["units"] = "test"
+        d0.yscale.units = "test"
         self.assertFalse(d0 == self.d0)
-        d0.yscale["units"] = YSCALE0["units"]
+        d0.yscale.units = YSCALE0["units"]
         self.assertTrue(d0 == self.d0)
 
         d0.nparray = numpy.full([4], 3.14, dtype=numpy.float64, order="C")
@@ -126,15 +126,15 @@ class NMDataTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.d0.xscale = None
         start = 100
-        self.d0.xscale["start"] = start
-        self.assertEqual(self.d0.xscale["start"], start)
+        self.d0.xscale.start = start
+        self.assertEqual(self.d0.xscale.start, start)
 
     def xtest04_y(self):
         with self.assertRaises(AttributeError):
             self.d0.yscale = None
         label = "test"
-        self.d0.yscale["label"] = label
-        self.assertEqual(self.d0.yscale["label"], label)
+        self.d0.yscale.label = label
+        self.assertEqual(self.d0.yscale.label, label)
 
     def xtest05_dataseries(self):
         """

--- a/tests/test_core/test_nm_dataseries.py
+++ b/tests/test_core/test_nm_dataseries.py
@@ -190,51 +190,51 @@ class TestNMDataSeriesBulkDimensions(unittest.TestCase):
         count = self.ds.set_xstart(0.5)
         self.assertEqual(count, 6)  # 3 data per channel * 2 channels
         for d in self.chan_a.data:
-            self.assertEqual(d.xscale["start"], 0.5)
+            self.assertEqual(d.xscale.start, 0.5)
         for d in self.chan_b.data:
-            self.assertEqual(d.xscale["start"], 0.5)
+            self.assertEqual(d.xscale.start, 0.5)
 
     def test_set_xstart_single_channel(self):
         count = self.ds.set_xstart(0.5, channel="A")
         self.assertEqual(count, 3)
         for d in self.chan_a.data:
-            self.assertEqual(d.xscale["start"], 0.5)
+            self.assertEqual(d.xscale.start, 0.5)
         # Channel B unchanged
         for d in self.chan_b.data:
-            self.assertEqual(d.xscale["start"], 0)
+            self.assertEqual(d.xscale.start, 0)
 
     def test_set_xdelta_all_channels(self):
         count = self.ds.set_xdelta(0.02)
         self.assertEqual(count, 6)
         for d in self.chan_a.data:
-            self.assertEqual(d.xscale["delta"], 0.02)
+            self.assertEqual(d.xscale.delta, 0.02)
 
     def test_set_xlabel_all_channels(self):
         count = self.ds.set_xlabel("Time")
         self.assertEqual(count, 6)
         for d in self.chan_a.data:
-            self.assertEqual(d.xscale["label"], "Time")
+            self.assertEqual(d.xscale.label, "Time")
 
     def test_set_xunits_single_channel(self):
         count = self.ds.set_xunits("s", channel="B")
         self.assertEqual(count, 3)
         for d in self.chan_b.data:
-            self.assertEqual(d.xscale["units"], "s")
+            self.assertEqual(d.xscale.units, "s")
         # Channel A unchanged
         for d in self.chan_a.data:
-            self.assertEqual(d.xscale["units"], "ms")
+            self.assertEqual(d.xscale.units, "ms")
 
     def test_set_ylabel_single_channel(self):
         count = self.ds.set_ylabel("Current", channel="A")
         self.assertEqual(count, 3)
         for d in self.chan_a.data:
-            self.assertEqual(d.yscale["label"], "Current")
+            self.assertEqual(d.yscale.label, "Current")
 
     def test_set_yunits_all_channels(self):
         count = self.ds.set_yunits("nA")
         self.assertEqual(count, 6)
         for d in self.chan_a.data:
-            self.assertEqual(d.yscale["units"], "nA")
+            self.assertEqual(d.yscale.units, "nA")
 
     def test_set_xstart_invalid_channel(self):
         with self.assertRaises(KeyError):

--- a/tests/test_core/test_nm_scale.py
+++ b/tests/test_core/test_nm_scale.py
@@ -1,0 +1,308 @@
+# -*- coding: utf-8 -*-
+"""Tests for NMScaleY and NMScaleX classes."""
+import copy
+import math
+import unittest
+
+from pyneuromatic.core.nm_scale import (
+    NMScaleX,
+    NMScaleY,
+    _xscale_from_dict,
+    _yscale_from_dict,
+)
+
+
+class TestNMScaleY(unittest.TestCase):
+    """Tests for NMScaleY."""
+
+    def test_init_defaults(self):
+        s = NMScaleY()
+        self.assertIsNone(s._parent)
+        self.assertEqual(s.label, "")
+        self.assertEqual(s.units, "")
+
+    def test_init_values(self):
+        s = NMScaleY(label="voltage", units="mV")
+        self.assertEqual(s.label, "voltage")
+        self.assertEqual(s.units, "mV")
+
+    def test_label_setter(self):
+        s = NMScaleY()
+        s.label = "current"
+        self.assertEqual(s.label, "current")
+
+    def test_label_setter_strips(self):
+        s = NMScaleY()
+        s.label = "  current  "
+        self.assertEqual(s.label, "current")
+
+    def test_label_setter_type_error(self):
+        s = NMScaleY()
+        with self.assertRaises(TypeError):
+            s.label = 123
+
+    def test_units_setter(self):
+        s = NMScaleY()
+        s.units = "pA"
+        self.assertEqual(s.units, "pA")
+
+    def test_units_setter_type_error(self):
+        s = NMScaleY()
+        with self.assertRaises(TypeError):
+            s.units = 42
+
+    def test_to_dict(self):
+        s = NMScaleY(label="voltage", units="mV")
+        self.assertEqual(s.to_dict(), {"label": "voltage", "units": "mV"})
+
+    def test_getitem(self):
+        s = NMScaleY(label="voltage", units="mV")
+        self.assertEqual(s["label"], "voltage")
+        self.assertEqual(s["units"], "mV")
+        with self.assertRaises(KeyError):
+            s["nonexistent"]
+
+    def test_eq_same_type(self):
+        s1 = NMScaleY(label="voltage", units="mV")
+        s2 = NMScaleY(label="voltage", units="mV")
+        self.assertEqual(s1, s2)
+
+    def test_eq_different_values(self):
+        s1 = NMScaleY(label="voltage", units="mV")
+        s2 = NMScaleY(label="current", units="pA")
+        self.assertNotEqual(s1, s2)
+
+    def test_eq_dict(self):
+        s = NMScaleY(label="voltage", units="mV")
+        self.assertEqual(s, {"label": "voltage", "units": "mV"})
+        self.assertNotEqual(s, {"label": "current", "units": "pA"})
+
+    def test_eq_wrong_type(self):
+        s = NMScaleY()
+        self.assertEqual(s.__eq__(42), NotImplemented)
+
+    def test_deepcopy(self):
+        parent = object()
+        s = NMScaleY(parent=parent, label="voltage", units="mV")
+        s2 = copy.deepcopy(s)
+        self.assertEqual(s2.label, "voltage")
+        self.assertEqual(s2.units, "mV")
+        self.assertIsNone(s2._parent)  # parent reset to None
+
+    def test_path_str_no_parent(self):
+        s = NMScaleY()
+        self.assertEqual(s.path_str, "yscale")
+
+    def test_path_str_with_parent(self):
+        class FakeParent:
+            @property
+            def path_str(self):
+                return "folder0.data0"
+
+        s = NMScaleY(parent=FakeParent())
+        self.assertEqual(s.path_str, "folder0.data0.yscale")
+
+    def test_repr(self):
+        s = NMScaleY(label="voltage", units="mV")
+        r = repr(s)
+        self.assertIn("NMScaleY", r)
+        self.assertIn("voltage", r)
+        self.assertIn("mV", r)
+
+    def test_noop_on_same_value(self):
+        s = NMScaleY(label="voltage")
+        # Setting the same value should be a no-op (no error)
+        s.label = "voltage"
+        self.assertEqual(s.label, "voltage")
+
+
+class TestNMScaleX(unittest.TestCase):
+    """Tests for NMScaleX."""
+
+    def test_init_defaults(self):
+        s = NMScaleX()
+        self.assertEqual(s.label, "")
+        self.assertEqual(s.units, "")
+        self.assertEqual(s.start, 0)
+        self.assertEqual(s.delta, 1)
+
+    def test_init_values(self):
+        s = NMScaleX(label="time", units="ms", start=0.5, delta=0.02)
+        self.assertEqual(s.label, "time")
+        self.assertEqual(s.units, "ms")
+        self.assertEqual(s.start, 0.5)
+        self.assertEqual(s.delta, 0.02)
+
+    def test_start_setter(self):
+        s = NMScaleX()
+        s.start = 1.5
+        self.assertEqual(s.start, 1.5)
+
+    def test_start_setter_int(self):
+        s = NMScaleX()
+        s.start = 10
+        self.assertEqual(s.start, 10)
+
+    def test_start_setter_type_error_bool(self):
+        s = NMScaleX()
+        with self.assertRaises(TypeError):
+            s.start = True
+
+    def test_start_setter_type_error_str(self):
+        s = NMScaleX()
+        with self.assertRaises(TypeError):
+            s.start = "bad"
+
+    def test_start_setter_inf(self):
+        s = NMScaleX()
+        with self.assertRaises(ValueError):
+            s.start = float("inf")
+
+    def test_start_setter_nan(self):
+        s = NMScaleX()
+        with self.assertRaises(ValueError):
+            s.start = float("nan")
+
+    def test_delta_setter(self):
+        s = NMScaleX()
+        s.delta = 0.05
+        self.assertEqual(s.delta, 0.05)
+
+    def test_delta_setter_zero(self):
+        s = NMScaleX()
+        with self.assertRaises(ValueError):
+            s.delta = 0
+
+    def test_delta_setter_type_error_bool(self):
+        s = NMScaleX()
+        with self.assertRaises(TypeError):
+            s.delta = False
+
+    def test_delta_setter_inf(self):
+        s = NMScaleX()
+        with self.assertRaises(ValueError):
+            s.delta = float("-inf")
+
+    def test_delta_setter_nan(self):
+        s = NMScaleX()
+        with self.assertRaises(ValueError):
+            s.delta = float("nan")
+
+    def test_to_dict(self):
+        s = NMScaleX(label="time", units="ms", start=0.5, delta=0.02)
+        expected = {"label": "time", "units": "ms", "start": 0.5, "delta": 0.02}
+        self.assertEqual(s.to_dict(), expected)
+
+    def test_getitem(self):
+        s = NMScaleX(start=0.5, delta=0.02)
+        self.assertEqual(s["start"], 0.5)
+        self.assertEqual(s["delta"], 0.02)
+        self.assertEqual(s["label"], "")
+        with self.assertRaises(KeyError):
+            s["nonexistent"]
+
+    def test_eq_same_type(self):
+        s1 = NMScaleX(label="time", units="ms", start=0.5, delta=0.02)
+        s2 = NMScaleX(label="time", units="ms", start=0.5, delta=0.02)
+        self.assertEqual(s1, s2)
+
+    def test_eq_different_start(self):
+        s1 = NMScaleX(start=0)
+        s2 = NMScaleX(start=1)
+        self.assertNotEqual(s1, s2)
+
+    def test_eq_dict(self):
+        s = NMScaleX(label="time", units="ms", start=0.5, delta=0.02)
+        expected = {"label": "time", "units": "ms", "start": 0.5, "delta": 0.02}
+        self.assertEqual(s, expected)
+
+    def test_eq_wrong_type(self):
+        s = NMScaleX()
+        self.assertEqual(s.__eq__(42), NotImplemented)
+
+    def test_deepcopy(self):
+        parent = object()
+        s = NMScaleX(parent=parent, label="time", units="ms", start=0.5, delta=0.02)
+        s2 = copy.deepcopy(s)
+        self.assertEqual(s2.label, "time")
+        self.assertEqual(s2.units, "ms")
+        self.assertEqual(s2.start, 0.5)
+        self.assertEqual(s2.delta, 0.02)
+        self.assertIsNone(s2._parent)
+
+    def test_path_str(self):
+        s = NMScaleX()
+        self.assertEqual(s.path_str, "xscale")
+
+    def test_repr(self):
+        s = NMScaleX(start=0.5, delta=0.02)
+        r = repr(s)
+        self.assertIn("NMScaleX", r)
+        self.assertIn("0.5", r)
+        self.assertIn("0.02", r)
+
+    def test_noop_on_same_value(self):
+        s = NMScaleX(start=5.0, delta=0.1)
+        s.start = 5.0
+        s.delta = 0.1
+        self.assertEqual(s.start, 5.0)
+        self.assertEqual(s.delta, 0.1)
+
+    def test_set_log_false(self):
+        """_set_* with log=False should still set value."""
+        s = NMScaleX()
+        s._set_start(2.0, log=False)
+        self.assertEqual(s.start, 2.0)
+        s._set_delta(0.5, log=False)
+        self.assertEqual(s.delta, 0.5)
+        s._set_label("time", log=False)
+        self.assertEqual(s.label, "time")
+        s._set_units("ms", log=False)
+        self.assertEqual(s.units, "ms")
+
+
+class TestHelperFunctions(unittest.TestCase):
+    """Tests for _xscale_from_dict and _yscale_from_dict."""
+
+    def test_xscale_from_none(self):
+        s = _xscale_from_dict(None)
+        self.assertIsInstance(s, NMScaleX)
+        self.assertEqual(s.start, 0)
+        self.assertEqual(s.delta, 1)
+        self.assertEqual(s.label, "")
+        self.assertEqual(s.units, "")
+
+    def test_xscale_from_dict(self):
+        d = {"start": 0.5, "delta": 0.02, "label": "time", "units": "ms"}
+        s = _xscale_from_dict(d)
+        self.assertEqual(s.start, 0.5)
+        self.assertEqual(s.delta, 0.02)
+        self.assertEqual(s.label, "time")
+        self.assertEqual(s.units, "ms")
+
+    def test_xscale_from_partial_dict(self):
+        d = {"start": 1.0}
+        s = _xscale_from_dict(d)
+        self.assertEqual(s.start, 1.0)
+        self.assertEqual(s.delta, 1)  # default
+
+    def test_xscale_parent(self):
+        parent = object()
+        s = _xscale_from_dict(None, parent=parent)
+        self.assertIs(s._parent, parent)
+
+    def test_yscale_from_none(self):
+        s = _yscale_from_dict(None)
+        self.assertIsInstance(s, NMScaleY)
+        self.assertEqual(s.label, "")
+        self.assertEqual(s.units, "")
+
+    def test_yscale_from_dict(self):
+        d = {"label": "current", "units": "pA"}
+        s = _yscale_from_dict(d)
+        self.assertEqual(s.label, "current")
+        self.assertEqual(s.units, "pA")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_io/test_abf.py
+++ b/tests/test_io/test_abf.py
@@ -58,30 +58,30 @@ class TestReadAbfFile(unittest.TestCase):
     def test_x_delta(self):
         # 5000 Hz = 0.2 ms sample interval
         self.assertAlmostEqual(
-            self.folder.data["RecordA0"].xscale["delta"], 0.2, places=4
+            self.folder.data["RecordA0"].xscale.delta, 0.2, places=4
         )
 
     def test_x_start(self):
         self.assertAlmostEqual(
-            self.folder.data["RecordA0"].xscale["start"], 0.0, places=4
+            self.folder.data["RecordA0"].xscale.start, 0.0, places=4
         )
 
     def test_x_units(self):
-        self.assertEqual(self.folder.data["RecordA0"].xscale["units"], "ms")
+        self.assertEqual(self.folder.data["RecordA0"].xscale.units, "ms")
 
     # y-axis
 
     def test_channel_a_y_label(self):
-        self.assertEqual(self.folder.data["RecordA0"].yscale["label"], "Im_1stCh2")
+        self.assertEqual(self.folder.data["RecordA0"].yscale.label, "Im_1stCh2")
 
     def test_channel_a_y_units(self):
-        self.assertEqual(self.folder.data["RecordA0"].yscale["units"], "pA")
+        self.assertEqual(self.folder.data["RecordA0"].yscale.units, "pA")
 
     def test_channel_b_y_label(self):
-        self.assertEqual(self.folder.data["RecordB0"].yscale["label"], "Light")
+        self.assertEqual(self.folder.data["RecordB0"].yscale.label, "Light")
 
     def test_channel_b_y_units(self):
-        self.assertEqual(self.folder.data["RecordB0"].yscale["units"], "V")
+        self.assertEqual(self.folder.data["RecordB0"].yscale.units, "V")
 
     # data shape
 

--- a/tests/test_io/test_axograph.py
+++ b/tests/test_io/test_axograph.py
@@ -65,11 +65,11 @@ class TestReadAxographXFile(unittest.TestCase):
     # channel A: Membrane Voltage
 
     def test_channel_a_label(self):
-        self.assertEqual(self.folder.data["RecordA0"].yscale["label"],
+        self.assertEqual(self.folder.data["RecordA0"].yscale.label,
                          "Membrane Voltage-1")
 
     def test_channel_a_units(self):
-        self.assertEqual(self.folder.data["RecordA0"].yscale["units"], "mV")
+        self.assertEqual(self.folder.data["RecordA0"].yscale.units, "mV")
 
     def test_channel_a_shape_epoch0(self):
         self.assertEqual(self.folder.data["RecordA0"].nparray.shape, (79840,))
@@ -80,28 +80,28 @@ class TestReadAxographXFile(unittest.TestCase):
     # channel B: Command Current
 
     def test_channel_b_label(self):
-        self.assertEqual(self.folder.data["RecordB0"].yscale["label"],
+        self.assertEqual(self.folder.data["RecordB0"].yscale.label,
                          "Raw Command Current-1")
 
     def test_channel_b_units(self):
-        self.assertEqual(self.folder.data["RecordB0"].yscale["units"], "pA")
+        self.assertEqual(self.folder.data["RecordB0"].yscale.units, "pA")
 
     # channel C: Analog Input
 
     def test_channel_c_label(self):
-        self.assertEqual(self.folder.data["RecordC0"].yscale["label"],
+        self.assertEqual(self.folder.data["RecordC0"].yscale.label,
                          "Analog Input #2")
 
     def test_channel_c_units(self):
-        self.assertEqual(self.folder.data["RecordC0"].yscale["units"], "mV")
+        self.assertEqual(self.folder.data["RecordC0"].yscale.units, "mV")
 
     # x-axis (time)
 
     def test_x_units(self):
-        self.assertEqual(self.folder.data["RecordA0"].xscale["units"], "ms")
+        self.assertEqual(self.folder.data["RecordA0"].xscale.units, "ms")
 
     def test_x_delta(self):
-        self.assertAlmostEqual(self.folder.data["RecordA0"].xscale["delta"],
+        self.assertAlmostEqual(self.folder.data["RecordA0"].xscale.delta,
                                0.0501, places=4)
 
     # dataseries

--- a/tests/test_io/test_pxp.py
+++ b/tests/test_io/test_pxp.py
@@ -56,30 +56,30 @@ class TestReadPxpFile(unittest.TestCase):
 
     def test_x_delta(self):
         self.assertAlmostEqual(
-            self.folder.data["RecordA0"].xscale["delta"], 0.02, places=4
+            self.folder.data["RecordA0"].xscale.delta, 0.02, places=4
         )
 
     def test_x_start(self):
         self.assertAlmostEqual(
-            self.folder.data["RecordA0"].xscale["start"], 0.0, places=4
+            self.folder.data["RecordA0"].xscale.start, 0.0, places=4
         )
 
     def test_x_units(self):
-        self.assertEqual(self.folder.data["RecordA0"].xscale["units"], "ms")
+        self.assertEqual(self.folder.data["RecordA0"].xscale.units, "ms")
 
     # y-axis (from yLabel wave)
 
     def test_channel_a_y_label(self):
-        self.assertEqual(self.folder.data["RecordA0"].yscale["label"], "Vmem")
+        self.assertEqual(self.folder.data["RecordA0"].yscale.label, "Vmem")
 
     def test_channel_a_y_units(self):
-        self.assertEqual(self.folder.data["RecordA0"].yscale["units"], "mV")
+        self.assertEqual(self.folder.data["RecordA0"].yscale.units, "mV")
 
     def test_channel_b_y_label(self):
-        self.assertEqual(self.folder.data["RecordB0"].yscale["label"], "Icmd")
+        self.assertEqual(self.folder.data["RecordB0"].yscale.label, "Icmd")
 
     def test_channel_b_y_units(self):
-        self.assertEqual(self.folder.data["RecordB0"].yscale["units"], "pA")
+        self.assertEqual(self.folder.data["RecordB0"].yscale.units, "pA")
 
     # data shape
 


### PR DESCRIPTION
## Summary

- Replace plain dict xscale/yscale on NMData and NMChannel with lightweight NMScaleX/NMScaleY wrapper classes providing property-based access, validation, and history logging
- NMScaleY holds label and units; NMScaleX extends with start and delta
- Setters validate types (reject bool/inf/nan for numerics, zero for delta) and log changes via nmh.history()
- IO readers now build scale dicts at construction time instead of post-mutation
- NMDataSeries bulk set methods use quiet=True for per-item history, then emit one summary entry
- Closes #79 

## Test plan

-  New test_nm_scale.py covers both classes (48 tests): init, properties, validation, equality, deepcopy, serialization, __getitem__, path_str
-  Existing tests updated from dict bracket access to property access
-  Full suite passes (828 tests)