### PR TITLE
Suppress verbose history in make_dataseries, log summary

### DIFF
--- a/pyneuromatic/core/nm_channel.py
+++ b/pyneuromatic/core/nm_channel.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
 from pyneuromatic.core.nm_scale import NMScaleX, NMScaleY, _xscale_from_dict, _yscale_from_dict
+import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
 
 
@@ -204,7 +205,7 @@ class NMChannelContainer(NMObjectContainer):
         select: bool = False,
         xscale: dict | None = None,
         yscale: dict | None = None,
-        # quiet: bool = nmp.QUIET
+        quiet: bool = nmp.QUIET,
     ) -> NMChannel | None:
         actual_name = self.auto_name_next()
         # Use self._parent (NMDataSeries) to skip container in parent chain,
@@ -215,6 +216,6 @@ class NMChannelContainer(NMObjectContainer):
             xscale=xscale,
             yscale=yscale
         )
-        if super()._new(c, select=select):
+        if super()._new(c, select=select, quiet=quiet):
             return c
         return None

--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -548,13 +548,13 @@ class NMDataSeriesContainer(NMObjectContainer):
         self,
         name: str = "",  # dataseries name/prefix
         select: bool = False,
-        # quiet: bool = nmp.QUIET
+        quiet: bool = nmp.QUIET,
     ) -> NMDataSeries | None:
         name = self._newkey(name)
         # Use self._parent (NMFolder) to skip container in parent chain,
         # consistent with NMFolder, NMData, NMChannel, NMEpoch
         s = NMDataSeries(parent=self._parent, name=name)
-        if super()._new(s, select=select):
+        if super()._new(s, select=select, quiet=quiet):
             return s
         return None
 

--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
+import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
 
 
@@ -205,7 +206,7 @@ class NMEpochContainer(NMObjectContainer):
         self,
         name: str | None = None,  # not used, instead name = name_next()
         select: bool = False,
-        # quiet: bool = nmp.QUIET
+        quiet: bool = nmp.QUIET,
     ) -> NMEpoch | None:
         actual_name = self.auto_name_next()
         istr = actual_name.replace(self.auto_name_prefix, "")
@@ -216,10 +217,10 @@ class NMEpochContainer(NMObjectContainer):
         # Use self._parent (NMDataSeries) to skip container in parent chain,
         # consistent with NMFolder, NMData, NMDataSeries, NMChannel
         c = NMEpoch(
-            parent=self._parent, 
-            name=actual_name, 
+            parent=self._parent,
+            name=actual_name,
             number=iseq
         )
-        if super()._new(c, select=select):
+        if super()._new(c, select=select, quiet=quiet):
             return c
         return None


### PR DESCRIPTION
## Summary

- Add quiet parameter to NMChannelContainer.new(), NMEpochContainer.new(), and NMDataSeriesContainer.new() so callers can suppress per-item history
- Update make_dataseries() to use quiet=True for all internal new() calls and log a single summary line instead of one entry per channel/epoch
- Closes #81 

## Test plan
 All 828 existing tests pass — no behavior change for default quiet value