### PR TITLE
Rename _new() to _add(), uncomment quiet in all container new() methods

### DIFF
--- a/pyneuromatic/analysis/nm_tool_folder.py
+++ b/pyneuromatic/analysis/nm_tool_folder.py
@@ -24,6 +24,7 @@ import copy
 from pyneuromatic.core.nm_data import NMDataContainer
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
+import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
 
 
@@ -163,10 +164,10 @@ class NMToolFolderContainer(NMObjectContainer):
         self,
         name: str | None = None,
         select: bool = False,
-        # quiet: bool = nmp.QUIET
+        quiet: bool = nmp.QUIET
     ) -> NMToolFolder | None:
         name = self._newkey(name)
         f = NMToolFolder(parent=self, name=name)
-        if super()._new(f, select=select):
+        if super()._add(f, select=select, quiet=quiet):
             return f
         return None

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -1282,9 +1282,9 @@ class NMStatsWinContainer(NMObjectContainer):
     # override
     def new(  # type: ignore[override]
         self,
-        # name: str = 'A',  use name_next()
+        name: str | None = None,  # not used, instead name = auto_name_next()
         select: bool = False,
-        # quiet: bool = nmp.QUIET
+        quiet: bool = nmp.QUIET
     ) -> NMStatsWin | None:
         name = self.auto_name_next()
         istr = name.replace(self.auto_name_prefix, "")
@@ -1293,7 +1293,7 @@ class NMStatsWinContainer(NMObjectContainer):
         else:
             iseq = -1
         c = NMStatsWin(parent=self._parent, name=name)
-        if super()._new(c, select=select):
+        if super()._add(c, select=select, quiet=quiet):
             return c
         return None
 

--- a/pyneuromatic/core/nm_channel.py
+++ b/pyneuromatic/core/nm_channel.py
@@ -201,7 +201,7 @@ class NMChannelContainer(NMObjectContainer):
     # override
     def new(
         self,
-        name: str | None = None,  # not used, instead name = name_next()
+        name: str | None = None,  # not used, instead name = auto_name_next()
         select: bool = False,
         xscale: dict | None = None,
         yscale: dict | None = None,
@@ -216,6 +216,6 @@ class NMChannelContainer(NMObjectContainer):
             xscale=xscale,
             yscale=yscale
         )
-        if super()._new(c, select=select, quiet=quiet):
+        if super()._add(c, select=select, quiet=quiet):
             return c
         return None

--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -512,7 +512,7 @@ class NMDataContainer(NMObjectContainer):
         nparray: numpy.ndarray | None = None,
         xscale: dict | None = None,
         yscale: dict | None = None,
-        # quiet: bool = nmp.QUIET
+        quiet: bool = nmp.QUIET
     ) -> NMData | None:
         actual_name = self._newkey(name)
         # Use self._parent (NMFolder) to skip container in parent chain,
@@ -524,7 +524,7 @@ class NMDataContainer(NMObjectContainer):
             xscale=xscale,
             yscale=yscale,
         )
-        if super()._new(d, select=select):
+        if super()._add(d, select=select, quiet=quiet):
             return d
         return None
 

--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -554,7 +554,7 @@ class NMDataSeriesContainer(NMObjectContainer):
         # Use self._parent (NMFolder) to skip container in parent chain,
         # consistent with NMFolder, NMData, NMChannel, NMEpoch
         s = NMDataSeries(parent=self._parent, name=name)
-        if super()._new(s, select=select, quiet=quiet):
+        if super()._add(s, select=select, quiet=quiet):
             return s
         return None
 

--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -204,7 +204,7 @@ class NMEpochContainer(NMObjectContainer):
     # override
     def new(
         self,
-        name: str | None = None,  # not used, instead name = name_next()
+        name: str | None = None,  # not used, instead name = auto_name_next()
         select: bool = False,
         quiet: bool = nmp.QUIET,
     ) -> NMEpoch | None:
@@ -221,6 +221,6 @@ class NMEpochContainer(NMObjectContainer):
             name=actual_name,
             number=iseq
         )
-        if super()._new(c, select=select, quiet=quiet):
+        if super()._add(c, select=select, quiet=quiet):
             return c
         return None

--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -417,13 +417,13 @@ class NMFolderContainer(NMObjectContainer):
         self,
         name: str | None = None,
         select: bool = False,
-        # quiet: bool = nmp.QUIET
+        quiet: bool = nmp.QUIET
     ) -> NMFolder | None:
         actual_name = self._newkey(name)
         # Use self._parent (NMProject) to skip container in parent chain,
         # consistent with NMData, NMDataSeries, NMChannel, NMEpoch
         f = NMFolder(parent=self._parent, name=actual_name)
-        if super()._new(f, select=select):
+        if super()._add(f, select=select, quiet=quiet):
             return f
         return None
 

--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -725,20 +725,20 @@ class NMObjectContainer(NMObject, MutableMapping):
         return c
 
     # children should override
-    # and call super()._new()
+    # and call super()._add()
     def new(
         self,
         name: str | None = None,
         select: bool = False,
-        # quiet: bool = nmp.QUIET
+        quiet: bool = nmp.QUIET
     ) -> NMObject | None:
         actual_name = self._newkey(name)
         o = NMObject(parent=self, name=actual_name)
-        if self._new(o, select=select):
+        if self._add(o, select=select, quiet=quiet):
             return o
         return None
     
-    def _new(
+    def _add(
         self,
         nmobject: NMObject,
         select: bool = False,

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -861,7 +861,7 @@ class TestNMObjectContainerDuplicate(NMObjectContainerTestBase):
 
 
 class TestNMObjectContainerNew(NMObjectContainerTestBase):
-    """Tests for new() and _new() methods."""
+    """Tests for new() and _add() methods."""
 
     def test_new_rejects_bad_types(self):
         bad = list(BAD_TYPES)
@@ -879,7 +879,7 @@ class TestNMObjectContainerNew(NMObjectContainerTestBase):
         nnext = self.map0.auto_name_next()
         self.assertEqual(nnext, OPREFIX0 + "6")
         o = NMObject(parent=NM0, name=nnext)
-        self.assertTrue(self.map0._new(o))
+        self.assertTrue(self.map0._add(o))
         self.assertEqual(len(self.map0), len(ONLIST0) + 1)
 
 
@@ -1228,9 +1228,9 @@ class TestNMObjectContainerHistory(unittest.TestCase):
         self.container.new("itemX")
         self.assertIn("new 'itemX'", self._last_message())
 
-    def test_new_via_internal_logs(self):
+    def test_add_logs(self):
         o = NMObject(parent=self.nm, name="itemZ")
-        self.container._new(o, quiet=False)
+        self.container._add(o, quiet=False)
         self.assertIn("new 'itemZ'", self._last_message())
 
     def test_pop_logs(self):


### PR DESCRIPTION
## Summary

- Rename NMObjectContainer._new() to _add() — the method inserts an already-constructed object into the container map, so _add better describes its role and avoids confusion with Python's __new__()
- Uncomment the quiet parameter in the remaining five container new() methods (NMObjectContainer, NMDataContainer, NMFolderContainer, NMToolFolderContainer, NMToolStatsContainer) for a consistent API
- Closes #83 

## Test plan

-  All 828 tests pass
-  No remaining references to _new() in codebase
-  No remaining commented-out # quiet parameters