### PR TITLE
Add NMTransform class hierarchy for data transforms

### DIFF
--- a/pyneuromatic/core/nm_transform.py
+++ b/pyneuromatic/core/nm_transform.py
@@ -1,0 +1,320 @@
+# -*- coding: utf-8 -*-
+"""
+NMTransform module — data transform classes for pyNeuroMatic.
+
+Provides NMTransform base class and simple transform subclasses
+(Invert, Differentiate, DoubleDifferentiate, Integrate, Log, Ln)
+for use in NMChannel and NMStatsWin transform pipelines.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+
+from pyneuromatic.core.nm_scale import NMScaleX
+import pyneuromatic.core.nm_utilities as nmu
+
+
+class NMTransform:
+    """Base class for data transforms.
+
+    Lightweight class (does not inherit NMObject) following the NMScaleY
+    pattern. Provides serialization, deepcopy, and an apply() method
+    that subclasses override.
+
+    Transforms operate on numpy ndarrays (y-data) and optionally receive
+    NMScaleX for x-scale information. Simple transforms ignore xscale.
+    """
+
+    _path_suffix: str = "transform"
+
+    def __init__(
+        self,
+        parent: object | None = None,
+    ) -> None:
+        self._parent = parent
+
+    def __repr__(self) -> str:
+        return "%s()" % self.__class__.__name__
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, NMTransform):
+            return self.__class__ == other.__class__
+        if isinstance(other, dict):
+            return self.to_dict() == other
+        return NotImplemented
+
+    def __deepcopy__(self, memo: dict) -> NMTransform:
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for attr, value in self.__dict__.items():
+            if attr == "_parent":
+                setattr(result, attr, None)
+            else:
+                setattr(result, attr, copy.deepcopy(value, memo))
+        return result
+
+    def __getitem__(self, key: str) -> object:
+        d = self.to_dict()
+        if key in d:
+            return d[key]
+        raise KeyError(key)
+
+    @property
+    def path_str(self) -> str:
+        if self._parent is not None and hasattr(self._parent, "path_str"):
+            return self._parent.path_str + "." + self._path_suffix
+        return self._path_suffix
+
+    @property
+    def type_str(self) -> str:
+        """Return the transform type string used for serialization."""
+        return self.__class__.__name__
+
+    def to_dict(self) -> dict:
+        """Serialize this transform to a dict.
+
+        Returns {"type": "ClassName"}. Subclasses with parameters
+        should call super().to_dict() and add their keys.
+        """
+        return {"type": self.type_str}
+
+    def apply(
+        self,
+        ydata: np.ndarray,
+        xscale: NMScaleX | None = None,
+    ) -> np.ndarray:
+        """Apply this transform to y-data.
+
+        Args:
+            ydata: numpy ndarray of y-values.
+            xscale: optional NMScaleX for x-scale info (start, delta).
+
+        Returns:
+            numpy ndarray of transformed y-values.
+
+        Raises:
+            NotImplementedError: if subclass does not override.
+        """
+        raise NotImplementedError(
+            "%s.apply() not implemented" % self.__class__.__name__
+        )
+
+
+# =========================================================================
+# Simple transforms (no parameters)
+# =========================================================================
+
+
+class NMTransformInvert(NMTransform):
+    """Invert (negate) the data: y -> -y."""
+
+    def apply(
+        self,
+        ydata: np.ndarray,
+        xscale: NMScaleX | None = None,
+    ) -> np.ndarray:
+        if not isinstance(ydata, np.ndarray):
+            raise TypeError(nmu.type_error_str(ydata, "ydata", "numpy.ndarray"))
+        return -ydata
+
+
+class NMTransformDifferentiate(NMTransform):
+    """First derivative using numpy.gradient (preserves array length).
+
+    Uses np.gradient() which computes central differences for interior
+    points and one-sided differences at boundaries. When xscale is
+    provided, divides by delta for proper dy/dx units.
+    """
+
+    def apply(
+        self,
+        ydata: np.ndarray,
+        xscale: NMScaleX | None = None,
+    ) -> np.ndarray:
+        if not isinstance(ydata, np.ndarray):
+            raise TypeError(nmu.type_error_str(ydata, "ydata", "numpy.ndarray"))
+        if xscale is not None and isinstance(xscale, NMScaleX):
+            return np.gradient(ydata, xscale.delta)
+        return np.gradient(ydata)
+
+
+class NMTransformDoubleDifferentiate(NMTransform):
+    """Second derivative: apply np.gradient twice."""
+
+    def apply(
+        self,
+        ydata: np.ndarray,
+        xscale: NMScaleX | None = None,
+    ) -> np.ndarray:
+        if not isinstance(ydata, np.ndarray):
+            raise TypeError(nmu.type_error_str(ydata, "ydata", "numpy.ndarray"))
+        if xscale is not None and isinstance(xscale, NMScaleX):
+            d1 = np.gradient(ydata, xscale.delta)
+            return np.gradient(d1, xscale.delta)
+        d1 = np.gradient(ydata)
+        return np.gradient(d1)
+
+
+class NMTransformIntegrate(NMTransform):
+    """Cumulative integration using numpy.cumsum.
+
+    When xscale is provided, multiplies by delta for proper units.
+    """
+
+    def apply(
+        self,
+        ydata: np.ndarray,
+        xscale: NMScaleX | None = None,
+    ) -> np.ndarray:
+        if not isinstance(ydata, np.ndarray):
+            raise TypeError(nmu.type_error_str(ydata, "ydata", "numpy.ndarray"))
+        result = np.cumsum(ydata)
+        if xscale is not None and isinstance(xscale, NMScaleX):
+            result = result * xscale.delta
+        return result
+
+
+class NMTransformLog(NMTransform):
+    """Base-10 logarithm: y -> log10(y).
+
+    Values <= 0 produce -inf (zero) or NaN (negative).
+    """
+
+    def apply(
+        self,
+        ydata: np.ndarray,
+        xscale: NMScaleX | None = None,
+    ) -> np.ndarray:
+        if not isinstance(ydata, np.ndarray):
+            raise TypeError(nmu.type_error_str(ydata, "ydata", "numpy.ndarray"))
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return np.log10(ydata)
+
+
+class NMTransformLn(NMTransform):
+    """Natural logarithm: y -> ln(y).
+
+    Values <= 0 produce -inf (zero) or NaN (negative).
+    """
+
+    def apply(
+        self,
+        ydata: np.ndarray,
+        xscale: NMScaleX | None = None,
+    ) -> np.ndarray:
+        if not isinstance(ydata, np.ndarray):
+            raise TypeError(nmu.type_error_str(ydata, "ydata", "numpy.ndarray"))
+        with np.errstate(divide="ignore", invalid="ignore"):
+            return np.log(ydata)
+
+
+# =========================================================================
+# Registry and helper functions
+# =========================================================================
+
+
+_TRANSFORM_REGISTRY: dict[str, type[NMTransform]] = {
+    "NMTransformInvert": NMTransformInvert,
+    "NMTransformDifferentiate": NMTransformDifferentiate,
+    "NMTransformDoubleDifferentiate": NMTransformDoubleDifferentiate,
+    "NMTransformIntegrate": NMTransformIntegrate,
+    "NMTransformLog": NMTransformLog,
+    "NMTransformLn": NMTransformLn,
+}
+
+
+def _transform_from_dict(
+    d: dict,
+    parent: object | None = None,
+) -> NMTransform:
+    """Reconstruct an NMTransform from a dict.
+
+    Args:
+        d: Dict with at least a "type" key naming the transform class.
+        parent: Optional parent reference.
+
+    Returns:
+        An NMTransform instance.
+
+    Raises:
+        TypeError: if d is not a dict.
+        KeyError: if "type" key is missing.
+        ValueError: if type string is not in the registry.
+    """
+    if not isinstance(d, dict):
+        raise TypeError(nmu.type_error_str(d, "d", "dict"))
+    if "type" not in d:
+        raise KeyError("missing key 'type' in transform dict")
+    type_str = d["type"]
+    if type_str not in _TRANSFORM_REGISTRY:
+        raise ValueError("unknown transform type: '%s'" % type_str)
+    cls = _TRANSFORM_REGISTRY[type_str]
+    return cls(parent=parent)
+
+
+def _transforms_from_list(
+    transform_list: list[dict] | None,
+    parent: object | None = None,
+) -> list[NMTransform] | None:
+    """Reconstruct a list of NMTransform objects from a list of dicts.
+
+    Args:
+        transform_list: List of transform dicts, or None.
+        parent: Optional parent reference.
+
+    Returns:
+        List of NMTransform instances, or None.
+    """
+    if transform_list is None:
+        return None
+    if not isinstance(transform_list, list):
+        raise TypeError(
+            nmu.type_error_str(transform_list, "transform_list", "list")
+        )
+    return [_transform_from_dict(d, parent=parent) for d in transform_list]
+
+
+def apply_transforms(
+    ydata: np.ndarray,
+    transforms: list[NMTransform] | None,
+    xscale: NMScaleX | None = None,
+) -> np.ndarray:
+    """Apply an ordered list of transforms to y-data.
+
+    Args:
+        ydata: numpy ndarray of y-values.
+        transforms: ordered list of NMTransform objects, or None.
+        xscale: optional NMScaleX for x-scale info.
+
+    Returns:
+        Transformed numpy ndarray (copy; original is never modified).
+    """
+    if not isinstance(ydata, np.ndarray):
+        raise TypeError(nmu.type_error_str(ydata, "ydata", "numpy.ndarray"))
+    if transforms is None or len(transforms) == 0:
+        return ydata
+    result = ydata.copy()
+    for t in transforms:
+        if not isinstance(t, NMTransform):
+            raise TypeError(nmu.type_error_str(t, "transform", "NMTransform"))
+        result = t.apply(result, xscale=xscale)
+    return result

--- a/tests/test_analysis/test_nm_stats.py
+++ b/tests/test_analysis/test_nm_stats.py
@@ -254,8 +254,59 @@ class NMStatsTest(unittest.TestCase):
         self.w0._x_set("bsln_x1", 99)
         self.assertEqual(self.w0.bsln_x1, 99)
 
-    def xtest07_statswin_transform(self):
-        pass  # TODO
+    def test07_statswin_transform(self):
+        from pyneuromatic.core.nm_transform import (
+            NMTransform,
+            NMTransformInvert,
+            NMTransformLog,
+            NMTransformLn,
+        )
+
+        # Default is None
+        self.assertIsNone(self.w0.transform)
+
+        # Set with NMTransform objects
+        transforms = [NMTransformInvert(), NMTransformLog()]
+        self.w0.transform = transforms
+        self.assertEqual(len(self.w0.transform), 2)
+        self.assertIsInstance(self.w0.transform[0], NMTransformInvert)
+        self.assertIsInstance(self.w0.transform[1], NMTransformLog)
+
+        # Set with dicts (should auto-convert)
+        self.w0.transform = [
+            {"type": "NMTransformInvert"},
+            {"type": "NMTransformLn"},
+        ]
+        self.assertEqual(len(self.w0.transform), 2)
+        self.assertIsInstance(self.w0.transform[0], NMTransformInvert)
+        self.assertIsInstance(self.w0.transform[1], NMTransformLn)
+
+        # win property should serialize to dicts
+        win = self.w0.win
+        self.assertIsInstance(win["transform"], list)
+        self.assertEqual(win["transform"][0], {"type": "NMTransformInvert"})
+        self.assertEqual(win["transform"][1], {"type": "NMTransformLn"})
+
+        # Round-trip: win dict -> new NMStatsWin
+        from pyneuromatic.analysis.nm_tool_stats import NMStatsWin
+        w2 = NMStatsWin(win=win)
+        self.assertIsNotNone(w2.transform)
+        self.assertEqual(len(w2.transform), 2)
+        self.assertIsInstance(w2.transform[0], NMTransformInvert)
+        self.assertIsInstance(w2.transform[1], NMTransformLn)
+
+        # Set to None
+        self.w0.transform = None
+        self.assertIsNone(self.w0.transform)
+
+        # win property with None transform
+        win = self.w0.win
+        self.assertIsNone(win["transform"])
+
+        # Type errors
+        for b in nmu.badtypes(ok=[None, []]):
+            with self.assertRaises(TypeError):
+                self.w0.transform = b
 
     def test08_statswin_bsln_func(self):
         self.assertTrue(isinstance(self.w1.bsln_func, dict))

--- a/tests/test_core/test_nm_transform.py
+++ b/tests/test_core/test_nm_transform.py
@@ -1,0 +1,385 @@
+# -*- coding: utf-8 -*-
+"""Tests for NMTransform classes."""
+import copy
+import unittest
+
+import numpy as np
+
+from pyneuromatic.core.nm_scale import NMScaleX
+from pyneuromatic.core.nm_transform import (
+    NMTransform,
+    NMTransformInvert,
+    NMTransformDifferentiate,
+    NMTransformDoubleDifferentiate,
+    NMTransformIntegrate,
+    NMTransformLog,
+    NMTransformLn,
+    _transform_from_dict,
+    _transforms_from_list,
+    apply_transforms,
+)
+
+
+class TestNMTransform(unittest.TestCase):
+    """Tests for the NMTransform base class (tested via concrete subclasses)."""
+
+    def test_init_defaults(self):
+        t = NMTransformInvert()
+        self.assertIsNone(t._parent)
+
+    def test_init_with_parent(self):
+        parent = object()
+        t = NMTransformInvert(parent=parent)
+        self.assertIs(t._parent, parent)
+
+    def test_base_apply_raises(self):
+        t = NMTransform()
+        with self.assertRaises(NotImplementedError):
+            t.apply(np.array([1.0, 2.0]))
+
+    def test_repr(self):
+        t = NMTransformInvert()
+        self.assertEqual(repr(t), "NMTransformInvert()")
+
+    def test_type_str(self):
+        t = NMTransformInvert()
+        self.assertEqual(t.type_str, "NMTransformInvert")
+
+    def test_to_dict(self):
+        t = NMTransformInvert()
+        self.assertEqual(t.to_dict(), {"type": "NMTransformInvert"})
+
+    def test_getitem(self):
+        t = NMTransformInvert()
+        self.assertEqual(t["type"], "NMTransformInvert")
+        with self.assertRaises(KeyError):
+            t["nonexistent"]
+
+    def test_eq_same_type(self):
+        t1 = NMTransformInvert()
+        t2 = NMTransformInvert()
+        self.assertEqual(t1, t2)
+
+    def test_eq_different_type(self):
+        t1 = NMTransformInvert()
+        t2 = NMTransformLog()
+        self.assertNotEqual(t1, t2)
+
+    def test_eq_dict(self):
+        t = NMTransformInvert()
+        self.assertEqual(t, {"type": "NMTransformInvert"})
+        self.assertNotEqual(t, {"type": "NMTransformLog"})
+
+    def test_eq_wrong_type(self):
+        t = NMTransformInvert()
+        self.assertEqual(t.__eq__(42), NotImplemented)
+
+    def test_deepcopy(self):
+        parent = object()
+        t = NMTransformInvert(parent=parent)
+        t2 = copy.deepcopy(t)
+        self.assertIsInstance(t2, NMTransformInvert)
+        self.assertIsNone(t2._parent)
+
+    def test_path_str_no_parent(self):
+        t = NMTransformInvert()
+        self.assertEqual(t.path_str, "transform")
+
+    def test_path_str_with_parent(self):
+        class FakeParent:
+            @property
+            def path_str(self):
+                return "folder0.data0"
+
+        t = NMTransformInvert(parent=FakeParent())
+        self.assertEqual(t.path_str, "folder0.data0.transform")
+
+
+class TestNMTransformInvert(unittest.TestCase):
+    """Tests for NMTransformInvert."""
+
+    def test_apply_basic(self):
+        t = NMTransformInvert()
+        y = np.array([1.0, -2.0, 3.0, 0.0])
+        result = t.apply(y)
+        np.testing.assert_array_equal(result, np.array([-1.0, 2.0, -3.0, -0.0]))
+
+    def test_apply_does_not_modify_input(self):
+        t = NMTransformInvert()
+        y = np.array([1.0, 2.0, 3.0])
+        y_orig = y.copy()
+        t.apply(y)
+        np.testing.assert_array_equal(y, y_orig)
+
+    def test_apply_with_nans(self):
+        t = NMTransformInvert()
+        y = np.array([1.0, np.nan, 3.0])
+        result = t.apply(y)
+        self.assertEqual(result[0], -1.0)
+        self.assertTrue(np.isnan(result[1]))
+        self.assertEqual(result[2], -3.0)
+
+    def test_apply_type_error(self):
+        t = NMTransformInvert()
+        with self.assertRaises(TypeError):
+            t.apply([1.0, 2.0])
+
+    def test_apply_ignores_xscale(self):
+        t = NMTransformInvert()
+        y = np.array([1.0, 2.0])
+        xs = NMScaleX(start=0, delta=0.1)
+        result = t.apply(y, xscale=xs)
+        np.testing.assert_array_equal(result, np.array([-1.0, -2.0]))
+
+
+class TestNMTransformDifferentiate(unittest.TestCase):
+    """Tests for NMTransformDifferentiate."""
+
+    def test_apply_preserves_length(self):
+        t = NMTransformDifferentiate()
+        y = np.array([0.0, 1.0, 4.0, 9.0, 16.0])
+        result = t.apply(y)
+        self.assertEqual(result.shape, y.shape)
+
+    def test_apply_linear(self):
+        t = NMTransformDifferentiate()
+        y = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        result = t.apply(y)
+        np.testing.assert_allclose(result, 1.0)
+
+    def test_apply_with_xscale(self):
+        t = NMTransformDifferentiate()
+        y = np.array([0.0, 0.5, 1.0, 1.5, 2.0])
+        xs = NMScaleX(start=0, delta=0.5)
+        result = t.apply(y, xscale=xs)
+        # dy/dx = 0.5/0.5 = 1.0
+        np.testing.assert_allclose(result, 1.0)
+
+    def test_apply_type_error(self):
+        t = NMTransformDifferentiate()
+        with self.assertRaises(TypeError):
+            t.apply("not an array")
+
+
+class TestNMTransformDoubleDifferentiate(unittest.TestCase):
+    """Tests for NMTransformDoubleDifferentiate."""
+
+    def test_apply_quadratic(self):
+        t = NMTransformDoubleDifferentiate()
+        # unit spacing: x = 0, 1, 2, ... so d2(x^2)/dx2 = 2
+        x = np.arange(0, 20, dtype=float)
+        y = x ** 2
+        result = t.apply(y)
+        # interior points should be exactly 2.0
+        np.testing.assert_allclose(result[2:-2], 2.0, atol=0.01)
+
+    def test_apply_with_xscale(self):
+        t = NMTransformDoubleDifferentiate()
+        x = np.arange(0, 5, 0.1)
+        y = x ** 2
+        xs = NMScaleX(start=0, delta=0.1)
+        result = t.apply(y, xscale=xs)
+        np.testing.assert_allclose(result[5:-5], 2.0, atol=0.1)
+
+    def test_apply_preserves_length(self):
+        t = NMTransformDoubleDifferentiate()
+        y = np.array([0.0, 1.0, 4.0, 9.0, 16.0])
+        result = t.apply(y)
+        self.assertEqual(result.shape, y.shape)
+
+
+class TestNMTransformIntegrate(unittest.TestCase):
+    """Tests for NMTransformIntegrate."""
+
+    def test_apply_basic(self):
+        t = NMTransformIntegrate()
+        y = np.array([1.0, 1.0, 1.0, 1.0])
+        result = t.apply(y)
+        np.testing.assert_array_equal(result, np.array([1.0, 2.0, 3.0, 4.0]))
+
+    def test_apply_with_xscale(self):
+        t = NMTransformIntegrate()
+        y = np.array([1.0, 1.0, 1.0, 1.0])
+        xs = NMScaleX(start=0, delta=0.5)
+        result = t.apply(y, xscale=xs)
+        np.testing.assert_array_equal(result, np.array([0.5, 1.0, 1.5, 2.0]))
+
+    def test_apply_preserves_length(self):
+        t = NMTransformIntegrate()
+        y = np.array([1.0, 2.0, 3.0])
+        result = t.apply(y)
+        self.assertEqual(result.shape, y.shape)
+
+    def test_apply_type_error(self):
+        t = NMTransformIntegrate()
+        with self.assertRaises(TypeError):
+            t.apply(42)
+
+
+class TestNMTransformLog(unittest.TestCase):
+    """Tests for NMTransformLog (base-10)."""
+
+    def test_apply_basic(self):
+        t = NMTransformLog()
+        y = np.array([1.0, 10.0, 100.0, 1000.0])
+        result = t.apply(y)
+        np.testing.assert_allclose(result, np.array([0.0, 1.0, 2.0, 3.0]))
+
+    def test_apply_zero_produces_neginf(self):
+        t = NMTransformLog()
+        y = np.array([0.0, 1.0])
+        result = t.apply(y)
+        self.assertTrue(np.isneginf(result[0]))
+
+    def test_apply_negative_produces_nan(self):
+        t = NMTransformLog()
+        y = np.array([-1.0, 1.0])
+        result = t.apply(y)
+        self.assertTrue(np.isnan(result[0]))
+
+    def test_apply_type_error(self):
+        t = NMTransformLog()
+        with self.assertRaises(TypeError):
+            t.apply(42)
+
+
+class TestNMTransformLn(unittest.TestCase):
+    """Tests for NMTransformLn (natural log)."""
+
+    def test_apply_basic(self):
+        t = NMTransformLn()
+        y = np.array([1.0, np.e, np.e ** 2])
+        result = t.apply(y)
+        np.testing.assert_allclose(result, np.array([0.0, 1.0, 2.0]))
+
+    def test_apply_zero_produces_neginf(self):
+        t = NMTransformLn()
+        y = np.array([0.0])
+        result = t.apply(y)
+        self.assertTrue(np.isneginf(result[0]))
+
+    def test_apply_negative_produces_nan(self):
+        t = NMTransformLn()
+        y = np.array([-1.0])
+        result = t.apply(y)
+        self.assertTrue(np.isnan(result[0]))
+
+
+class TestTransformFromDict(unittest.TestCase):
+    """Tests for _transform_from_dict."""
+
+    def test_invert(self):
+        t = _transform_from_dict({"type": "NMTransformInvert"})
+        self.assertIsInstance(t, NMTransformInvert)
+
+    def test_all_types(self):
+        types = [
+            ("NMTransformInvert", NMTransformInvert),
+            ("NMTransformDifferentiate", NMTransformDifferentiate),
+            ("NMTransformDoubleDifferentiate", NMTransformDoubleDifferentiate),
+            ("NMTransformIntegrate", NMTransformIntegrate),
+            ("NMTransformLog", NMTransformLog),
+            ("NMTransformLn", NMTransformLn),
+        ]
+        for type_str, cls in types:
+            t = _transform_from_dict({"type": type_str})
+            self.assertIsInstance(t, cls)
+
+    def test_missing_type_key(self):
+        with self.assertRaises(KeyError):
+            _transform_from_dict({"name": "invert"})
+
+    def test_unknown_type(self):
+        with self.assertRaises(ValueError):
+            _transform_from_dict({"type": "UnknownTransform"})
+
+    def test_type_error(self):
+        with self.assertRaises(TypeError):
+            _transform_from_dict("not a dict")
+
+    def test_parent_set(self):
+        parent = object()
+        t = _transform_from_dict({"type": "NMTransformInvert"}, parent=parent)
+        self.assertIs(t._parent, parent)
+
+    def test_round_trip(self):
+        original = NMTransformDifferentiate()
+        d = original.to_dict()
+        restored = _transform_from_dict(d)
+        self.assertEqual(original, restored)
+
+
+class TestTransformsFromList(unittest.TestCase):
+    """Tests for _transforms_from_list."""
+
+    def test_none_returns_none(self):
+        self.assertIsNone(_transforms_from_list(None))
+
+    def test_empty_list(self):
+        result = _transforms_from_list([])
+        self.assertEqual(result, [])
+
+    def test_list_of_dicts(self):
+        dicts = [
+            {"type": "NMTransformInvert"},
+            {"type": "NMTransformLog"},
+        ]
+        result = _transforms_from_list(dicts)
+        self.assertEqual(len(result), 2)
+        self.assertIsInstance(result[0], NMTransformInvert)
+        self.assertIsInstance(result[1], NMTransformLog)
+
+    def test_type_error(self):
+        with self.assertRaises(TypeError):
+            _transforms_from_list("not a list")
+
+
+class TestApplyTransforms(unittest.TestCase):
+    """Tests for apply_transforms."""
+
+    def test_none_returns_original(self):
+        y = np.array([1.0, 2.0, 3.0])
+        result = apply_transforms(y, None)
+        np.testing.assert_array_equal(result, y)
+
+    def test_empty_list_returns_original(self):
+        y = np.array([1.0, 2.0, 3.0])
+        result = apply_transforms(y, [])
+        np.testing.assert_array_equal(result, y)
+
+    def test_single_transform(self):
+        y = np.array([1.0, -2.0, 3.0])
+        result = apply_transforms(y, [NMTransformInvert()])
+        np.testing.assert_array_equal(result, np.array([-1.0, 2.0, -3.0]))
+
+    def test_pipeline_double_invert(self):
+        y = np.array([10.0, 100.0])
+        transforms = [NMTransformInvert(), NMTransformInvert()]
+        result = apply_transforms(y, transforms)
+        np.testing.assert_array_equal(result, y)
+
+    def test_does_not_modify_input(self):
+        y = np.array([1.0, 2.0, 3.0])
+        y_orig = y.copy()
+        apply_transforms(y, [NMTransformInvert()])
+        np.testing.assert_array_equal(y, y_orig)
+
+    def test_type_error_ydata(self):
+        with self.assertRaises(TypeError):
+            apply_transforms([1, 2, 3], [NMTransformInvert()])
+
+    def test_type_error_transform_item(self):
+        y = np.array([1.0, 2.0])
+        with self.assertRaises(TypeError):
+            apply_transforms(y, ["not a transform"])
+
+    def test_with_xscale(self):
+        y = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        xs = NMScaleX(start=0, delta=0.5)
+        result = apply_transforms(y, [NMTransformDifferentiate()], xscale=xs)
+        # dy/dx = 1/0.5 = 2.0
+        np.testing.assert_allclose(result, 2.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `NMTransform` base class and 6 simple transform subclasses (Invert, Differentiate, DoubleDifferentiate, Integrate, Log, Ln) following the lightweight NMScaleY pattern
- Include registry for dict serialization/deserialization and `apply_transforms()` pipeline function
- Integrate transforms into `NMStatsWin`: replace `list[Any]` with `list[NMTransform]`, implement transform application in `compute()`

## Test plan
- [x] 56 new tests in `test_nm_transform.py` covering base class, all 6 subclasses, registry helpers, and pipeline
- [x] Updated `test_nm_stats.py` with transform integration tests (set, auto-convert from dicts, serialization round-trip, type errors)
- [x] Full test suite passes (885 tests)

Closes #85 