### PR TITLE
refactor(analysis): simplify NMStatsWin — drop NMObject inheritance and clean up

### DIFF
--- a/tests/test_analysis/test_nm_stats.py
+++ b/tests/test_analysis/test_nm_stats.py
@@ -714,7 +714,7 @@ class NMStatsTest(unittest.TestCase):
             nms.check_meanatmaxmin(func)
         with self.assertRaises(KeyError):
             func = {"name": f}
-            nms.check_meanatmaxmin(func, getinput=False)
+            nms.check_meanatmaxmin(func)
 
         for f in ["min", "max", "mean@max", "mean@min"]:
             func = {"name": f, "imean": 10}
@@ -732,31 +732,6 @@ class NMStatsTest(unittest.TestCase):
                 self.assertEqual(p["name"], f)
             self.assertEqual(p["imean"], 10)
 
-    def test94_input_meanatmaxmin(self):
-        # mean@max, mean@min
-        for b in nmu.badtypes(ok=["string"]):
-            with self.assertRaises(TypeError):
-                nms.input_meanatmaxmin(b)
-        with self.assertRaises(ValueError):
-            nms.input_meanatmaxmin("badfuncname")
-        for b in nmu.badtypes(ok=[None, "string"]):
-            with self.assertRaises(TypeError):
-                nms.input_meanatmaxmin("min", test_input=b)
-        for b in ["-10", "nan", "inf"]:
-            with self.assertRaises(ValueError):
-                nms.input_meanatmaxmin("min", test_input=b)
-        i = 10
-        for f in ["max", "mean@max"]:
-            p = nms.input_meanatmaxmin(f, test_input=str(i))
-            self.assertEqual(p["name"], "mean@max")
-            # "max" is changed to "mean@max"
-            self.assertEqual(p["imean"], i)
-        for f in ["min", "mean@min"]:
-            p = nms.input_meanatmaxmin(f, test_input=str(i))
-            self.assertEqual(p["name"], "mean@min")
-            # "min" is changed to "mean@min"
-            self.assertEqual(p["imean"], i)
-
     def test95_check_level(self):
         f = "level"
         for b in nmu.badtypes(ok=[{}, "string"]):
@@ -773,7 +748,7 @@ class NMStatsTest(unittest.TestCase):
             nms.check_level(func)
         with self.assertRaises(KeyError):
             func = {"name": f}
-            nms.check_level(func, getinput=False)
+            nms.check_level(func)
 
         for b in nmu.badtypes(ok=["string"]):
             with self.assertRaises(TypeError):
@@ -839,52 +814,13 @@ class NMStatsTest(unittest.TestCase):
 
         with self.assertRaises(KeyError):
             func = {"name": f}
-            nms.check_level(func, getinput=False)
+            nms.check_level(func)
         with self.assertRaises(KeyError):
             func = {"name": f}
-            nms.check_level(func, option=1, getinput=False)
+            nms.check_level(func, option=1)
         func = {"name": f, "ylevel": 10}
-        p = nms.check_level(func, option=3, getinput=False)
+        p = nms.check_level(func, option=3)
         self.assertEqual(p["ylevel"], 10)  # option is ignored
-
-    def test96_input_level(self):
-        f = "level"
-        for b in nmu.badtypes(ok=["string"]):
-            with self.assertRaises(TypeError):
-                nms.input_level(b)
-        with self.assertRaises(ValueError):
-            nms.input_level("badfuncname")
-
-        for b in nmu.badtypes(ok=[None, "string"]):
-            with self.assertRaises(TypeError):
-                nms.input_level(f, option=1, test_input=b)
-            with self.assertRaises(TypeError):
-                nms.input_level(f, option=2, test_input=b)
-            with self.assertRaises(TypeError):
-                nms.input_level(f, option=3, test_input=b)
-            with self.assertRaises(TypeError):
-                nms.input_level(f, option=0, test_input=b)
-        with self.assertRaises(ValueError):
-            nms.input_level(f, option=0, test_input="10")
-
-        for b in ["nan", "inf"]:
-            with self.assertRaises(ValueError):
-                nms.input_level(f, option=1, test_input=b)
-            with self.assertRaises(ValueError):
-                nms.input_level(f, option=2, test_input=b)
-            with self.assertRaises(ValueError):
-                nms.input_level(f, option=3, test_input=b)
-        i = 10
-        for f in ["level", "level+", "level-"]:
-            p = nms.input_level(f, option=1, test_input=str(i))
-            self.assertEqual(p["name"], f)
-            self.assertEqual(p["ylevel"], i)
-            p = nms.input_level(f, option=2, test_input=str(i))
-            self.assertEqual(p["name"], f)
-            self.assertEqual(p["nstd"], i)
-            p = nms.input_level(f, option=3, test_input=str(i))
-            self.assertEqual(p["name"], f)
-            self.assertEqual(p["nstd"], -i)
 
     def test97_check_risefall(self):
         f = "risetime+"
@@ -902,13 +838,13 @@ class NMStatsTest(unittest.TestCase):
             nms.check_risefall(func)
         with self.assertRaises(KeyError):
             func = {"name": f}  # need p0 and p1 keys
-            nms.check_risefall(func, getinput=False)
+            nms.check_risefall(func)
         with self.assertRaises(KeyError):
-            func = {"name": f, "p0": 10}  # need p1 keys
-            nms.check_risefall(func, getinput=False)
+            func = {"name": f, "p0": 10}  # need p1 key
+            nms.check_risefall(func)
         with self.assertRaises(KeyError):
-            func = {"name": f, "p1": 90}  # need p1 keys
-            nms.check_risefall(func, getinput=False)
+            func = {"name": f, "p1": 90}  # need p0 key
+            nms.check_risefall(func)
 
         for b in nmu.badtypes(ok=["string"]):
             with self.assertRaises(TypeError):
@@ -973,41 +909,6 @@ class NMStatsTest(unittest.TestCase):
             p = nms.check_risefall(func)
             self.assertEqual(p["p0"], 36)
             self.assertEqual(p["p1"], None)
-
-    def test98_input_risefall(self):
-        f = "risetime+"
-        for b in nmu.badtypes(ok=["string"]):
-            with self.assertRaises(TypeError):
-                nms.input_risefall(b)
-        with self.assertRaises(ValueError):
-            nms.input_risefall("badfuncname")
-        for b in nmu.badtypes(ok=[None, "string"]):
-            with self.assertRaises(TypeError):
-                nms.input_risefall(f, test_input=b)
-        for b in ["-10", "nan", "inf"]:
-            with self.assertRaises(ValueError):
-                nms.input_risefall(f, test_input=b)
-
-        options = {1: [5, 95], 2: [10, 90], 3: [15, 85], 4: [20, 80]}
-        for f in ["risetime+", "risetime-", "risetimeslope+",
-                  "risetimeslope-"]:
-            for k, v in options.items():
-                p = nms.input_risefall(f, test_input=str(k))
-                self.assertEqual(p["name"], f)
-                self.assertEqual(p["p0"], v[0])
-                self.assertEqual(p["p1"], v[1])
-        options = {1: [95, 5], 2: [90, 10], 3: [85, 15], 4: [80, 20],
-                   5: [36.79, None]}
-        for f in ["falltime+", "falltime-", "falltimeslope+",
-                  "falltimeslope-"]:
-            for k, v in options.items():
-                p = nms.input_risefall(f, test_input=str(k))
-                self.assertEqual(p["name"], f)
-                self.assertEqual(p["p0"], v[0])
-                if v[1] is None:
-                    self.assertTrue(numpy.isnan(p["p1"]))
-                else:
-                    self.assertEqual(p["p1"], v[1])
 
     def test99_check_fwhm(self):
         for b in nmu.badtypes(ok=[{}, "string"]):


### PR DESCRIPTION
## Summary

- Drop NMObject/NMObjectContainer inheritance from NMStatsWin/NMStatsWinContainer — replace with lightweight standalone classes following the NMScaleY/NMTransform pattern
- Add _run_stat helper to eliminate repeated result-dict boilerplate in compute()
- Collapse 4-way main stats dispatch and simplify rise/fall/fwhm sections
- Consolidate _x_set inf-handling into a single line
- Remove input_meanatmaxmin(), input_level(), input_risefall() — library code should not call input()
- Remove getinput parameter from _func_set, check_meanatmaxmin, check_level, check_risefall

## Test plan

-  All 882 tests pass (python3 -m pytest tests/ -x -v)
-  Stats-specific tests pass with input test cases (test94, test96, test98) removed
-  Verified check_* functions now always raise KeyError on missing parameters