### PR TITLE
refactor: rename execute → run in NMTool/NMManager API

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ NMManager (nm)
                             NMEpoch ('E0', 'E1', 'E2'...)
 ```
 
-### Selection and Execution (✅ Implemented)
+### Selection and Run (✅ Implemented)
 
 **Select Items:**
 
@@ -218,9 +218,9 @@ nm.select_values  # or nm.select_keys
 
 Users can perform tasks on selected items, such as baselining or filtering.
 
-**Execute Items:**
+**Run Items:**
 
-Each `NMObjectContainer` has one 'execute' item. By default, this is the 'select' item, but users can set the execute item to a container key (e.g., `nm.projects.execute_key = 'project0'`) or a `NMSet` (e.g., `nm.projects.execute_key = 'set3'`).
+Each `NMObjectContainer` has one 'run' item. By default, this is the 'select' item, but users can set the run item to a container key (e.g., `nm.projects.run_key = 'project0'`) or a `NMSet` (e.g., `nm.projects.run_key = 'set3'`).
 
 ### Analysis Tools
 

--- a/README.md.old
+++ b/README.md.old
@@ -86,7 +86,7 @@ NM's container tree hierarchy is as follows:
 
 In the future, users will be able to instruct NM to perform a given task on the selected items, such as baselining or filtering.
 
-(3) NM container 'execute' items. Each NMObjectContainer has one 'execute' item. By default the execute item is the 'select' item, just described (2). However, users have the option to set the 'execute' item to a NM container key (e.g. nm.projects.execute_key = 'project0') or a NMSet (e.g. nm.projects.execute_key = 'set3').
+(3) NM container 'run' items. Each NMObjectContainer has one 'run' item. By default the run item is the 'select' item, just described (2). However, users have the option to set the 'run' item to a NM container key (e.g. nm.projects.run_key = 'project0') or a NMSet (e.g. nm.projects.run_key = 'set3').
 
 (4) GUI built with pyQt6 and channel graphs.
 

--- a/pip-wheel-metadata/pyNeuroMatic-0.0.1.dist-info/METADATA
+++ b/pip-wheel-metadata/pyNeuroMatic-0.0.1.dist-info/METADATA
@@ -120,7 +120,7 @@ NM's container tree hierarchy is as follows:
 
 In the future, users will be able to instruct NM to perform a given task on the selected items, such as baselining or filtering.
 
-(3) NM container 'execute' items. Each NMObjectContainer has one 'execute' item. By default the execute item is the 'select' item, just described (2). However, users have the option to set the 'execute' item to a NM container key (e.g. nm.projects.execute_key = 'project0') or a NMSet (e.g. nm.projects.execute_key = 'set3').
+(3) NM container 'run' items. Each NMObjectContainer has one 'run' item. By default the 'run' item is the 'select' item, just described (2). However, users have the option to set the 'run' item to a NM container key (e.g. nm.projects.run_key = 'project0') or a NMSet (e.g. nm.projects.run_key = 'set3').
 
 (4) GUI built with pyQt6 and channel graphs.
 

--- a/pyneuromatic/analysis/nm_tool.py
+++ b/pyneuromatic/analysis/nm_tool.py
@@ -34,15 +34,15 @@ class NMTool:
     NM Tool - Base class for analysis tools.
 
     Tools receive selection state from NMManager via select_values and
-    perform analysis during execute(). Subclasses override execute()
-    to implement specific analysis.
+    perform analysis during run(). Subclasses override run() to implement
+    specific analysis.
 
     Selection is set by NMManager - tools have read-only access to
     individual levels (folder, data, dataseries, channel, epoch).
 
     Example:
         class MyTool(NMTool):
-            def execute(self) -> bool:
+            def run(self) -> bool:
                 data = self.dataseries.get_data(self.channel, self.epoch)
                 # analyze data...
                 return True
@@ -94,7 +94,7 @@ class NMTool:
         """
         Set selection from a dictionary of NMObjects.
 
-        Called by NMManager.execute_tool() to set the context for execution.
+        Called by NMManager.run_tool() to set the context for run execution.
 
         Args:
             values: Dictionary mapping level names to NMObjects.
@@ -112,15 +112,15 @@ class NMTool:
             for level, obj in self._select.items()
         }
 
-    def execute_init(self) -> bool:
-        """Called once before execute loop. Override in subclass."""
+    def run_init(self) -> bool:
+        """Called once before run loop. Override in subclass."""
         return True
 
-    def execute(self) -> bool:
-        """Called for each execution target. Override in subclass."""
+    def run(self) -> bool:
+        """Called for each run target. Override in subclass."""
         print(self.select_keys)
         return True
 
-    def execute_finish(self) -> bool:
-        """Called once after execute loop. Override in subclass."""
+    def run_finish(self) -> bool:
+        """Called once after run loop. Override in subclass."""
         return True

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -813,13 +813,13 @@ class NMToolStats(NMTool):
             raise TypeError(e)
 
     # override, no super
-    def execute_init(self) -> bool:
+    def run_init(self) -> bool:
         if isinstance(self.__results, dict):
             self.__results.clear()
         return True  # ok
 
     # override, no super
-    def execute(self) -> bool:
+    def run(self) -> bool:
         if not isinstance(self.data, NMData):
             raise RuntimeError("no data selected")
         for w in self.windows:
@@ -838,7 +838,7 @@ class NMToolStats(NMTool):
         return True  # ok
 
     # override, no super
-    def execute_finish(self) -> bool:
+    def run_finish(self) -> bool:
         NMToolStats.results_print(self.__results)
         self.results_save()
         self.results_save_as_numpy()

--- a/tests/test_analysis/test_nm_tool.py
+++ b/tests/test_analysis/test_nm_tool.py
@@ -224,40 +224,40 @@ class TestNMToolSelectKeys(unittest.TestCase):
         self.assertEqual(set(keys.keys()), set(SELECT_LEVELS))
 
 
-class TestNMToolExecuteMethods(unittest.TestCase):
-    """Tests for NMTool execute methods."""
+class TestNMToolRunMethods(unittest.TestCase):
+    """Tests for NMTool run methods."""
 
-    def test_execute_init_returns_true(self):
+    def test_run_init_returns_true(self):
         tool = NMTool()
-        self.assertTrue(tool.execute_init())
+        self.assertTrue(tool.run_init())
 
-    def test_execute_returns_true(self):
+    def test_run_returns_true(self):
         tool = NMTool()
-        self.assertTrue(tool.execute())
+        self.assertTrue(tool.run())
 
-    def test_execute_finish_returns_true(self):
+    def test_run_finish_returns_true(self):
         tool = NMTool()
-        self.assertTrue(tool.execute_finish())
+        self.assertTrue(tool.run_finish())
 
 
 class TestNMToolSubclass(unittest.TestCase):
     """Tests for NMTool subclassing."""
 
-    def test_subclass_can_override_execute(self):
+    def test_subclass_can_override_run(self):
         class CustomTool(NMTool):
             def __init__(self):
                 super().__init__()
-                self.executed = False
+                self.run_finished = False
 
-            def execute(self) -> bool:
-                self.executed = True
+            def run(self) -> bool:
+                self.run_finished = True
                 return True
 
         tool = CustomTool()
-        self.assertFalse(tool.executed)
-        result = tool.execute()
+        self.assertFalse(tool.run_finished)
+        result = tool.run()
         self.assertTrue(result)
-        self.assertTrue(tool.executed)
+        self.assertTrue(tool.run_finished)
 
     def test_subclass_can_access_selection(self):
         nm = NMManager(quiet=QUIET)
@@ -266,37 +266,37 @@ class TestNMToolSubclass(unittest.TestCase):
         assert isinstance(folder, NMFolder)
 
         class CustomTool(NMTool):
-            def execute(self) -> bool:
+            def run(self) -> bool:
                 return self.folder is not None
 
         tool = CustomTool()
         tool._select["folder"] = folder
 
-        self.assertTrue(tool.execute())
+        self.assertTrue(tool.run())
         self.assertEqual(tool.folder.name, "test_folder")
 
-    def test_subclass_execute_init_called_before_execute(self):
+    def test_subclass_run_init_called_before_run(self):
         call_order = []
 
         class CustomTool(NMTool):
-            def execute_init(self) -> bool:
+            def run_init(self) -> bool:
                 call_order.append("init")
                 return True
 
-            def execute(self) -> bool:
-                call_order.append("execute")
+            def run(self) -> bool:
+                call_order.append("run")
                 return True
 
-            def execute_finish(self) -> bool:
+            def run_finish(self) -> bool:
                 call_order.append("finish")
                 return True
 
         tool = CustomTool()
-        tool.execute_init()
-        tool.execute()
-        tool.execute_finish()
+        tool.run_init()
+        tool.run()
+        tool.run_finish()
 
-        self.assertEqual(call_order, ["init", "execute", "finish"])
+        self.assertEqual(call_order, ["init", "run", "finish"])
 
 
 class TestNMToolIntegration(unittest.TestCase):

--- a/tests/test_core/test_nm_manager.py
+++ b/tests/test_core/test_nm_manager.py
@@ -203,122 +203,122 @@ class TestNMManagerSelect(NMManagerTestBase):
         self.assertEqual(self.nm.select_keys["dataseries"], "data")
 
 
-class TestNMManagerExecuteKeys(NMManagerTestBase):
-    """Tests for execute_keys and execute_values methods."""
+class TestNMManagerRunKeys(NMManagerTestBase):
+    """Tests for run_keys and run_values methods."""
 
-    def test_execute_keys_returns_selected_dataseries(self):
+    def test_run_keys_returns_selected_dataseries(self):
         s = self.nm.select_keys.copy()
         s.pop("data")
-        elist = self.nm.execute_keys(dataseries_priority=True)
+        elist = self.nm.run_keys(dataseries_priority=True)
         self.assertEqual(elist, [s])
 
-    def test_execute_keys_returns_selected_data(self):
+    def test_run_keys_returns_selected_data(self):
         s = self.nm.select_keys.copy()
         s.pop("dataseries")
         s.pop("channel")
         s.pop("epoch")
-        elist = self.nm.execute_keys(dataseries_priority=False)
+        elist = self.nm.run_keys(dataseries_priority=False)
         self.assertEqual(elist, [s])
 
-    def test_execute_reset_all_restores_selected(self):
-        self.nm.execute_reset_all()
+    def test_run_reset_all_restores_selected(self):
+        self.nm.run_reset_all()
         s = self.nm.select_keys.copy()
         s.pop("data")
-        elist = self.nm.execute_keys(dataseries_priority=True)
+        elist = self.nm.run_keys(dataseries_priority=True)
         self.assertEqual(elist, [s])
 
-    def test_execute_keys_with_folder_set(self):
+    def test_run_keys_with_folder_set(self):
         p = self.nm.project
-        p.folders.execute_target = "set0"
-        elist = self.nm.execute_keys(dataseries_priority=True)
+        p.folders.run_target = "set0"
+        elist = self.nm.run_keys(dataseries_priority=True)
         self.assertEqual(len(elist), 2)  # set0 has folder0 and folder1
 
-    def test_execute_keys_with_folder_all(self):
+    def test_run_keys_with_folder_all(self):
         p = self.nm.project
-        p.folders.execute_target = "all"
-        elist = self.nm.execute_keys(dataseries_priority=True)
+        p.folders.run_target = "all"
+        elist = self.nm.run_keys(dataseries_priority=True)
         self.assertEqual(len(elist), NUMFOLDERS)
 
-    def test_execute_count_returns_target_count(self):
-        self.nm.execute_reset_all()
-        count = self.nm.execute_count(dataseries_priority=True)
+    def test_run_count_returns_target_count(self):
+        self.nm.run_reset_all()
+        count = self.nm.run_count(dataseries_priority=True)
         self.assertEqual(count, 1)
 
-    def test_execute_count_with_all_epochs(self):
+    def test_run_count_with_all_epochs(self):
         e0 = {
             "folder": "folder0",
             "dataseries": "data",
             "channel": "A",
             "epoch": "all",
         }
-        self.nm.execute_keys_set(e0)
-        count = self.nm.execute_count(dataseries_priority=True)
+        self.nm.run_keys_set(e0)
+        count = self.nm.run_count(dataseries_priority=True)
         self.assertEqual(count, NUMEPOCHS[0])
 
 
-class TestNMManagerExecuteKeysSet(NMManagerTestBase):
-    """Tests for execute_keys_set method."""
+class TestNMManagerRunKeysSet(NMManagerTestBase):
+    """Tests for run_keys_set method."""
 
     def test_rejects_non_dict(self):
         bad_types = (None, 3, 3.14, True, [], (), set(), "string")
         for b in bad_types:
             with self.assertRaises(TypeError):
-                self.nm.execute_keys_set(b)
+                self.nm.run_keys_set(b)
 
     def test_rejects_non_string_key(self):
         bad_types = (None, 3, 3.14, True, [], (), {}, set())
         for b in bad_types:
             with self.assertRaises(TypeError):
-                self.nm.execute_keys_set({b: ""})
+                self.nm.run_keys_set({b: ""})
 
     def test_rejects_non_string_value(self):
         bad_types = (None, 3, 3.14, True, [], (), {}, set())
         for b in bad_types:
             with self.assertRaises(TypeError):
-                self.nm.execute_keys_set({"folder": b})
+                self.nm.run_keys_set({"folder": b})
 
     def test_rejects_unknown_key(self):
         with self.assertRaises(KeyError):
-            self.nm.execute_keys_set({"test": ""})
+            self.nm.run_keys_set({"test": ""})
 
     def test_rejects_both_data_and_dataseries(self):
         with self.assertRaises(KeyError):
-            self.nm.execute_keys_set({"data": "", "dataseries": ""})
+            self.nm.run_keys_set({"data": "", "dataseries": ""})
 
     def test_rejects_missing_folder(self):
         e0 = {"dataseries": "stim", "channel": "A", "epoch": "E0"}
         with self.assertRaises(KeyError):
-            self.nm.execute_keys_set(e0)
+            self.nm.run_keys_set(e0)
 
     def test_rejects_missing_data_or_dataseries(self):
         e0 = {"folder": "folder1", "channel": "A", "epoch": "E0"}
         with self.assertRaises(KeyError):
-            self.nm.execute_keys_set(e0)
+            self.nm.run_keys_set(e0)
 
     def test_rejects_data_with_channel(self):
         e0 = {"folder": "folder1", "data": "stim", "channel": "A", "epoch": "E0"}
         with self.assertRaises(KeyError):
-            self.nm.execute_keys_set(e0)
+            self.nm.run_keys_set(e0)
 
     def test_rejects_missing_channel(self):
         e0 = {"folder": "folder1", "dataseries": "stim", "epoch": "E0"}
         with self.assertRaises(KeyError):
-            self.nm.execute_keys_set(e0)
+            self.nm.run_keys_set(e0)
 
     def test_rejects_missing_epoch(self):
         e0 = {"folder": "folder1", "dataseries": "stim", "channel": "A"}
         with self.assertRaises(KeyError):
-            self.nm.execute_keys_set(e0)
+            self.nm.run_keys_set(e0)
 
     def test_rejects_invalid_folder_name(self):
         e0 = {"folder": "test", "dataseries": "stim", "channel": "A", "epoch": "E0"}
         with self.assertRaises(ValueError):
-            self.nm.execute_keys_set(e0)
+            self.nm.run_keys_set(e0)
 
     def test_rejects_invalid_dataseries_name(self):
         e0 = {"folder": "folder1", "dataseries": "test", "channel": "A", "epoch": "E0"}
         with self.assertRaises(ValueError):
-            self.nm.execute_keys_set(e0)
+            self.nm.run_keys_set(e0)
 
     def test_sets_specific_targets(self):
         e0 = {
@@ -327,18 +327,18 @@ class TestNMManagerExecuteKeysSet(NMManagerTestBase):
             "channel": "A",
             "epoch": "E0",
         }
-        elist = self.nm.execute_keys_set(e0)
+        elist = self.nm.run_keys_set(e0)
         self.assertEqual(elist, [e0])
 
     def test_selected_uses_current_selection(self):
-        self.nm.execute_reset_all()
+        self.nm.run_reset_all()
         e1 = {
             "folder": "selected",
             "dataseries": "selected",
             "channel": "selected",
             "epoch": "selected",
         }
-        elist = self.nm.execute_keys_set(e1)
+        elist = self.nm.run_keys_set(e1)
         select = self.nm.select_keys.copy()
         select.pop("data")
         self.assertEqual(elist, [select])
@@ -350,7 +350,7 @@ class TestNMManagerExecuteKeysSet(NMManagerTestBase):
             "channel": "all",
             "epoch": "E0",
         }
-        elist = self.nm.execute_keys_set(e0)
+        elist = self.nm.run_keys_set(e0)
         self.assertEqual(len(elist), NUMCHANNELS[2])
 
     def test_epoch_all_expands_to_all_epochs(self):
@@ -360,12 +360,12 @@ class TestNMManagerExecuteKeysSet(NMManagerTestBase):
             "channel": "A",
             "epoch": "all",
         }
-        elist = self.nm.execute_keys_set(e0)
+        elist = self.nm.run_keys_set(e0)
         self.assertEqual(len(elist), NUMEPOCHS[2])
 
     def test_data_set_expands_to_set_members(self):
         e0 = {"folder": "folder1", "data": "set0"}
-        elist = self.nm.execute_keys_set(e0)
+        elist = self.nm.run_keys_set(e0)
         self.assertEqual(len(elist), len(self.data_set0))
 
     def test_folder_all_is_valid(self):
@@ -375,7 +375,7 @@ class TestNMManagerExecuteKeysSet(NMManagerTestBase):
             "channel": "A",
             "epoch": "E0",
         }
-        elist = self.nm.execute_keys_set(e0)
+        elist = self.nm.run_keys_set(e0)
         self.assertEqual(len(elist), NUMFOLDERS)
 
     def test_folder_set_is_valid(self):
@@ -385,10 +385,10 @@ class TestNMManagerExecuteKeysSet(NMManagerTestBase):
             "channel": "A",
             "epoch": "E0",
         }
-        elist = self.nm.execute_keys_set(e0)
+        elist = self.nm.run_keys_set(e0)
         self.assertEqual(len(elist), 2)  # set0 has folder0 and folder1
 
-    def test_execute_keys_set_case_insensitive(self):
+    def test_run_keys_set_case_insensitive(self):
         # Test with uppercase keys
         e0 = {
             "FOLDER": "folder1",
@@ -396,22 +396,22 @@ class TestNMManagerExecuteKeysSet(NMManagerTestBase):
             "CHANNEL": "A",
             "EPOCH": "E0",
         }
-        elist = self.nm.execute_keys_set(e0)
+        elist = self.nm.run_keys_set(e0)
         self.assertEqual(len(elist), 1)
         self.assertEqual(elist[0]["folder"], "folder1")
         self.assertEqual(elist[0]["dataseries"], "stim")
 
-    def test_execute_keys_set_mixed_case(self):
+    def test_run_keys_set_mixed_case(self):
         # Test with mixed case keys
         e0 = {"Folder": "folder1", "Data": "data0"}
-        elist = self.nm.execute_keys_set(e0)
+        elist = self.nm.run_keys_set(e0)
         self.assertEqual(len(elist), 1)
         self.assertEqual(elist[0]["folder"], "folder1")
         self.assertEqual(elist[0]["data"], "data0")
 
 
-class TestNMManagerExecuteMaxTargets(NMManagerTestBase):
-    """Tests for max_targets parameter in execute_keys_set."""
+class TestNMManagerRunMaxTargets(NMManagerTestBase):
+    """Tests for max_targets parameter in run_keys_set."""
 
     def test_succeeds_within_limit(self):
         e0 = {
@@ -420,7 +420,7 @@ class TestNMManagerExecuteMaxTargets(NMManagerTestBase):
             "channel": "A",
             "epoch": "all",
         }
-        elist = self.nm.execute_keys_set(e0, max_targets=100)
+        elist = self.nm.run_keys_set(e0, max_targets=100)
         self.assertEqual(len(elist), NUMEPOCHS[0])
 
     def test_raises_when_exceeding_limit(self):
@@ -431,7 +431,7 @@ class TestNMManagerExecuteMaxTargets(NMManagerTestBase):
             "epoch": "all",
         }
         with self.assertRaises(ValueError):
-            self.nm.execute_keys_set(e0, max_targets=1)
+            self.nm.run_keys_set(e0, max_targets=1)
 
     def test_none_allows_unlimited(self):
         e0 = {
@@ -440,7 +440,7 @@ class TestNMManagerExecuteMaxTargets(NMManagerTestBase):
             "channel": "A",
             "epoch": "all",
         }
-        elist = self.nm.execute_keys_set(e0, max_targets=None)
+        elist = self.nm.run_keys_set(e0, max_targets=None)
         self.assertEqual(len(elist), NUMEPOCHS[0])
 
 

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -12,7 +12,7 @@ import unittest
 import pyneuromatic.core.nm_utilities as nmu
 from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.core.nm_object import NMObject
-from pyneuromatic.core.nm_object_container import NMObjectContainer, ExecuteMode
+from pyneuromatic.core.nm_object_container import NMObjectContainer, RunMode
 from tests.test_core.test_nm_object import NMObject2
 
 QUIET = True
@@ -111,14 +111,14 @@ class TestNMObjectContainerInit(NMObjectContainerTestBase):
         self.assertIsNone(self.map0.selected_name)
         self.assertIsNone(self.map0.selected_value)
 
-    def test_default_execute_mode_is_selected(self):
-        self.assertEqual(self.map0.execute_mode, ExecuteMode.SELECTED)
+    def test_default_run_mode_is_selected(self):
+        self.assertEqual(self.map0.run_mode, RunMode.SELECTED)
 
-    def test_default_execute_target_name_is_none(self):
-        self.assertEqual(self.map0.execute_target_name, None)
+    def test_default_run_target_name_is_none(self):
+        self.assertEqual(self.map0.run_target_name, None)
 
-    def test_execute_targets_empty_when_no_selection(self):
-        self.assertEqual(self.map0.execute_targets, [])
+    def test_run_targets_empty_when_no_selection(self):
+        self.assertEqual(self.map0.run_targets, [])
 
     def test_stores_sets(self):
         self.assertEqual(list(self.map0.sets.keys()), [SETS_NLIST0[0]])
@@ -147,8 +147,8 @@ class TestNMObjectContainerInit(NMObjectContainerTestBase):
     def test_map1_selected_value(self):
         self.assertEqual(self.map1.selected_value, self.olist1[2])
 
-    def test_map1_execute_targets(self):
-        self.assertEqual(self.map1.execute_targets, [self.olist1[2]])
+    def test_map1_run_targets(self):
+        self.assertEqual(self.map1.run_targets, [self.olist1[2]])
 
     def test_map1_stores_multiple_sets(self):
         self.assertEqual(list(self.map1.sets.keys()), [SETS_NLIST1[0], SETS_NLIST1[1]])
@@ -175,8 +175,8 @@ class TestNMObjectContainerCopy(NMObjectContainerTestBase):
     def test_copy_preserves_selected_name(self):
         self.assertEqual(self.map1_copy.selected_name, ONLIST1[2])
 
-    def test_copy_preserves_execute_mode(self):
-        self.assertEqual(self.map1_copy.execute_mode, ExecuteMode.SELECTED)
+    def test_copy_preserves_run_mode(self):
+        self.assertEqual(self.map1_copy.run_mode, RunMode.SELECTED)
 
     def test_copy_preserves_sets(self):
         self.assertEqual(list(self.map1_copy.sets.keys()), [SETS_NLIST1[0], SETS_NLIST1[1]])
@@ -210,7 +210,7 @@ class TestNMObjectContainerParameters(NMObjectContainerTestBase):
         expected_keys = [
             "name", "created", "copy of", "content_type", "rename_on",
             "auto_name_prefix", "auto_name_seq_format", "selected_name",
-            "execute_mode", "execute_target_name", "sets"
+            "run_mode", "run_target_name", "sets"
         ]
         plist = self.map0.parameters
         self.assertEqual(list(plist.keys()), expected_keys)
@@ -243,13 +243,13 @@ class TestNMObjectContainerParameters(NMObjectContainerTestBase):
         plist = self.map0.parameters
         self.assertIsNone(plist["selected_name"])
 
-    def test_map0_execute_mode(self):
+    def test_map0_run_mode(self):
         plist = self.map0.parameters
-        self.assertEqual(plist["execute_mode"], ExecuteMode.SELECTED.name)
+        self.assertEqual(plist["run_mode"], RunMode.SELECTED.name)
 
-    def test_map0_execute_target_name(self):
+    def test_map0_run_target_name(self):
         plist = self.map0.parameters
-        self.assertEqual(plist["execute_target_name"], None)
+        self.assertEqual(plist["run_target_name"], None)
 
     def test_map0_sets(self):
         plist = self.map0.parameters
@@ -1134,69 +1134,69 @@ class TestNMObjectContainerSelection(NMObjectContainerTestBase):
         self.assertIsNone(self.map0.selected_name)
 
 
-class TestNMObjectContainerExecute(NMObjectContainerTestBase):
-    """Tests for execute_mode, execute_target_name, execute_targets, and is_execute_target."""
+class TestNMObjectContainerRun(NMObjectContainerTestBase):
+    """Tests for run_mode, run_target_name, run_targets, and is_run_target."""
 
-    def test_execute_mode_rejects_bad_types(self):
+    def test_run_mode_rejects_bad_types(self):
         for b in BAD_TYPES:
             with self.assertRaises(TypeError):
-                self.map0.execute_mode = b
+                self.map0.run_mode = b
 
-    def test_is_execute_target_false_for_bad_types(self):
+    def test_is_run_target_false_for_bad_types(self):
         for b in BAD_TYPES:
-            self.assertFalse(self.map0.is_execute_target(b))
+            self.assertFalse(self.map0.is_run_target(b))
 
-    def test_execute_mode_name_with_no_target(self):
-        self.map0.execute_mode = ExecuteMode.NAME
-        self.assertIsNone(self.map0.execute_target_name)
+    def test_run_mode_name_with_no_target(self):
+        self.map0.run_mode = RunMode.NAME
+        self.assertIsNone(self.map0.run_target_name)
 
-    def test_execute_target_name_rejects_invalid(self):
-        self.map0.execute_mode = ExecuteMode.NAME
+    def test_run_target_name_rejects_invalid(self):
+        self.map0.run_mode = RunMode.NAME
         with self.assertRaises(KeyError):
-            self.map0.execute_target_name = "test"
+            self.map0.run_target_name = "test"
 
-    def test_is_execute_target_false_for_invalid(self):
-        self.map0.execute_mode = ExecuteMode.NAME
-        self.assertFalse(self.map0.is_execute_target("test"))
+    def test_is_run_target_false_for_invalid(self):
+        self.map0.run_mode = RunMode.NAME
+        self.assertFalse(self.map0.is_run_target("test"))
 
-    def test_execute_mode_name_sets_target(self):
-        self.map0.execute_mode = ExecuteMode.NAME
-        self.map0.execute_target_name = ONLIST0[3]
-        self.assertTrue(self.map0.is_execute_target(ONLIST0[3]))
+    def test_run_mode_name_sets_target(self):
+        self.map0.run_mode = RunMode.NAME
+        self.map0.run_target_name = ONLIST0[3]
+        self.assertTrue(self.map0.is_run_target(ONLIST0[3]))
 
-    def test_execute_mode_selected_clears_target_name(self):
-        self.map0.execute_mode = ExecuteMode.NAME
-        self.map0.execute_target_name = ONLIST0[3]
-        self.map0.execute_mode = ExecuteMode.SELECTED
-        self.assertIsNone(self.map0.execute_target_name)
+    def test_run_mode_selected_clears_target_name(self):
+        self.map0.run_mode = RunMode.NAME
+        self.map0.run_target_name = ONLIST0[3]
+        self.map0.run_mode = RunMode.SELECTED
+        self.assertIsNone(self.map0.run_target_name)
 
-    def test_execute_targets_selected_mode(self):
+    def test_run_targets_selected_mode(self):
         self.map0.selected_name = ONLIST0[3]
         self.assertEqual(self.map0.selected_value, self.olist0[3])
-        self.assertTrue(self.map0.is_execute_target(ONLIST0[3]))
-        self.assertEqual(self.map0.execute_targets, [self.olist0[3]])
+        self.assertTrue(self.map0.is_run_target(ONLIST0[3]))
+        self.assertEqual(self.map0.run_targets, [self.olist0[3]])
 
-    def test_execute_targets_name_mode(self):
-        self.map0.execute_mode = ExecuteMode.NAME
-        self.map0.execute_target_name = ONLIST0[4]
-        self.assertEqual(self.map0.execute_targets, [self.olist0[4]])
-        self.assertFalse(self.map0.is_execute_target(ONLIST0[3]))
-        self.assertTrue(self.map0.is_execute_target(ONLIST0[4]))
+    def test_run_targets_name_mode(self):
+        self.map0.run_mode = RunMode.NAME
+        self.map0.run_target_name = ONLIST0[4]
+        self.assertEqual(self.map0.run_targets, [self.olist0[4]])
+        self.assertFalse(self.map0.is_run_target(ONLIST0[3]))
+        self.assertTrue(self.map0.is_run_target(ONLIST0[4]))
 
-    def test_execute_targets_set_mode(self):
-        self.map0.execute_mode = ExecuteMode.SET
-        self.map0.execute_target_name = SETS_NLIST0[0]
-        self.assertEqual(self.map0.execute_targets, [self.olist0[0], self.olist0[2], self.olist0[3]])
+    def test_run_targets_set_mode(self):
+        self.map0.run_mode = RunMode.SET
+        self.map0.run_target_name = SETS_NLIST0[0]
+        self.assertEqual(self.map0.run_targets, [self.olist0[0], self.olist0[2], self.olist0[3]])
 
-    def test_execute_targets_all_mode(self):
-        self.map0.execute_mode = ExecuteMode.ALL
-        self.assertIsNone(self.map0.execute_target_name)
-        self.assertEqual(self.map0.execute_targets, self.olist0)
+    def test_run_targets_all_mode(self):
+        self.map0.run_mode = RunMode.ALL
+        self.assertIsNone(self.map0.run_target_name)
+        self.assertEqual(self.map0.run_targets, self.olist0)
 
-    def test_is_execute_target_all_mode(self):
-        self.map0.execute_mode = ExecuteMode.ALL
+    def test_is_run_target_all_mode(self):
+        self.map0.run_mode = RunMode.ALL
         for n in ONLIST0:
-            self.assertTrue(self.map0.is_execute_target(n))
+            self.assertTrue(self.map0.is_run_target(n))
 
 
 class TestNMObjectContainerHistory(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Renames `NMTool.execute()` → `run()` and the surrounding template methods
  `execute_init/execute_finish` → `run_init/run_finish`
- Renames `NMManager.execute_tool()` → `run_tool()` and related helpers
  `execute_values/execute_keys/execute_count/execute_targets` →
  `run_values/run_keys/run_count/run_targets`
- Updates `NMObjectContainer.execute_targets` → `run_targets`
- Updates all related tests and README examples
- #94 

## Motivation

`execute` is verbose and implies a batch operation, but each `run()` call
processes a single data wave. `run` is shorter, more familiar, and consistent
with how similar frameworks name this method.

## Test plan
- [x] All existing tests pass (`pytest tests/ -x -q` → 1114 passed)