### PR TITLE
refactor: restructure NMFolder.toolresults as nested dict keyed by to…

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -862,7 +862,7 @@ class NMToolStats(NMTool):
                     print(rdict)
         return None
 
-    def results_save(self) -> str | None:
+    def results_save(self) -> int | None:
         if not isinstance(self.folder, NMFolder):
             return None
         if not self.__results:


### PR DESCRIPTION
Closes #99 .

Replaces the flat auto-numbered key scheme (`stats0`, `stats1`, `main0`, ...)
with a nested dict keyed by tool name, making it straightforward to retrieve
results for a specific tool:

```python
# Before — required filtering to get stats results
folder.toolresults["stats0"]["results"]

# After — direct access
folder.toolresults["stats"][-1]["results"]   # most recent
folder.toolresults["stats"][0]["results"]    # first run
```

## Changes
NMFolder.toolresults_save(): appends to a per-tool list, returns list index (int), drops redundant "tool" field from entries, removes arbitrary 99-key limit, replaces print() with nmh.history()
NMFolder.toolresults_clear(): new method — clear all, clear by tool name, or delete a single entry by index; logs to history
NMToolStats.results_save(): return type updated str | None → int | None
tests/test_core/test_nm_folder.py: add TestNMFolderToolResults with 17 tests covering save, clear, and all error cases

## Test plan
 All existing tests pass (pytest tests/ -x -q → 1114 passed)
 17 new tests for toolresults_save() and toolresults_clear()
