### PR TITLE
feat: add save_history, save_cache, save_numpy flags to NMToolStats

### DIFF
--- a/tests/test_analysis/test_nm_stats.py
+++ b/tests/test_analysis/test_nm_stats.py
@@ -1473,5 +1473,86 @@ class TestNMStatsWinContainer(unittest.TestCase):
         self.assertEqual(w.name, "win0")
 
 
+class TestNMToolStats(unittest.TestCase):
+    """Tests for NMToolStats save flags and _save_history()."""
+
+    def setUp(self):
+        self.tool = nms.NMToolStats()
+
+    # --- defaults ---
+
+    def test_save_history_default(self):
+        self.assertFalse(self.tool.save_history)
+
+    def test_save_cache_default(self):
+        self.assertTrue(self.tool.save_cache)
+
+    def test_save_numpy_default(self):
+        self.assertFalse(self.tool.save_numpy)
+
+    # --- save_history ---
+
+    def test_save_history_set_true(self):
+        self.tool.save_history = True
+        self.assertTrue(self.tool.save_history)
+
+    def test_save_history_set_false(self):
+        self.tool.save_history = True
+        self.tool.save_history = False
+        self.assertFalse(self.tool.save_history)
+
+    def test_save_history_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.save_history = 1
+
+    def test_save_history_rejects_none(self):
+        with self.assertRaises(TypeError):
+            self.tool.save_history = None
+
+    # --- save_cache ---
+
+    def test_save_cache_set_false(self):
+        self.tool.save_cache = False
+        self.assertFalse(self.tool.save_cache)
+
+    def test_save_cache_set_true(self):
+        self.tool.save_cache = False
+        self.tool.save_cache = True
+        self.assertTrue(self.tool.save_cache)
+
+    def test_save_cache_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.save_cache = "yes"
+
+    # --- save_numpy ---
+
+    def test_save_numpy_set_true(self):
+        self.tool.save_numpy = True
+        self.assertTrue(self.tool.save_numpy)
+
+    def test_save_numpy_set_false(self):
+        self.tool.save_numpy = True
+        self.tool.save_numpy = False
+        self.assertFalse(self.tool.save_numpy)
+
+    def test_save_numpy_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.save_numpy = 0
+
+    # --- _save_history ---
+
+    def test__save_history_empty_results(self):
+        # Should not raise with no results
+        self.tool._save_history(quiet=True)
+
+    def test__save_history_with_results(self):
+        # Populate results via compute then call print
+        data = _make_data()
+        w = list(self.tool.windows)[0]
+        w.func = "mean"
+        w.compute(data)
+        self.tool._save_history(quiet=True)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Closes #101 .

Adds three boolean instance attributes to `NMToolStats` to give users
control over what happens after each run, replacing the previous
unconditional calls in `run_finish()`.

| Flag | Default | Action |
|------|---------|--------|
| `save_history` | `False` | Log results to NM history via `nmh.history()` |
| `save_cache` | `True` | Append to `folder.toolresults` dict |
| `save_numpy` | `False` | Save as NMData arrays in `folder.toolfolder` |

### Changes

- `NMToolStats.__init__()`: add `__save_history`, `__save_cache`,
  `__save_numpy` with matching properties and `_*_set(quiet)` setters,
  consistent with `xclip`/`ignore_nans` pattern
- `NMToolStats.run_finish()`: check each flag before calling corresponding
  method
- Rename `results_print()` → `_save_history()`, `results_save()` →
  `_save_cache()`, `results_save_as_numpy()` → `_save_numpy()` to match
  flag names
- `_save_history()`: remove `@staticmethod`, replace `print()` with
  `nmh.history()`, add `quiet` parameter, use `self.__results` directly
- `tests/test_analysis/test_nm_stats.py`: add `TestNMToolStats` with
  15 tests covering defaults, set/unset, type validation, and
  `_save_history()`

## Test plan
- [x] All existing tests pass (`pytest tests/ -x -q` → 1146 passed)
- [x] 15 new tests in `TestNMToolStats`
