### PR TITLE
refactor(analysis): rename save_* flags to results_to_* for clarity

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -108,9 +108,9 @@ class NMToolStats(NMTool):
         # results for each measure {} made for the stat window
         # e.g. baseline, main, p0, p1, slope, etc.
 
-        self.__save_history = False
-        self.__save_cache = True
-        self.__save_numpy = False
+        self.__results_to_history = False
+        self.__results_to_cache = True
+        self.__results_to_numpy = False
 
     @property
     def windows(self) -> NMStatWinContainer:
@@ -157,58 +157,58 @@ class NMToolStats(NMTool):
         nmh.history("set ignore_nans=%s" % ignore_nans, quiet=quiet)
 
     @property
-    def save_history(self) -> bool:
-        return self.__save_history
+    def results_to_history(self) -> bool:
+        return self.__results_to_history
 
-    @save_history.setter
-    def save_history(self, value: bool) -> None:
-        self._save_history_set(value)
+    @results_to_history.setter
+    def results_to_history(self, value: bool) -> None:
+        self._results_to_history_set(value)
 
-    def _save_history_set(
+    def _results_to_history_set(
         self,
         value: bool,
         quiet: bool = nmp.QUIET,
     ) -> None:
         if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "save_history", "boolean"))
-        self.__save_history = value
-        nmh.history("set save_history=%s" % value, quiet=quiet)
+            raise TypeError(nmu.type_error_str(value, "results_to_history", "boolean"))
+        self.__results_to_history = value
+        nmh.history("set results_to_history=%s" % value, quiet=quiet)
 
     @property
-    def save_cache(self) -> bool:
-        return self.__save_cache
+    def results_to_cache(self) -> bool:
+        return self.__results_to_cache
 
-    @save_cache.setter
-    def save_cache(self, value: bool) -> None:
-        self._save_cache_set(value)
+    @results_to_cache.setter
+    def results_to_cache(self, value: bool) -> None:
+        self._results_to_cache_set(value)
 
-    def _save_cache_set(
+    def _results_to_cache_set(
         self,
         value: bool,
         quiet: bool = nmp.QUIET,
     ) -> None:
         if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "save_cache", "boolean"))
-        self.__save_cache = value
-        nmh.history("set save_cache=%s" % value, quiet=quiet)
+            raise TypeError(nmu.type_error_str(value, "results_to_cache", "boolean"))
+        self.__results_to_cache = value
+        nmh.history("set results_to_cache=%s" % value, quiet=quiet)
 
     @property
-    def save_numpy(self) -> bool:
-        return self.__save_numpy
+    def results_to_numpy(self) -> bool:
+        return self.__results_to_numpy
 
-    @save_numpy.setter
-    def save_numpy(self, value: bool) -> None:
-        self._save_numpy_set(value)
+    @results_to_numpy.setter
+    def results_to_numpy(self, value: bool) -> None:
+        self._results_to_numpy_set(value)
 
-    def _save_numpy_set(
+    def _results_to_numpy_set(
         self,
         value: bool,
         quiet: bool = nmp.QUIET,
     ) -> None:
         if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "save_numpy", "boolean"))
-        self.__save_numpy = value
-        nmh.history("set save_numpy=%s" % value, quiet=quiet)
+            raise TypeError(nmu.type_error_str(value, "results_to_numpy", "boolean"))
+        self.__results_to_numpy = value
+        nmh.history("set results_to_numpy=%s" % value, quiet=quiet)
 
     # override, no super
     def run_init(self) -> bool:
@@ -237,15 +237,15 @@ class NMToolStats(NMTool):
 
     # override, no super
     def run_finish(self) -> bool:
-        if self.__save_history:
-            self._save_history()
-        if self.__save_cache:
-            self._save_cache()
-        if self.__save_numpy:
-            self._save_numpy()
+        if self.__results_to_history:
+            self._results_to_history()
+        if self.__results_to_cache:
+            self._results_to_cache()
+        if self.__results_to_numpy:
+            self._results_to_numpy()
         return True  # ok
 
-    def _save_history(self, quiet: bool = False) -> None:
+    def _results_to_history(self, quiet: bool = False) -> None:
         if not isinstance(self.__results, dict):
             return None
         for kwin, vlist in self.__results.items():  # windows
@@ -262,7 +262,7 @@ class NMToolStats(NMTool):
                     nmh.history(str(rdict), quiet=quiet)
         return None
 
-    def _save_cache(self) -> int | None:
+    def _results_to_cache(self) -> int | None:
         if not isinstance(self.folder, NMFolder):
             return None
         if not self.__results:
@@ -287,7 +287,7 @@ class NMToolStats(NMTool):
         "dx":   ("dx",   "xunits"),
     }
 
-    def _save_numpy(self) -> NMToolFolder | None:
+    def _results_to_numpy(self) -> NMToolFolder | None:
         if not isinstance(self.folder, NMFolder):
             return None
         if not self.__results:
@@ -365,7 +365,7 @@ class NMToolStats(NMTool):
 class NMToolStats2:
     """Compute summary statistics of Stats results (ST_ arrays).
 
-    Operates on a NMToolFolder produced by NMToolStats._save_numpy(),
+    Operates on a NMToolFolder produced by NMToolStats._results_to_numpy(),
     computing stats() on each selected ST_ array and saving results as
     ST2_ arrays in the same folder.
     """
@@ -376,9 +376,9 @@ class NMToolStats2:
     def __init__(self) -> None:
         self.__results: dict[str, Any] = {}
         self.__ignore_nans: bool = True
-        self.__save_history: bool = False
-        self.__save_cache: bool = True
-        self.__save_numpy: bool = False
+        self.__results_to_history: bool = False
+        self.__results_to_cache: bool = True
+        self.__results_to_numpy: bool = False
 
     # --- ignore_nans (same pattern as NMToolStats) ---
 
@@ -401,52 +401,52 @@ class NMToolStats2:
     # --- save flags (same pattern as NMToolStats) ---
 
     @property
-    def save_history(self) -> bool:
-        return self.__save_history
+    def results_to_history(self) -> bool:
+        return self.__results_to_history
 
-    @save_history.setter
-    def save_history(self, value: bool) -> None:
-        self._save_history_flag_set(value)
+    @results_to_history.setter
+    def results_to_history(self, value: bool) -> None:
+        self._results_to_history_set(value)
 
-    def _save_history_flag_set(
+    def _results_to_history_set(
         self, value: bool, quiet: bool = nmp.QUIET
     ) -> None:
         if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "save_history", "boolean"))
-        self.__save_history = value
-        nmh.history("set save_history=%s" % value, quiet=quiet)
+            raise TypeError(nmu.type_error_str(value, "results_to_history", "boolean"))
+        self.__results_to_history = value
+        nmh.history("set results_to_history=%s" % value, quiet=quiet)
 
     @property
-    def save_cache(self) -> bool:
-        return self.__save_cache
+    def results_to_cache(self) -> bool:
+        return self.__results_to_cache
 
-    @save_cache.setter
-    def save_cache(self, value: bool) -> None:
-        self._save_cache_flag_set(value)
+    @results_to_cache.setter
+    def results_to_cache(self, value: bool) -> None:
+        self._results_to_cache_set(value)
 
-    def _save_cache_flag_set(
+    def _results_to_cache_set(
         self, value: bool, quiet: bool = nmp.QUIET
     ) -> None:
         if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "save_cache", "boolean"))
-        self.__save_cache = value
-        nmh.history("set save_cache=%s" % value, quiet=quiet)
+            raise TypeError(nmu.type_error_str(value, "results_to_cache", "boolean"))
+        self.__results_to_cache = value
+        nmh.history("set results_to_cache=%s" % value, quiet=quiet)
 
     @property
-    def save_numpy(self) -> bool:
-        return self.__save_numpy
+    def results_to_numpy(self) -> bool:
+        return self.__results_to_numpy
 
-    @save_numpy.setter
-    def save_numpy(self, value: bool) -> None:
-        self._save_numpy_flag_set(value)
+    @results_to_numpy.setter
+    def results_to_numpy(self, value: bool) -> None:
+        self._results_to_numpy_set(value)
 
-    def _save_numpy_flag_set(
+    def _results_to_numpy_set(
         self, value: bool, quiet: bool = nmp.QUIET
     ) -> None:
         if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "save_numpy", "boolean"))
-        self.__save_numpy = value
-        nmh.history("set save_numpy=%s" % value, quiet=quiet)
+            raise TypeError(nmu.type_error_str(value, "results_to_numpy", "boolean"))
+        self.__results_to_numpy = value
+        nmh.history("set results_to_numpy=%s" % value, quiet=quiet)
 
     @property
     def results(self) -> dict:
@@ -509,20 +509,20 @@ class NMToolStats2:
             stats(d.nparray, ignore_nans=ignore_nans, results=r)
             self.__results[d.name] = r
 
-        if self.__save_history:
-            self._save_history_results()
-        if self.__save_cache:
-            self._save_cache_results(toolfolder)
-        if self.__save_numpy:
-            self._save_numpy_results(toolfolder)
+        if self.__results_to_history:
+            self._results_to_history()
+        if self.__results_to_cache:
+            self._results_to_cache(toolfolder)
+        if self.__results_to_numpy:
+            self._results_to_numpy(toolfolder)
 
         return self.__results
 
-    def _save_history_results(self, quiet: bool = False) -> None:
+    def _results_to_history(self, quiet: bool = False) -> None:
         for src_name, r in self.__results.items():
             nmh.history("stats2 %s: %s" % (src_name, r), quiet=quiet)
 
-    def _save_cache_results(self, toolfolder: NMToolFolder) -> None:
+    def _results_to_cache(self, toolfolder: NMToolFolder) -> None:
         # Store in the folder's parent NMFolder toolresults if available
         parent = toolfolder._parent
         while parent is not None:
@@ -531,7 +531,7 @@ class NMToolStats2:
                 return
             parent = getattr(parent, "_parent", None)
 
-    def _save_numpy_results(self, toolfolder: NMToolFolder) -> None:
+    def _results_to_numpy(self, toolfolder: NMToolFolder) -> None:
         if not self.__results:
             return
         src_names = list(self.__results.keys())

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -34,86 +34,86 @@ def _make_data(n=100, name="recordA0", with_nans=False, units=True):
 
 
 class TestNMToolStats(unittest.TestCase):
-    """Tests for NMToolStats save flags and _save_history()."""
+    """Tests for NMToolStats results_to_* flags and _results_to_history()."""
 
     def setUp(self):
         self.tool = nms.NMToolStats()
 
     # --- defaults ---
 
-    def test_save_history_default(self):
-        self.assertFalse(self.tool.save_history)
+    def test_results_to_history_default(self):
+        self.assertFalse(self.tool.results_to_history)
 
-    def test_save_cache_default(self):
-        self.assertTrue(self.tool.save_cache)
+    def test_results_to_cache_default(self):
+        self.assertTrue(self.tool.results_to_cache)
 
-    def test_save_numpy_default(self):
-        self.assertFalse(self.tool.save_numpy)
+    def test_results_to_numpy_default(self):
+        self.assertFalse(self.tool.results_to_numpy)
 
-    # --- save_history ---
+    # --- results_to_history ---
 
-    def test_save_history_set_true(self):
-        self.tool.save_history = True
-        self.assertTrue(self.tool.save_history)
+    def test_results_to_history_set_true(self):
+        self.tool.results_to_history = True
+        self.assertTrue(self.tool.results_to_history)
 
-    def test_save_history_set_false(self):
-        self.tool.save_history = True
-        self.tool.save_history = False
-        self.assertFalse(self.tool.save_history)
+    def test_results_to_history_set_false(self):
+        self.tool.results_to_history = True
+        self.tool.results_to_history = False
+        self.assertFalse(self.tool.results_to_history)
 
-    def test_save_history_rejects_non_bool(self):
+    def test_results_to_history_rejects_non_bool(self):
         with self.assertRaises(TypeError):
-            self.tool.save_history = 1
+            self.tool.results_to_history = 1
 
-    def test_save_history_rejects_none(self):
+    def test_results_to_history_rejects_none(self):
         with self.assertRaises(TypeError):
-            self.tool.save_history = None
+            self.tool.results_to_history = None
 
-    # --- save_cache ---
+    # --- results_to_cache ---
 
-    def test_save_cache_set_false(self):
-        self.tool.save_cache = False
-        self.assertFalse(self.tool.save_cache)
+    def test_results_to_cache_set_false(self):
+        self.tool.results_to_cache = False
+        self.assertFalse(self.tool.results_to_cache)
 
-    def test_save_cache_set_true(self):
-        self.tool.save_cache = False
-        self.tool.save_cache = True
-        self.assertTrue(self.tool.save_cache)
+    def test_results_to_cache_set_true(self):
+        self.tool.results_to_cache = False
+        self.tool.results_to_cache = True
+        self.assertTrue(self.tool.results_to_cache)
 
-    def test_save_cache_rejects_non_bool(self):
+    def test_results_to_cache_rejects_non_bool(self):
         with self.assertRaises(TypeError):
-            self.tool.save_cache = "yes"
+            self.tool.results_to_cache = "yes"
 
-    # --- save_numpy ---
+    # --- results_to_numpy ---
 
-    def test_save_numpy_set_true(self):
-        self.tool.save_numpy = True
-        self.assertTrue(self.tool.save_numpy)
+    def test_results_to_numpy_set_true(self):
+        self.tool.results_to_numpy = True
+        self.assertTrue(self.tool.results_to_numpy)
 
-    def test_save_numpy_set_false(self):
-        self.tool.save_numpy = True
-        self.tool.save_numpy = False
-        self.assertFalse(self.tool.save_numpy)
+    def test_results_to_numpy_set_false(self):
+        self.tool.results_to_numpy = True
+        self.tool.results_to_numpy = False
+        self.assertFalse(self.tool.results_to_numpy)
 
-    def test_save_numpy_rejects_non_bool(self):
+    def test_results_to_numpy_rejects_non_bool(self):
         with self.assertRaises(TypeError):
-            self.tool.save_numpy = 0
+            self.tool.results_to_numpy = 0
 
-    # --- _save_history ---
+    # --- _results_to_history ---
 
-    def test__save_history_empty_results(self):
+    def test_results_to_history_empty_results(self):
         # Should not raise with no results
-        self.tool._save_history(quiet=True)
+        self.tool._results_to_history(quiet=True)
 
-    def test__save_history_with_results(self):
+    def test_results_to_history_with_results(self):
         # Populate results via compute then call print
         data = _make_data()
         w = list(self.tool.windows)[0]
         w.func = "mean"
         w.compute(data)
-        self.tool._save_history(quiet=True)
+        self.tool._results_to_history(quiet=True)
 
-    # --- _save_numpy ---
+    # --- _results_to_numpy ---
 
     def _setup_folder(self):
         """Create a real NMFolder and wire it into the tool's selection."""
@@ -138,65 +138,65 @@ class TestNMToolStats(unittest.TestCase):
             else:
                 self.tool._NMToolStats__results[wname] = [results]
 
-    def test_save_numpy_returns_toolfolder(self):
+    def test_results_to_numpy_returns_toolfolder(self):
         from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
         self._setup_folder()
         self._run_compute()
-        f = self.tool._save_numpy()
+        f = self.tool._results_to_numpy()
         self.assertIsInstance(f, NMToolFolder)
 
-    def test_save_numpy_folder_named_stats0(self):
+    def test_results_to_numpy_folder_named_stats0(self):
         self._setup_folder()
         self._run_compute()
-        f = self.tool._save_numpy()
+        f = self.tool._results_to_numpy()
         self.assertEqual(f.name, "stats0")
 
-    def test_save_numpy_second_run_named_stats1(self):
+    def test_results_to_numpy_second_run_named_stats1(self):
         self._setup_folder()
         self._run_compute()
-        self.tool._save_numpy()
+        self.tool._results_to_numpy()
         self.tool._NMToolStats__results.clear()
         self._run_compute()
-        f = self.tool._save_numpy()
+        f = self.tool._results_to_numpy()
         self.assertEqual(f.name, "stats1")
 
-    def test_save_numpy_creates_data_array(self):
+    def test_results_to_numpy_creates_data_array(self):
         self._setup_folder()
         self._run_compute(n_waves=3)
-        f = self.tool._save_numpy()
+        f = self.tool._results_to_numpy()
         self.assertIn("ST_w0_data", f.data)
 
-    def test_save_numpy_data_array_length(self):
+    def test_results_to_numpy_data_array_length(self):
         self._setup_folder()
         self._run_compute(n_waves=3)
-        f = self.tool._save_numpy()
+        f = self.tool._results_to_numpy()
         d = f.data.get("ST_w0_data")
         self.assertEqual(len(d.nparray), 3)
 
-    def test_save_numpy_creates_s_array(self):
+    def test_results_to_numpy_creates_s_array(self):
         self._setup_folder()
         self._run_compute(func="mean", n_waves=3)
-        f = self.tool._save_numpy()
+        f = self.tool._results_to_numpy()
         self.assertIn("ST_w0_main_s", f.data)
 
-    def test_save_numpy_s_array_length(self):
+    def test_results_to_numpy_s_array_length(self):
         self._setup_folder()
         self._run_compute(func="mean", n_waves=3)
-        f = self.tool._save_numpy()
+        f = self.tool._results_to_numpy()
         d = f.data.get("ST_w0_main_s")
         self.assertEqual(len(d.nparray), 3)
 
-    def test_save_numpy_no_folder_returns_none(self):
+    def test_results_to_numpy_no_folder_returns_none(self):
         from pyneuromatic.analysis.nm_tool import SELECT_LEVELS
         self.tool._select = {level: None for level in SELECT_LEVELS}
         # folder is None — should return None
-        result = self.tool._save_numpy()
+        result = self.tool._results_to_numpy()
         self.assertIsNone(result)
 
-    def test_save_numpy_no_results_raises(self):
+    def test_results_to_numpy_no_results_raises(self):
         self._setup_folder()
         with self.assertRaises(RuntimeError):
-            self.tool._save_numpy()
+            self.tool._results_to_numpy()
 
 
 class TestNMToolStats2(unittest.TestCase):
@@ -216,40 +216,40 @@ class TestNMToolStats2(unittest.TestCase):
 
     # --- defaults ---
 
-    def test_save_history_default(self):
-        self.assertFalse(self.tool2.save_history)
+    def test_results_to_history_default(self):
+        self.assertFalse(self.tool2.results_to_history)
 
-    def test_save_cache_default(self):
-        self.assertTrue(self.tool2.save_cache)
+    def test_results_to_cache_default(self):
+        self.assertTrue(self.tool2.results_to_cache)
 
-    def test_save_numpy_default(self):
-        self.assertFalse(self.tool2.save_numpy)
+    def test_results_to_numpy_default(self):
+        self.assertFalse(self.tool2.results_to_numpy)
 
     # --- save flag setters ---
 
-    def test_save_history_set(self):
-        self.tool2.save_history = True
-        self.assertTrue(self.tool2.save_history)
+    def test_results_to_history_set(self):
+        self.tool2.results_to_history = True
+        self.assertTrue(self.tool2.results_to_history)
 
-    def test_save_cache_set(self):
-        self.tool2.save_cache = False
-        self.assertFalse(self.tool2.save_cache)
+    def test_results_to_cache_set(self):
+        self.tool2.results_to_cache = False
+        self.assertFalse(self.tool2.results_to_cache)
 
-    def test_save_numpy_set(self):
-        self.tool2.save_numpy = True
-        self.assertTrue(self.tool2.save_numpy)
+    def test_results_to_numpy_set(self):
+        self.tool2.results_to_numpy = True
+        self.assertTrue(self.tool2.results_to_numpy)
 
-    def test_save_history_rejects_non_bool(self):
+    def test_results_to_history_rejects_non_bool(self):
         with self.assertRaises(TypeError):
-            self.tool2.save_history = 1
+            self.tool2.results_to_history = 1
 
-    def test_save_cache_rejects_non_bool(self):
+    def test_results_to_cache_rejects_non_bool(self):
         with self.assertRaises(TypeError):
-            self.tool2.save_cache = "yes"
+            self.tool2.results_to_cache = "yes"
 
-    def test_save_numpy_rejects_non_bool(self):
+    def test_results_to_numpy_rejects_non_bool(self):
         with self.assertRaises(TypeError):
-            self.tool2.save_numpy = 0
+            self.tool2.results_to_numpy = 0
 
     # --- ignore_nans ---
 
@@ -320,30 +320,30 @@ class TestNMToolStats2(unittest.TestCase):
         r = self.tool2.compute(self.tf, select="ST_w0_main_s")
         self.assertEqual(r["ST_w0_main_s"]["N"], 5)
 
-    # --- _save_numpy_results ---
+    # --- _results_to_numpy_results ---
 
-    def test_save_numpy_creates_st2_data(self):
-        self.tool2.save_cache = False
-        self.tool2.save_numpy = True
+    def test_results_to_numpy_creates_st2_data(self):
+        self.tool2.results_to_cache = False
+        self.tool2.results_to_numpy = True
         self.tool2.compute(self.tf, select="all")
         self.assertIn("ST2_data", self.tf.data)
 
-    def test_save_numpy_creates_st2_mean(self):
-        self.tool2.save_cache = False
-        self.tool2.save_numpy = True
+    def test_results_to_numpy_creates_st2_mean(self):
+        self.tool2.results_to_cache = False
+        self.tool2.results_to_numpy = True
         self.tool2.compute(self.tf, select="all")
         self.assertIn("ST2_mean", self.tf.data)
 
-    def test_save_numpy_st2_data_length(self):
-        self.tool2.save_cache = False
-        self.tool2.save_numpy = True
+    def test_results_to_numpy_st2_data_length(self):
+        self.tool2.results_to_cache = False
+        self.tool2.results_to_numpy = True
         self.tool2.compute(self.tf, select="all")
         d = self.tf.data.get("ST2_data")
         self.assertEqual(len(d.nparray), 2)  # 2 ST_ numeric arrays
 
-    def test_save_numpy_st2_mean_value(self):
-        self.tool2.save_cache = False
-        self.tool2.save_numpy = True
+    def test_results_to_numpy_st2_mean_value(self):
+        self.tool2.results_to_cache = False
+        self.tool2.results_to_numpy = True
         self.tool2.compute(self.tf, select="ST_w0_main_s")
         d = self.tf.data.get("ST2_mean")
         self.assertAlmostEqual(d.nparray[0], 3.0)


### PR DESCRIPTION
## Summary
- Rename `save_history`, `save_cache`, `save_numpy` → `results_to_history`,
  `results_to_cache`, `results_to_numpy` on `NMToolStats` and `NMToolStats2`
- The old names were ambiguous ("save the X" vs "write results into X");
  the new names make the direction explicit
- Rename applied consistently: public properties, private attrs, setter
  helpers, post-run methods, tests, and docstrings

## Test plan
- [ ] `python3 -m pytest tests/ -x -q` — all tests passing

Closes #111 
