### PR TITLE
feat(analysis): add decaytime+/- function for exponential decay time …

### DIFF
--- a/tests/test_analysis/test_nm_stat_win.py
+++ b/tests/test_analysis/test_nm_stat_win.py
@@ -183,9 +183,6 @@ class TestNMStatWin(unittest.TestCase):
         self.assertEqual(self.w1.func["name"], "falltime+")
         self.assertEqual(self.w1.func["p0"], 90)
         self.assertEqual(self.w1.func["p1"], 10)
-        self.w1._func_set({"p0": 36})
-        self.assertEqual(self.w1.func["p0"], 36)
-        self.assertIsNone(self.w1.func["p1"])
         with self.assertRaises(ValueError):
             self.w1._func_set({"p0": 25, "p1": 75})
 
@@ -388,15 +385,15 @@ class TestNMStatWin(unittest.TestCase):
             round(r[1]["Δs"] * 1000),
             round(n_std * r[0]["std"] * 1000))
 
-    def test_compute_falltime_p0_only(self):
+    def test_compute_decaytime(self):
         self.w1.bsln_x0 = 0
         self.w1.bsln_x1 = 10
         self.w1.x0 = -math.inf
         self.w1.x1 = math.inf
-        self.w1.func = {"name": "falltime+", "p0": 36}
+        self.w1.func = {"name": "decaytime+", "p0": 36}
         r = self.w1.compute(self.data, xclip=True, ignore_nans=True)
         self.assertEqual(r[0]["id"], "bsln")
-        self.assertEqual(r[1]["id"], "falltime+")
+        self.assertEqual(r[1]["id"], "decaytime+")
         self.assertIn("Δs", r[1])
         if not math.isnan(r[1]["Δs"]):
             self.assertEqual(len(r), 3)


### PR DESCRIPTION
## Summary
- Add `NMStatFuncDecayTime` (`decaytime+`, `decaytime-`) to the stat func
  hierarchy — measures time from signal peak to when it has decayed to
  `p0`% of its amplitude above baseline
- Default `p0 = 100/e ≈ 36.79%` (one exponential time constant, tau),
  stored as `DECAY_TIME_DEFAULT_PCT = 100.0 / math.e`
- Make `p1` required in `NMStatFuncFallTime`, now consistent with
  `NMStatFuncRiseTime`; the former `p0`-only decay use case is replaced
  by the dedicated `decaytime` function
- Add `TestNMStatFuncDecayTime` unit tests and `TestSineWaveDecayTime`
  Igor comparison tests (dx ≈ 7.6015 ms against Igor NM reference value)

## Test plan
- [ ] `python3 -m pytest tests/ -x -q` — 1212 tests passing

Closes #113 
