### PR TITLE
refactor(analysis): remove FUNC_NAMES and migrate annotations to nm_stat_func.py

### DIFF
--- a/pyneuromatic/analysis/nm_stat_func.py
+++ b/pyneuromatic/analysis/nm_stat_func.py
@@ -27,12 +27,33 @@ import pyneuromatic.core.nm_utilities as nmu
 
 
 FUNC_NAMES_BASIC = (
-    "median", "mean", "mean+var", "mean+std", "mean+sem",
-    "var", "std", "sem", "rms", "sum", "pathlength", "area", "slope",
-    "value@x0", "value@x1", "count", "count_nans", "count_infs",
+    "median",       # np.median
+    "mean",         # np.mean (Igor: "avg")
+    "mean+var",
+    "mean+std",
+    "mean+sem",
+    "var",          # np.var
+    "std",          # np.std (Igor: "sdev")
+    "sem",
+    "rms",
+    "sum",          # np.sum
+    "pathlength",
+    "area",
+    "slope",
+    "value@x0",
+    "value@x1",
+    "count",        # np.size (Igor: "numpnts")
+    "count_nans",
+    "count_infs",
+    # TODO: add "onset" — Igor version requires sigmoid curve fit
 )
 
-FUNC_NAMES_MAXMIN = ("max", "min", "mean@max", "mean@min")
+FUNC_NAMES_MAXMIN = (
+    "max",          # np.argmax
+    "min",          # np.argmin
+    "mean@max",
+    "mean@min",
+)
 
 FUNC_NAMES_LEVEL = ("level", "level+", "level-")
 

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -36,48 +36,6 @@ import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
 
 
-FUNC_NAMES = (
-    "max",  # np.argmax
-    "min",  # np.argmin
-    "mean@max",
-    "mean@min",
-    "median",  # np.median
-    "mean",  # "avg" # np.mean
-    "mean+var",
-    "mean+std",
-    "mean+sem",
-    "var",  # np.var
-    "std",  # "sdev" # np.std
-    "sem",
-    "rms",
-    "sum",  # np.sum
-    "pathlength",
-    "area",
-    "slope",
-    # TODO "onset",  # Igor version requires sigmoid curvefit
-    "level",
-    "level+",
-    "level-",
-    "value@x0",
-    "value@x1",
-    "count",  # "numpnts"
-    "count_nans",
-    "count_infs",
-    # positive peaks
-    "risetime+",
-    "falltime+",
-    "risetimeslope+",
-    "falltimeslope+",
-    "fwhm+",
-    # negative peaks
-    "risetime-",
-    "falltime-",
-    "risetimeslope-",
-    "falltimeslope-",
-    "fwhm-"
-)
-
-
 class NMToolStats(NMTool):
     """
     NM Stats Tool class

--- a/tests/test_analysis/test_nm_stat_win.py
+++ b/tests/test_analysis/test_nm_stat_win.py
@@ -14,7 +14,7 @@ import numpy as np
 from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_manager import NMManager
 import pyneuromatic.analysis.nm_stat_win as nmsw
-from pyneuromatic.analysis.nm_tool_stats import FUNC_NAMES
+import pyneuromatic.analysis.nm_stat_func as nmsf
 from pyneuromatic.analysis.nm_stat_func import FUNC_NAMES_BSLN
 import pyneuromatic.core.nm_utilities as nmu
 
@@ -197,19 +197,31 @@ class TestNMStatWin(unittest.TestCase):
             self.assertEqual(self.w1.func["p1"], 40)
 
     def test_func_names_complete(self):
-        fnames = [
-            "max", "min", "mean@max", "mean@min",
-            "median", "mean", "mean+var", "mean+std", "mean+sem",
-            "var", "std", "sem", "rms", "sum", "pathlength", "area", "slope",
-            "level", "level+", "level-", "value@x0", "value@x1",
-            "count", "count_nans", "count_infs",
-            "risetime+", "falltime+", "risetimeslope+", "falltimeslope+",
-            "fwhm+", "risetime-", "falltime-", "risetimeslope-",
-            "falltimeslope-", "fwhm-",
-        ]
-        self.assertEqual(len(FUNC_NAMES), len(fnames))
-        for f in fnames:
-            self.assertIn(f, FUNC_NAMES)
+        expected = {
+            "basic":     ("median", "mean", "mean+var", "mean+std", "mean+sem",
+                          "var", "std", "sem", "rms", "sum", "pathlength",
+                          "area", "slope", "value@x0", "value@x1",
+                          "count", "count_nans", "count_infs"),
+            "maxmin":    ("max", "min", "mean@max", "mean@min"),
+            "level":     ("level", "level+", "level-"),
+            "risetime":  ("risetime+", "risetime-",
+                          "risetimeslope+", "risetimeslope-"),
+            "falltime":  ("falltime+", "falltime-",
+                          "falltimeslope+", "falltimeslope-"),
+            "decaytime": ("decaytime+", "decaytime-"),
+            "fwhm":      ("fwhm+", "fwhm-"),
+        }
+        actual = {
+            "basic":     nmsf.FUNC_NAMES_BASIC,
+            "maxmin":    nmsf.FUNC_NAMES_MAXMIN,
+            "level":     nmsf.FUNC_NAMES_LEVEL,
+            "risetime":  nmsf.FUNC_NAMES_RISETIME,
+            "falltime":  nmsf.FUNC_NAMES_FALLTIME,
+            "decaytime": nmsf.FUNC_NAMES_DECAYTIME,
+            "fwhm":      nmsf.FUNC_NAMES_FWHM,
+        }
+        for key in expected:
+            self.assertEqual(set(actual[key]), set(expected[key]), msg=key)
 
     def test_bsln_func_names_complete(self):
         fnames = ("median", "mean", "mean+var", "mean+std", "mean+sem")


### PR DESCRIPTION
## Summary
- Remove `FUNC_NAMES` flat tuple from `nm_tool_stats.py` — it duplicated
  the `FUNC_NAMES_*` tuples in `nm_stat_func.py` and was only referenced
  in test code
- Move numpy equivalent annotations (`# np.argmax`, `# np.mean`, etc.),
  Igor name aliases, and `TODO: onset` comment to the relevant
  `FUNC_NAMES_*` tuples in `nm_stat_func.py` where the names are defined
- Update `test_nm_stat_win.py` to test each `FUNC_NAMES_*` tuple
  individually; test now also covers `decaytime+/-` which was missing
  from the old flat-list check

## Test plan
- [ ] `python3 -m pytest tests/ -x -q` — 1212 tests passing

Closes #115 
