### PR TITLE
refactor(stats): remove unused _parent, __deepcopy__, and copy() from…

### DIFF
--- a/pyneuromatic/analysis/nm_stat_utilities.py
+++ b/pyneuromatic/analysis/nm_stat_utilities.py
@@ -21,7 +21,6 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 import math
-from typing import Any
 
 import numpy as np
 

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -24,9 +24,8 @@ from typing import Any
 
 import numpy as np
 
-from pyneuromatic.analysis.nm_stat_func import FUNC_NAMES_BSLN  # noqa: F401
 from pyneuromatic.analysis.nm_stat_utilities import stats
-from pyneuromatic.analysis.nm_stat_win import NMStatWin, NMStatWinContainer  # noqa: F401
+from pyneuromatic.analysis.nm_stat_win import NMStatWinContainer  # noqa: F401
 from pyneuromatic.analysis.nm_tool import NMTool
 from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
 from pyneuromatic.core.nm_data import NMData
@@ -57,7 +56,7 @@ class NMToolStats(NMTool):
 
     def __init__(self) -> None:
 
-        self.__win_container = NMStatWinContainer(parent=self)
+        self.__win_container = NMStatWinContainer()
         self.__win_container.new()
 
         self.__xclip = True

--- a/tests/test_analysis/test_nm_stat_func.py
+++ b/tests/test_analysis/test_nm_stat_func.py
@@ -85,10 +85,9 @@ class TestNMStatFunc(unittest.TestCase):
         self.assertIn("NMStatFuncBasic", repr(t))
         self.assertIn("mean", repr(t))
 
-    def test_deepcopy_resets_parent(self):
-        t = nmsf.NMStatFuncBasic("mean", parent=object())
+    def test_deepcopy(self):
+        t = nmsf.NMStatFuncBasic("mean")
         t2 = copy.deepcopy(t)
-        self.assertIsNone(t2._parent)
         self.assertEqual(t, t2)
 
     def test_validate_baseline_is_noop(self):

--- a/tests/test_analysis/test_nm_stat_win.py
+++ b/tests/test_analysis/test_nm_stat_win.py
@@ -66,8 +66,8 @@ class TestNMStatWin(unittest.TestCase):
             "bsln_x0": 0,
             "bsln_x1": 10,
         }
-        self.w0 = nmsw.NMStatWin(NM, "w0", win=self.win0)
-        self.w1 = nmsw.NMStatWin(NM, "w1", win=self.win1)
+        self.w0 = nmsw.NMStatWin("w0", win=self.win0)
+        self.w1 = nmsw.NMStatWin("w1", win=self.win1)
         self.data = _make_data(n=n)
         self.datanan = _make_data(n=n, with_nans=True)
 
@@ -82,7 +82,7 @@ class TestNMStatWin(unittest.TestCase):
         self.assertFalse(self.w0 == self.w1)
 
     def test_eq_same_after_copy(self):
-        c = self.w0.copy()
+        c = nmsw.NMStatWin(name=self.w0.name, win=self.w0.to_dict())
         self.assertTrue(self.w0 == c)
 
     def test_eq_after_win_set(self):


### PR DESCRIPTION

## Summary
- Removed unused `_parent` parameter and storage from `NMStatFunc`, `NMStatWin`, and `NMStatWinContainer` — it was forwarded down the chain but never read at any level
- Removed `__deepcopy__` methods from `NMStatFunc` and `NMStatWin`, which existed solely to reset `_parent` to `None` on copy
- Removed `copy()` method and `import copy` from `NMStatWin` — the `to_dict()` round-trip is the idiomatic NM equivalent

## Test plan
- [ ] Updated `test_nm_stat_win.py`: removed stale `NM` positional arg from two `NMStatWin()` constructor calls
- [ ] Updated `test_nm_stat_func.py`: replaced `test_deepcopy_resets_parent` with `test_deepcopy` (no parent arg)
- [ ] Updated `test_nm_stat_win.py`: replaced `w.copy()` with `NMStatWin(name=w.name, win=w.to_dict())`
- [ ] All 1212 tests pass

Closes #125
