### PR TITLE
feat(NMToolStats2): add histogram() method

### DIFF
--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -278,45 +278,45 @@ class TestNMToolStats2(unittest.TestCase):
         r = self.tool2.stats(self.tf, select="ST_w0_nan_s", ignore_nans=False)
         self.assertEqual(r["ST_w0_nan_s"]["N"], 3)  # NaN counted
 
-    # --- compute() type validation ---
+    # --- stats() type validation ---
 
-    def test_compute_rejects_non_toolfolder(self):
+    def test_stats_rejects_non_toolfolder(self):
         with self.assertRaises(TypeError):
             self.tool2.stats("bad")
 
-    def test_compute_rejects_non_string_select(self):
+    def test_stats_rejects_non_string_select(self):
         with self.assertRaises(TypeError):
             self.tool2.stats(self.tf, select=123)
 
-    def test_compute_unknown_select_raises(self):
+    def test_stats_unknown_select_raises(self):
         with self.assertRaises(KeyError):
             self.tool2.stats(self.tf, select="ST_w0_missing")
 
-    # --- compute() results ---
+    # --- stats() results ---
 
-    def test_compute_all_returns_dict(self):
+    def test_stats_all_returns_dict(self):
         r = self.tool2.stats(self.tf, select="all")
         self.assertIsInstance(r, dict)
 
-    def test_compute_all_keys_are_st_arrays(self):
+    def test_stats_all_keys_are_st_arrays(self):
         r = self.tool2.stats(self.tf, select="all")
         self.assertIn("ST_w0_main_s", r)
         self.assertIn("ST_w0_bsln_s", r)
 
-    def test_compute_all_excludes_data_array(self):
+    def test_stats_all_excludes_data_array(self):
         r = self.tool2.stats(self.tf, select="all")
         self.assertNotIn("ST_w0_data", r)
 
-    def test_compute_single_array(self):
+    def test_stats_single_array(self):
         r = self.tool2.stats(self.tf, select="ST_w0_main_s")
         self.assertIn("ST_w0_main_s", r)
         self.assertEqual(len(r), 1)
 
-    def test_compute_mean_correct(self):
+    def test_stats_mean_correct(self):
         r = self.tool2.stats(self.tf, select="ST_w0_main_s")
         self.assertAlmostEqual(r["ST_w0_main_s"]["mean"], 3.0)
 
-    def test_compute_N_correct(self):
+    def test_stats_N_correct(self):
         r = self.tool2.stats(self.tf, select="ST_w0_main_s")
         self.assertEqual(r["ST_w0_main_s"]["N"], 5)
 
@@ -347,6 +347,98 @@ class TestNMToolStats2(unittest.TestCase):
         self.tool2.stats(self.tf, select="ST_w0_main_s")
         d = self.tf.data.get("ST2_mean")
         self.assertAlmostEqual(d.nparray[0], 3.0)
+
+
+class TestNMToolStats2Histogram(unittest.TestCase):
+    """Tests for NMToolStats2.histogram()."""
+
+    def setUp(self):
+        from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
+        self.tool2 = nms.NMToolStats2()
+        self.tf = NMToolFolder(name="stats0")
+        arr = np.array([1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 5.0])
+        self.tf.data.new("ST_w0_main_s", nparray=arr)
+
+    # --- return value ---
+
+    def test_histogram_returns_dict(self):
+        r = self.tool2.histogram(self.tf, "ST_w0_main_s")
+        self.assertIsInstance(r, dict)
+        self.assertIn("counts", r)
+        self.assertIn("edges", r)
+
+    def test_histogram_counts_length(self):
+        r = self.tool2.histogram(self.tf, "ST_w0_main_s", bins=4)
+        self.assertEqual(len(r["counts"]), 4)
+
+    def test_histogram_edges_length(self):
+        r = self.tool2.histogram(self.tf, "ST_w0_main_s", bins=4)
+        self.assertEqual(len(r["edges"]), 5)  # bins + 1
+
+    def test_histogram_counts_sum(self):
+        r = self.tool2.histogram(self.tf, "ST_w0_main_s", bins=4)
+        self.assertEqual(sum(r["counts"]), 9)  # all 9 values counted
+
+    # --- saved arrays (save_to_numpy=True, default) ---
+
+    def test_histogram_saves_counts_array(self):
+        self.tool2.histogram(self.tf, "ST_w0_main_s", bins=4)
+        self.assertIn("HIST_ST_w0_main_s_counts", self.tf.data)
+
+    def test_histogram_saves_edges_array(self):
+        self.tool2.histogram(self.tf, "ST_w0_main_s", bins=4)
+        self.assertIn("HIST_ST_w0_main_s_edges", self.tf.data)
+
+    def test_histogram_xscale_start(self):
+        self.tool2.histogram(self.tf, "ST_w0_main_s", bins=4)
+        d = self.tf.data.get("HIST_ST_w0_main_s_counts")
+        self.assertAlmostEqual(d.xscale.start, 1.0)
+
+    def test_histogram_xscale_delta(self):
+        self.tool2.histogram(self.tf, "ST_w0_main_s", bins=4)
+        d = self.tf.data.get("HIST_ST_w0_main_s_counts")
+        self.assertAlmostEqual(d.xscale.delta, 1.0)  # (5 - 1) / 4 = 1.0
+
+    # --- save_to_numpy=False ---
+
+    def test_histogram_no_save_skips_arrays(self):
+        self.tool2.histogram(self.tf, "ST_w0_main_s", bins=4, save_to_numpy=False)
+        self.assertNotIn("HIST_ST_w0_main_s_counts", self.tf.data)
+        self.assertNotIn("HIST_ST_w0_main_s_edges", self.tf.data)
+
+    def test_histogram_no_save_still_returns_dict(self):
+        r = self.tool2.histogram(self.tf, "ST_w0_main_s", bins=4,
+                                 save_to_numpy=False)
+        self.assertIn("counts", r)
+        self.assertIn("edges", r)
+
+    # --- NaN/Inf handling ---
+
+    def test_histogram_strips_nans(self):
+        arr_nan = np.array([1.0, 2.0, np.nan, 3.0])
+        self.tf.data.new("ST_w0_nan_s", nparray=arr_nan)
+        r = self.tool2.histogram(self.tf, "ST_w0_nan_s", bins=3)
+        self.assertEqual(sum(r["counts"]), 3)  # NaN excluded
+
+    def test_histogram_strips_infs(self):
+        arr_inf = np.array([1.0, 2.0, np.inf, 3.0])
+        self.tf.data.new("ST_w0_inf_s", nparray=arr_inf)
+        r = self.tool2.histogram(self.tf, "ST_w0_inf_s", bins=3)
+        self.assertEqual(sum(r["counts"]), 3)  # Inf excluded
+
+    # --- type validation ---
+
+    def test_histogram_rejects_non_toolfolder(self):
+        with self.assertRaises(TypeError):
+            self.tool2.histogram("bad", "ST_w0_main_s")
+
+    def test_histogram_rejects_non_string_name(self):
+        with self.assertRaises(TypeError):
+            self.tool2.histogram(self.tf, 123)
+
+    def test_histogram_unknown_name_raises(self):
+        with self.assertRaises(KeyError):
+            self.tool2.histogram(self.tf, "ST_w0_missing")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `NMToolStats2.histogram()` to compute a histogram of a single ST_ array using `numpy.histogram()`
- NaN and Inf values are excluded before computing
- `save_to_numpy=True` (default) saves `HIST_{name}_counts` (with x-scaling from bin edges) and `HIST_{name}_edges` as NMData arrays in the toolfolder
- `save_to_numpy=False` returns the result dict without saving, for users who just want the numpy arrays directly
- minor: in TestNMToolStats2, changed "compute" to "stats"

## Test plan
- [ ] `test_histogram_returns_dict` — returns `{"counts", "edges"}`
- [ ] `test_histogram_counts_length` / `test_histogram_edges_length` — correct array sizes
- [ ] `test_histogram_counts_sum` — all values counted
- [ ] `test_histogram_saves_counts_array` / `test_histogram_saves_edges_array` — HIST_ arrays created
- [ ] `test_histogram_xscale_start` / `test_histogram_xscale_delta` — x-scaling correct
- [ ] `test_histogram_strips_nans` / `test_histogram_strips_infs` — NaN/Inf excluded
- [ ] `test_histogram_no_save_skips_arrays` / `test_histogram_no_save_still_returns_dict` — save_to_numpy=False
- [ ] Type validation tests (TypeError, KeyError)
- [ ] All 1227 tests pass

Closes #129 
