### PR TITLE
feat: rename NMToolStats output folder to stats_{dataseries}_N

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -333,8 +333,9 @@ class NMToolStats(NMTool):
     def _results_to_numpy(self) -> NMToolFolder | None:
         """Write results as ST_ NMData arrays in a new NMToolFolder.
 
-        Creates a new folder named ``stats0``, ``stats1``, … (first unused
-        name) under the current folder's toolfolder, then writes one NMData
+        Creates a new folder named ``stats_{dataseries}_0``,
+        ``stats_{dataseries}_1``, … (first unused name) under the current
+        folder's toolfolder, then writes one NMData
         array per numeric result key per window/id combination, named
         ``ST_{wname}_{id}_{suffix}``.  String data paths are saved as
         ``ST_{wname}_data``.
@@ -347,13 +348,18 @@ class NMToolStats(NMTool):
         if not self.__results:
             raise RuntimeError("there are no results to save")
 
-        # Find next unused folder name stats0, stats1, ...
+        # Find next unused folder name stats_{dataseries}_N, ...
         tf = self.folder.toolfolder
+        ds = self.dataseries
+        if ds is not None:
+            base = "stats_%s" % ds.name
+        else:
+            base = "stats"
         i = 0
         f = None
         while f is None:
             try:
-                f = tf.new(name="stats%d" % i)
+                f = tf.new(name="%s_%d" % (base, i))
             except KeyError:
                 i += 1
 

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -145,20 +145,32 @@ class TestNMToolStats(unittest.TestCase):
         f = self.tool._results_to_numpy()
         self.assertIsInstance(f, NMToolFolder)
 
-    def test_results_to_numpy_folder_named_stats0(self):
+    def test_results_to_numpy_folder_named_stats_0_no_dataseries(self):
+        # No dataseries selected → fallback name "stats_0"
         self._setup_folder()
         self._run_compute()
         f = self.tool._results_to_numpy()
-        self.assertEqual(f.name, "stats0")
+        self.assertEqual(f.name, "stats_0")
 
-    def test_results_to_numpy_second_run_named_stats1(self):
+    def test_results_to_numpy_second_run_named_stats_1_no_dataseries(self):
+        # Second run with no dataseries → "stats_1"
         self._setup_folder()
         self._run_compute()
         self.tool._results_to_numpy()
         self.tool._NMToolStats__results.clear()
         self._run_compute()
         f = self.tool._results_to_numpy()
-        self.assertEqual(f.name, "stats1")
+        self.assertEqual(f.name, "stats_1")
+
+    def test_results_to_numpy_folder_named_with_dataseries(self):
+        # Dataseries selected → name uses dataseries name
+        from pyneuromatic.core.nm_dataseries import NMDataSeries
+        self._setup_folder()
+        ds = NMDataSeries(name="Record")
+        self.tool._select["dataseries"] = ds
+        self._run_compute()
+        f = self.tool._results_to_numpy()
+        self.assertEqual(f.name, "stats_Record_0")
 
     def test_results_to_numpy_creates_data_array(self):
         self._setup_folder()


### PR DESCRIPTION
## Summary

1. NMToolStats._results_to_numpy() now names the output NMToolFolder using the dataseries name (e.g. stats_Record_0, stats_Avg_1) so users can immediately identify the data source
2. Falls back to stats_N (e.g. stats_0) when no dataseries is selected
3. Updates two existing naming tests and adds one new test for the dataseries case

## Test plan

1.  test_results_to_numpy_folder_named_stats_0_no_dataseries — fallback name when no dataseries
2.  test_results_to_numpy_second_run_named_stats_1_no_dataseries — sequential increment with fallback
3.  test_results_to_numpy_folder_named_with_dataseries — dataseries name used when set
4.  Full test suite passes (55 tests)

Closes #135