### PR TITLE
feat: add channel name to NMToolStats output folder name

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -453,13 +453,16 @@ class NMToolStats(NMTool):
         if not self.__results:
             raise RuntimeError("there are no results to save")
 
-        # Find next unused folder name stats_{dataseries}_N, ...
+        # Find next unused folder name stats_{dataseries}_{channel}_N, ...
         tf = self.folder.toolfolder
         ds = self.dataseries
+        ch = self.channel
+        parts = ["stats"]
         if ds is not None:
-            base = "stats_%s" % ds.name
-        else:
-            base = "stats"
+            parts.append(ds.name)
+        if ch is not None:
+            parts.append(ch.name)
+        base = "_".join(parts)
         i = 0
         f = None
         while f is None:

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -188,6 +188,26 @@ class TestNMToolStats(unittest.TestCase):
         f = self.tool._results_to_numpy()
         self.assertEqual(f.name, "stats_Record_0")
 
+    def test_results_to_numpy_folder_named_with_dataseries_and_channel(self):
+        # Dataseries + channel → stats_{ds}_{ch}_N
+        from pyneuromatic.core.nm_dataseries import NMDataSeries
+        from pyneuromatic.core.nm_channel import NMChannel
+        self._setup_folder()
+        self.tool._select["dataseries"] = NMDataSeries(name="Record")
+        self.tool._select["channel"] = NMChannel(name="A")
+        self._run_compute()
+        f = self.tool._results_to_numpy()
+        self.assertEqual(f.name, "stats_Record_A_0")
+
+    def test_results_to_numpy_folder_named_channel_only(self):
+        # Channel but no dataseries → stats_{ch}_N
+        from pyneuromatic.core.nm_channel import NMChannel
+        self._setup_folder()
+        self.tool._select["channel"] = NMChannel(name="B")
+        self._run_compute()
+        f = self.tool._results_to_numpy()
+        self.assertEqual(f.name, "stats_B_0")
+
     def test_results_to_numpy_creates_data_array(self):
         self._setup_folder()
         self._run_compute(n_waves=3)


### PR DESCRIPTION
## Summary

- NMToolStats._results_to_numpy() now includes channel name in the output NMToolFolder name, separating results from different channels into distinct folders
- Name pattern: stats_{dataseries}_{channel}_N (e.g. stats_Record_A_0, stats_Record_B_0)
- Graceful fallback when dataseries or channel are not selected:
   -    ds + ch → stats_Record_A_0
   -    ds only → stats_Record_0
   -    ch only → stats_A_0
   -    neither → stats_0

## Test plan

-  test_results_to_numpy_folder_named_with_dataseries_and_channel — stats_Record_A_0
-  test_results_to_numpy_folder_named_channel_only — stats_B_0
-  Full test suite passes (1232 tests)

Closes #139 