### PR TITLE
feat: add run_meta to NMTool for full run context tracking

### DIFF
--- a/pyneuromatic/core/nm_manager.py
+++ b/pyneuromatic/core/nm_manager.py
@@ -111,6 +111,7 @@ class NMManager:
 
         self.__toolkit: dict[str, "NMTool"] = {}
         self.__toolselect: str | None = None
+        self.__run_config: dict | None = None
 
         # Load workspace (or default)
         self._load_workspace_internal(workspace, quiet=quiet)
@@ -571,6 +572,7 @@ class NMManager:
 
             result = self.run_keys(dataseries_priority=False)
             self._check_max_targets(result, max_targets)
+            self.__run_config = dict(run)
             return result
 
         # Dataseries mode - requires dataseries, channel, epoch
@@ -593,6 +595,7 @@ class NMManager:
 
         result = self.run_keys(dataseries_priority=True)
         self._check_max_targets(result, max_targets)
+        self.__run_config = dict(run)
         return result
 
     def _check_max_targets(
@@ -625,6 +628,7 @@ class NMManager:
                     continue
                 ds.channels.run_target = RUN_SELECTED
                 ds.epochs.run_target = RUN_SELECTED
+        self.__run_config = None
         return None
 
     def run_tool(
@@ -669,7 +673,7 @@ class NMManager:
         targets = self.run_values()
         if not targets:
             print("nothing to run")
-        return tool.run_all(targets)
+        return tool.run_all(targets, run_keys=self.__run_config)
 
     # Workspace methods
 


### PR DESCRIPTION
## Summary
- Adds `run_meta` dict property to `NMTool`, populated at the start of
  each `run_all()` call before `run_init()` is invoked, so subclasses
  can access it throughout the run lifecycle
- `run_meta` contains: `date` (ISO timestamp), `run_keys` (copy of the
  run configuration dict, capturing set names for any level), and
  `folders`/`dataseries`/`channels`/`epochs` (unique names actually
  processed, in order of first encounter)
- `NMManager` stores `__run_config` after each `run_keys_set()` call
  (cleared by `run_reset_all()`) and passes it to `tool.run_all()` via
  `run_tool()` — preserving the original set names (e.g. `"ChanSet1"`,
  `"all"`) that are lost once targets are expanded

## Test plan
- [ ] `TestNMToolRunMeta` — 18 tests: date, run_keys storage, copy
  isolation, channel/folder/dataseries/epoch accumulation, deduplication,
  order preservation, accessibility from `run_init`/`run_finish`, reset
  between runs
- [ ] `TestNMManagerRunConfig` — 3 tests: epoch set name propagated via
  `run_tool()`, epoch list matches targets, reset clears run_keys
- [ ] Full suite: `python3 -m pytest tests/ -x -q` → 1265 passed

Closes #143 
