### PR TITLE
feat(analysis): add NMToolStats2.inequality() with op/a/b API

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -755,12 +755,9 @@ class NMToolStats2:
     def inequality(
         toolfolder: NMToolFolder,
         name: str,
-        greater_than: float | None = None,
-        greater_than_or_equal: float | None = None,
-        less_than: float | None = None,
-        less_than_or_equal: float | None = None,
-        equal: float | None = None,
-        not_equal: float | None = None,
+        op: str,
+        a: float,
+        b: float | None = None,
         binary_output: bool = True,
         dataseries: NMDataSeries | None = None,
         set_name_success: str | None = None,
@@ -769,22 +766,21 @@ class NMToolStats2:
     ) -> dict:
         """Filter an ST_ array by an inequality condition.
 
-        Applies one or more threshold conditions (AND logic) to each value in
-        the named ST_ array and returns a result array plus success/failure
-        counts.  Optionally creates epoch sets from the passing and failing
-        epochs.
+        Applies a threshold condition to each value in the named ST_ array
+        and returns a result array plus success/failure counts.  Optionally
+        creates epoch sets from the passing and failing epochs.
 
         This mirrors the Igor NeuroMatic ``NMStatsInequality()`` function.
 
         Args:
             toolfolder: NMToolFolder containing the ST_ array.
             name: Name of the ST_ array to filter (e.g. ``"ST_w0_max_y"``).
-            greater_than: Keep values where ``y > greater_than``.
-            greater_than_or_equal: Keep values where ``y >= greater_than_or_equal``.
-            less_than: Keep values where ``y < less_than``.
-            less_than_or_equal: Keep values where ``y <= less_than_or_equal``.
-            equal: Keep values where ``y == equal``.
-            not_equal: Keep values where ``y != not_equal``.
+            op: Comparison operator.  Single-threshold: ``">"``, ``">="``,
+                ``"<"``, ``"<="``, ``"=="``, ``"!="``.  Range (requires
+                ``b``): ``"<<"`` (a < y < b), ``"<=<="`` (a <= y <= b),
+                ``"<=<"`` (a <= y < b), ``"<<="`` (a < y <= b).
+            a: Threshold value (or lower bound for range operators).
+            b: Upper bound; required for range operators.
             binary_output: If True (default), result array contains 1.0
                 (pass) or 0.0 (fail).  If False, result contains the
                 original value where the condition is met and NaN elsewhere.
@@ -809,22 +805,27 @@ class NMToolStats2:
         Raises:
             TypeError: If toolfolder is not NMToolFolder or name is not str.
             KeyError: If name is not found in toolfolder.
-            ValueError: If the named array has no data, or no condition is
-                specified.
+            ValueError: If the named array has no data, op is unrecognised,
+                or a range op is given without b.
         """
+        _SINGLE_OPS = frozenset({">", ">=", "<", "<=", "==", "!="})
+        _RANGE_OPS = frozenset({"<<", "<=<=", "<=<", "<<="})
+
         if not isinstance(toolfolder, NMToolFolder):
             raise TypeError(
                 nmu.type_error_str(toolfolder, "toolfolder", "NMToolFolder")
             )
         if not isinstance(name, str):
             raise TypeError(nmu.type_error_str(name, "name", "string"))
-
-        conditions_specified = [
-            greater_than, greater_than_or_equal, less_than,
-            less_than_or_equal, equal, not_equal,
-        ]
-        if all(v is None for v in conditions_specified):
-            raise ValueError("at least one inequality condition must be specified")
+        if op not in _SINGLE_OPS | _RANGE_OPS:
+            raise ValueError(
+                "unknown operator %r. Single: %s; range: %s"
+                % (op, sorted(_SINGLE_OPS), sorted(_RANGE_OPS))
+            )
+        if op in _RANGE_OPS and b is None:
+            raise ValueError(
+                "range operator %r requires b to be specified" % op
+            )
 
         d = toolfolder.data.get(name)
         if d is None:
@@ -834,20 +835,27 @@ class NMToolStats2:
 
         arr = d.nparray.astype(float)
 
-        # Build boolean mask — AND logic, NaN propagates as False
-        mask = np.ones(len(arr), dtype=bool)
-        if greater_than is not None:
-            mask &= arr > greater_than
-        if greater_than_or_equal is not None:
-            mask &= arr >= greater_than_or_equal
-        if less_than is not None:
-            mask &= arr < less_than
-        if less_than_or_equal is not None:
-            mask &= arr <= less_than_or_equal
-        if equal is not None:
-            mask &= arr == equal
-        if not_equal is not None:
-            mask &= arr != not_equal
+        # Build boolean mask — NaN propagates as False in comparisons
+        if op == ">":
+            mask = arr > a
+        elif op == ">=":
+            mask = arr >= a
+        elif op == "<":
+            mask = arr < a
+        elif op == "<=":
+            mask = arr <= a
+        elif op == "==":
+            mask = arr == a
+        elif op == "!=":
+            mask = arr != a
+        elif op == "<<":     # a < y < b
+            mask = (arr > a) & (arr < b)
+        elif op == "<=<=":   # a <= y <= b
+            mask = (arr >= a) & (arr <= b)
+        elif op == "<=<":    # a <= y < b
+            mask = (arr >= a) & (arr < b)
+        else:                # op == "<<="  a < y <= b
+            mask = (arr > a) & (arr <= b)
 
         if binary_output:
             result = mask.astype(float)
@@ -857,12 +865,7 @@ class NMToolStats2:
         successes = int(np.sum(mask))
         failures = len(mask) - successes
 
-        # Build human-readable condition string
-        condition = NMToolStats2._inequality_condition_str(
-            greater_than, greater_than_or_equal,
-            less_than, less_than_or_equal,
-            equal, not_equal,
-        )
+        condition = NMToolStats2._inequality_condition_str(op, a, b)
 
         if save_to_numpy and toolfolder.data is not None:
             toolfolder.data.new("IQ_%s" % name, nparray=result)
@@ -922,42 +925,19 @@ class NMToolStats2:
         }
 
     @staticmethod
-    def _inequality_condition_str(
-        greater_than: float | None,
-        greater_than_or_equal: float | None,
-        less_than: float | None,
-        less_than_or_equal: float | None,
-        equal: float | None,
-        not_equal: float | None,
-    ) -> str:
+    def _inequality_condition_str(op: str, a: float, b: float | None) -> str:
         """Build a human-readable condition string for inequality().
 
-        Examples: ``"y > 50"``, ``"20 < y < 100"``, ``"y == 0"``.
+        Examples: ``"y > 50"``, ``"2 < y < 5"``, ``"y == 0"``.
         """
-        if equal is not None:
-            return "y == %g" % equal
-        if not_equal is not None:
-            return "y != %g" % not_equal
-
-        lo_str = ""
-        hi_str = ""
-
-        if greater_than is not None:
-            lo_str = "%g <" % greater_than
-        elif greater_than_or_equal is not None:
-            lo_str = "%g <=" % greater_than_or_equal
-
-        if less_than is not None:
-            hi_str = "< %g" % less_than
-        elif less_than_or_equal is not None:
-            hi_str = "<= %g" % less_than_or_equal
-
-        if lo_str and hi_str:
-            return "%s y %s" % (lo_str, hi_str)   # "20 < y < 100"
-        if lo_str:
-            if greater_than is not None:
-                return "y > %g" % greater_than
-            return "y >= %g" % greater_than_or_equal
-        if hi_str:
-            return "y %s" % hi_str   # "y < 100" or "y <= 100"
+        if op == ">":   return "y > %g" % a
+        if op == ">=":  return "y >= %g" % a
+        if op == "<":   return "y < %g" % a
+        if op == "<=":  return "y <= %g" % a
+        if op == "==":  return "y == %g" % a
+        if op == "!=":  return "y != %g" % a
+        if op == "<<":   return "%g < y < %g" % (a, b)
+        if op == "<=<=": return "%g <= y <= %g" % (a, b)
+        if op == "<=<":  return "%g <= y < %g" % (a, b)
+        if op == "<<=":  return "%g < y <= %g" % (a, b)
         return ""

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -495,7 +495,6 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def setUp(self):
         from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
-        from pyneuromatic.core.nm_folder import NMFolder
         from pyneuromatic.core.nm_dataseries import NMDataSeries
 
         self.tf = NMToolFolder(name="stats0")
@@ -522,53 +521,65 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def test_condition_str_greater_than(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", greater_than=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", ">", 3, save_to_numpy=False
         )
         self.assertEqual(r["condition"], "y > 3")
 
     def test_condition_str_greater_than_or_equal(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y",
-            greater_than_or_equal=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", ">=", 3, save_to_numpy=False
         )
         self.assertEqual(r["condition"], "y >= 3")
 
     def test_condition_str_less_than(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", less_than=4, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "<", 4, save_to_numpy=False
         )
         self.assertEqual(r["condition"], "y < 4")
 
     def test_condition_str_less_than_or_equal(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", less_than_or_equal=4, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "<=", 4, save_to_numpy=False
         )
         self.assertEqual(r["condition"], "y <= 4")
 
-    def test_condition_str_range(self):
+    def test_condition_str_range_exclusive(self):
+        # "<<" → a < y < b
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y",
-            greater_than=2, less_than=5, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "<<", 2, 5, save_to_numpy=False
         )
         self.assertEqual(r["condition"], "2 < y < 5")
 
     def test_condition_str_range_inclusive(self):
+        # "<=<=" → a <= y <= b
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y",
-            greater_than_or_equal=2, less_than_or_equal=4,
-            save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "<=<=", 2, 4, save_to_numpy=False
         )
         self.assertEqual(r["condition"], "2 <= y <= 4")
 
+    def test_condition_str_range_half_open_left(self):
+        # "<=<" → a <= y < b
+        r = nms.NMToolStats2.inequality(
+            self.tf, "ST_w0_mean_y", "<=<", 2, 5, save_to_numpy=False
+        )
+        self.assertEqual(r["condition"], "2 <= y < 5")
+
+    def test_condition_str_range_half_open_right(self):
+        # "<<=" → a < y <= b
+        r = nms.NMToolStats2.inequality(
+            self.tf, "ST_w0_mean_y", "<<=", 2, 5, save_to_numpy=False
+        )
+        self.assertEqual(r["condition"], "2 < y <= 5")
+
     def test_condition_str_equal(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", equal=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "==", 3, save_to_numpy=False
         )
         self.assertEqual(r["condition"], "y == 3")
 
     def test_condition_str_not_equal(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", not_equal=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "!=", 3, save_to_numpy=False
         )
         self.assertEqual(r["condition"], "y != 3")
 
@@ -576,7 +587,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def test_greater_than_mask(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", greater_than=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", ">", 3, save_to_numpy=False
         )
         expected = np.array([False, False, False, True, True])
         np.testing.assert_array_equal(r["mask"], expected)
@@ -585,7 +596,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def test_less_than_mask(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", less_than=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "<", 3, save_to_numpy=False
         )
         expected = np.array([True, True, False, False, False])
         np.testing.assert_array_equal(r["mask"], expected)
@@ -593,10 +604,9 @@ class TestNMToolStats2Inequality(unittest.TestCase):
         self.assertEqual(r["failures"], 3)
 
     def test_range_mask(self):
-        # 2 < y < 5 → [2, 3, 4] pass
+        # "<<" → 2 < y < 5 → [3, 4] pass (not 2, not 5)
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y",
-            greater_than=2, less_than=5, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "<<", 2, 5, save_to_numpy=False
         )
         expected = np.array([False, False, True, True, False])
         np.testing.assert_array_equal(r["mask"], expected)
@@ -604,7 +614,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def test_equal_mask(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", equal=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "==", 3, save_to_numpy=False
         )
         expected = np.array([False, False, True, False, False])
         np.testing.assert_array_equal(r["mask"], expected)
@@ -612,7 +622,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def test_not_equal_mask(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", not_equal=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", "!=", 3, save_to_numpy=False
         )
         self.assertEqual(r["successes"], 4)
 
@@ -622,7 +632,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
             nparray=np.array([1.0, np.nan, 3.0, 4.0, 5.0])
         )
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_nan_y", greater_than=0, save_to_numpy=False
+            self.tf, "ST_w0_nan_y", ">", 0, save_to_numpy=False
         )
         # NaN > 0 is False
         self.assertEqual(r["successes"], 4)
@@ -632,7 +642,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def test_binary_output_true(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", greater_than=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", ">", 3, save_to_numpy=False
         )
         np.testing.assert_array_equal(
             r["result"], np.array([0.0, 0.0, 0.0, 1.0, 1.0])
@@ -640,7 +650,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def test_binary_output_false(self):
         r = nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", greater_than=3,
+            self.tf, "ST_w0_mean_y", ">", 3,
             binary_output=False, save_to_numpy=False
         )
         expected = np.array([np.nan, np.nan, np.nan, 4.0, 5.0])
@@ -657,13 +667,13 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def test_save_to_numpy_creates_iq_array(self):
         nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", greater_than=3, save_to_numpy=True
+            self.tf, "ST_w0_mean_y", ">", 3, save_to_numpy=True
         )
         self.assertIn("IQ_ST_w0_mean_y", self.tf.data)
 
     def test_save_to_numpy_false_does_not_create_array(self):
         nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", greater_than=3, save_to_numpy=False
+            self.tf, "ST_w0_mean_y", ">", 3, save_to_numpy=False
         )
         self.assertNotIn("IQ_ST_w0_mean_y", self.tf.data)
 
@@ -671,7 +681,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
     def test_set_name_success_creates_epoch_set(self):
         nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", greater_than=3,
+            self.tf, "ST_w0_mean_y", ">", 3,
             dataseries=self.ds,
             set_name_success="Successes",
             save_to_numpy=False,
@@ -680,9 +690,9 @@ class TestNMToolStats2Inequality(unittest.TestCase):
         self.assertIsNotNone(set_epochs)
 
     def test_set_name_success_contains_correct_epochs(self):
-        # greater_than=3 → E3, E4 pass
+        # ">" 3 → E3, E4 pass
         nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", greater_than=3,
+            self.tf, "ST_w0_mean_y", ">", 3,
             dataseries=self.ds,
             set_name_success="Pass",
             save_to_numpy=False,
@@ -694,9 +704,9 @@ class TestNMToolStats2Inequality(unittest.TestCase):
         self.assertNotIn("E0", epoch_names)
 
     def test_set_name_failure_contains_failing_epochs(self):
-        # greater_than=3 → E0, E1, E2 fail
+        # ">" 3 → E0, E1, E2 fail
         nms.NMToolStats2.inequality(
-            self.tf, "ST_w0_mean_y", greater_than=3,
+            self.tf, "ST_w0_mean_y", ">", 3,
             dataseries=self.ds,
             set_name_failure="Fail",
             save_to_numpy=False,
@@ -708,26 +718,32 @@ class TestNMToolStats2Inequality(unittest.TestCase):
         self.assertIn("E2", epoch_names)
         self.assertNotIn("E3", epoch_names)
 
-    # --- type validation ---
+    # --- type and value validation ---
 
     def test_bad_toolfolder_raises_typeerror(self):
         with self.assertRaises(TypeError):
             nms.NMToolStats2.inequality("not_a_folder", "ST_w0_mean_y",
-                                        greater_than=1)
+                                        ">", 1)
 
     def test_bad_name_raises_typeerror(self):
         with self.assertRaises(TypeError):
-            nms.NMToolStats2.inequality(self.tf, 123, greater_than=1)
+            nms.NMToolStats2.inequality(self.tf, 123, ">", 1)
 
     def test_unknown_name_raises_keyerror(self):
         with self.assertRaises(KeyError):
-            nms.NMToolStats2.inequality(self.tf, "ST_w0_missing",
-                                        greater_than=1)
+            nms.NMToolStats2.inequality(self.tf, "ST_w0_missing", ">", 1)
 
-    def test_no_condition_raises_valueerror(self):
+    def test_unknown_op_raises_valueerror(self):
         with self.assertRaises(ValueError):
-            nms.NMToolStats2.inequality(self.tf, "ST_w0_mean_y",
-                                        save_to_numpy=False)
+            nms.NMToolStats2.inequality(
+                self.tf, "ST_w0_mean_y", "??", 1, save_to_numpy=False
+            )
+
+    def test_range_op_without_b_raises_valueerror(self):
+        with self.assertRaises(ValueError):
+            nms.NMToolStats2.inequality(
+                self.tf, "ST_w0_mean_y", "<<", 1, save_to_numpy=False
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #145

- Add `NMToolStats2.inequality()` to filter ST_ arrays by threshold
  conditions, mirroring Igor `NMStatsInequality()`
- API uses `op` string + scalar `a` + optional `b` instead of six
  keyword params — single-threshold ops (`>`, `>=`, `<`, `<=`, `==`,
  `!=`) and range ops (`<<`, `<=<=`, `<=<`, `<<=`); range ops are
  derived by removing `y` from the compound inequality `a OP y OP b`
- Returns `result` array (binary 0/1 or value/NaN), boolean `mask`,
  success/failure counts, and a human-readable `condition` string
- Optionally saves `IQ_{name}` array to the NMToolFolder and creates
  epoch sets for passing/failing epochs from a linked NMDataSeries
- 28 tests in `TestNMToolStats2Inequality`

## Test plan
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_stats.py -v -k "Inequality"`
- [ ] `python3 -m pytest tests/ -x -q`
