### PR TITLE
feat(stats): add ks_test() to NMToolStats2 — two-sample Kolmogorov-Smirnov test

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -941,3 +941,110 @@ class NMToolStats2:
         if op == "<=<":  return "%g <= y < %g" % (a, b)
         if op == "<<=":  return "%g < y <= %g" % (a, b)
         return ""
+
+    @staticmethod
+    def ks_test(
+        toolfolder: NMToolFolder,
+        name1: str,
+        name2: str,
+        alpha: float = 0.05,
+        method: str = "auto",
+        save_to_numpy: bool = False,
+    ) -> dict:
+        """Two-sample Kolmogorov-Smirnov test on two ST_ arrays.
+
+        Determines whether two distributions of ST_ results are significantly
+        different.  NaN and Inf values are excluded before testing, matching
+        the Igor ``NMKSTest()`` behaviour of removing NaNs before sorting.
+
+        This mirrors the Igor NeuroMatic ``NMKSTest()`` function
+        (``NM_StatsTabKolmogorov.ipf``), originally written by Dr. Angus
+        Silver (UCL) based on *Numerical Recipes*.
+
+        Args:
+            toolfolder: NMToolFolder containing the ST_ arrays.
+            name1: Name of the first ST_ array (e.g. ``"ST_w0_peak_y"``).
+            name2: Name of the second ST_ array.
+            alpha: Significance level; ``significant`` is True when
+                ``pvalue <= alpha``.  Defaults to 0.05.
+            method: P-value calculation method forwarded to
+                ``scipy.stats.ks_2samp``.  One of ``"auto"`` (default),
+                ``"exact"``, or ``"asymp"``.
+            save_to_numpy: If True (default), save empirical CDF arrays to
+                toolfolder:
+
+                - ``KS_{name1}_sort``, ``KS_{name1}_ecdf``
+                - ``KS_{name2}_sort``, ``KS_{name2}_ecdf``
+
+        Returns:
+            Dict with keys:
+
+            - ``"d"``: KS statistic — max |CDF1 - CDF2|.
+            - ``"pvalue"``: p-value.
+            - ``"alpha"``: significance level (echoed from param).
+            - ``"significant"``: True if ``pvalue <= alpha``.
+            - ``"message"``: ``"different populations"`` or
+              ``"same population"``.
+            - ``"n1"``: sample size of arr1 after NaN/Inf removal.
+            - ``"n2"``: sample size of arr2 after NaN/Inf removal.
+
+        Raises:
+            TypeError: If toolfolder is not NMToolFolder or name1/name2 are
+                not strings.
+            KeyError: If name1 or name2 is not found in toolfolder.
+            ValueError: If the named array has no nparray data.
+            ImportError: If scipy is not installed.
+        """
+        from scipy.stats import ks_2samp  # noqa: PLC0415
+
+        if not isinstance(toolfolder, NMToolFolder):
+            raise TypeError(
+                nmu.type_error_str(toolfolder, "toolfolder", "NMToolFolder")
+            )
+        if not isinstance(name1, str):
+            raise TypeError(nmu.type_error_str(name1, "name1", "string"))
+        if not isinstance(name2, str):
+            raise TypeError(nmu.type_error_str(name2, "name2", "string"))
+
+        d1 = toolfolder.data.get(name1)
+        if d1 is None:
+            raise KeyError("array not found in toolfolder: %s" % name1)
+        if not isinstance(d1.nparray, np.ndarray):
+            raise ValueError("array has no nparray: %s" % name1)
+
+        d2 = toolfolder.data.get(name2)
+        if d2 is None:
+            raise KeyError("array not found in toolfolder: %s" % name2)
+        if not isinstance(d2.nparray, np.ndarray):
+            raise ValueError("array has no nparray: %s" % name2)
+
+        # Strip NaN/Inf — matches Igor's Redimension after Sort + WaveStats
+        arr1 = d1.nparray.astype(float)
+        arr2 = d2.nparray.astype(float)
+        arr1 = arr1[np.isfinite(arr1)]
+        arr2 = arr2[np.isfinite(arr2)]
+
+        stat, pvalue = ks_2samp(arr1, arr2, method=method)
+
+        significant = bool(pvalue <= alpha)
+        message = "different populations" if significant else "same population"
+
+        if save_to_numpy and toolfolder.data is not None:
+            sort1 = np.sort(arr1)
+            prob1 = np.arange(1, len(sort1) + 1) / len(sort1)
+            sort2 = np.sort(arr2)
+            prob2 = np.arange(1, len(sort2) + 1) / len(sort2)
+            toolfolder.data.new("KS_%s_sort" % name1, nparray=sort1)
+            toolfolder.data.new("KS_%s_ecdf" % name1, nparray=prob1)
+            toolfolder.data.new("KS_%s_sort" % name2, nparray=sort2)
+            toolfolder.data.new("KS_%s_ecdf" % name2, nparray=prob2)
+
+        return {
+            "d":           float(stat),
+            "pvalue":      float(pvalue),
+            "alpha":       float(alpha),
+            "significant": significant,
+            "message":     message,
+            "n1":          int(len(arr1)),
+            "n2":          int(len(arr2)),
+        }

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifiers=
 [options]
 install_requires =
     numpy
+    scipy
     h5py
     colorama
     tomli;python_version<"3.11"

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -746,5 +746,171 @@ class TestNMToolStats2Inequality(unittest.TestCase):
             )
 
 
+class TestNMToolStats2KSTest(unittest.TestCase):
+    """Tests for NMToolStats2.ks_test()."""
+
+    def setUp(self):
+        from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
+
+        rng = np.random.default_rng(42)
+        self.tf = NMToolFolder(name="stats0")
+
+        # Two clearly different distributions (mean 0 vs mean 10, n=50)
+        self.pop1 = rng.normal(loc=0, scale=1, size=50)
+        self.pop2 = rng.normal(loc=10, scale=1, size=50)
+        self.tf.data.new("ST_w0_pop1_y", nparray=self.pop1.copy())
+        self.tf.data.new("ST_w0_pop2_y", nparray=self.pop2.copy())
+
+        # Two samples from the same distribution
+        self.same1 = rng.normal(loc=0, scale=1, size=50)
+        self.same2 = rng.normal(loc=0, scale=1, size=50)
+        self.tf.data.new("ST_w0_same1_y", nparray=self.same1.copy())
+        self.tf.data.new("ST_w0_same2_y", nparray=self.same2.copy())
+
+    # --- return value structure ---
+
+    def test_ks_test_returns_dict(self):
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
+        )
+        for key in ("d", "pvalue", "alpha", "significant", "message", "n1", "n2"):
+            self.assertIn(key, r)
+
+    def test_ks_test_d_range(self):
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
+        )
+        self.assertGreaterEqual(r["d"], 0.0)
+        self.assertLessEqual(r["d"], 1.0)
+
+    def test_ks_test_pvalue_range(self):
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
+        )
+        self.assertGreaterEqual(r["pvalue"], 0.0)
+        self.assertLessEqual(r["pvalue"], 1.0)
+
+    # --- significance ---
+
+    def test_ks_test_significant_true(self):
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
+        )
+        self.assertTrue(r["significant"])
+
+    def test_ks_test_significant_false(self):
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_same1_y", "ST_w0_same2_y", save_to_numpy=False
+        )
+        self.assertFalse(r["significant"])
+
+    # --- message ---
+
+    def test_ks_test_message_different(self):
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
+        )
+        self.assertEqual(r["message"], "different populations")
+
+    def test_ks_test_message_same(self):
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_same1_y", "ST_w0_same2_y", save_to_numpy=False
+        )
+        self.assertEqual(r["message"], "same population")
+
+    # --- n1/n2 ---
+
+    def test_ks_test_n1_n2(self):
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
+        )
+        self.assertEqual(r["n1"], 50)
+        self.assertEqual(r["n2"], 50)
+
+    def test_ks_test_strips_nans(self):
+        arr_nan = np.concatenate([self.pop1, [np.nan, np.nan]])
+        self.tf.data.new("ST_w0_nan_y", nparray=arr_nan)
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_nan_y", "ST_w0_pop2_y", save_to_numpy=False
+        )
+        self.assertEqual(r["n1"], 50)  # 2 NaNs removed
+
+    # --- alpha ---
+
+    def test_ks_test_alpha_in_result(self):
+        r = nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y",
+            alpha=0.01, save_to_numpy=False
+        )
+        self.assertAlmostEqual(r["alpha"], 0.01)
+
+    # --- save_to_numpy ---
+
+    def test_ks_test_saves_sort_arrays(self):
+        nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=True
+        )
+        self.assertIn("KS_ST_w0_pop1_y_sort", self.tf.data)
+        self.assertIn("KS_ST_w0_pop2_y_sort", self.tf.data)
+
+    def test_ks_test_saves_ecdf_arrays(self):
+        nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=True
+        )
+        self.assertIn("KS_ST_w0_pop1_y_ecdf", self.tf.data)
+        self.assertIn("KS_ST_w0_pop2_y_ecdf", self.tf.data)
+
+    def test_ks_test_ecdf_values_in_range(self):
+        nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=True
+        )
+        ecdf = self.tf.data.get("KS_ST_w0_pop1_y_ecdf").nparray
+        self.assertTrue(np.all(ecdf >= 0.0))
+        self.assertTrue(np.all(ecdf <= 1.0))
+
+    def test_ks_test_ecdf_last_value_is_one(self):
+        nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=True
+        )
+        ecdf = self.tf.data.get("KS_ST_w0_pop1_y_ecdf").nparray
+        self.assertAlmostEqual(ecdf[-1], 1.0)
+
+    def test_ks_test_sort_array_is_sorted(self):
+        nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=True
+        )
+        sort_arr = self.tf.data.get("KS_ST_w0_pop1_y_sort").nparray
+        self.assertTrue(np.all(sort_arr[:-1] <= sort_arr[1:]))
+
+    def test_ks_test_no_save(self):
+        nms.NMToolStats2.ks_test(
+            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
+        )
+        self.assertNotIn("KS_ST_w0_pop1_y_sort", self.tf.data)
+        self.assertNotIn("KS_ST_w0_pop1_y_ecdf", self.tf.data)
+
+    # --- type validation ---
+
+    def test_ks_test_rejects_bad_toolfolder(self):
+        with self.assertRaises(TypeError):
+            nms.NMToolStats2.ks_test("bad", "ST_w0_pop1_y", "ST_w0_pop2_y")
+
+    def test_ks_test_rejects_bad_name1(self):
+        with self.assertRaises(TypeError):
+            nms.NMToolStats2.ks_test(self.tf, 123, "ST_w0_pop2_y")
+
+    def test_ks_test_rejects_bad_name2(self):
+        with self.assertRaises(TypeError):
+            nms.NMToolStats2.ks_test(self.tf, "ST_w0_pop1_y", 123)
+
+    def test_ks_test_unknown_name1_raises(self):
+        with self.assertRaises(KeyError):
+            nms.NMToolStats2.ks_test(self.tf, "ST_w0_missing", "ST_w0_pop2_y")
+
+    def test_ks_test_unknown_name2_raises(self):
+        with self.assertRaises(KeyError):
+            nms.NMToolStats2.ks_test(self.tf, "ST_w0_pop1_y", "ST_w0_missing")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Add `NMToolStats2.ks_test()` — two-sample KS test on ST_ arrays
- Add `scipy` to `install_requires`
- Add `TestNMToolStats2KSTest` (21 tests)

## Details

Ports the Igor NeuroMatic `NMKSTest()` function
(`NM_StatsTabKolmogorov.ipf`, originally by Dr. Angus Silver, UCL)
to Python using `scipy.stats.ks_2samp`.

**API:**
```python
result = NMToolStats2.ks_test(
    toolfolder, "ST_w0_peak_y", "ST_w0_control_y",
    alpha=0.05, method="auto", save_to_numpy=False,
)
# {"d": 0.42, "pvalue": 0.003, "significant": True,
#  "message": "different populations", "n1": 48, "n2": 50, "alpha": 0.05}
```
method supports "auto" / "exact" / "asymp" (forwarded to
scipy). NaN/Inf values are stripped before testing, matching the Igor
behaviour. When save_to_numpy=True, empirical CDF arrays
(KS_{name}_sort, KS_{name}_ecdf) are written to the toolfolder
for plotting.

## Test plan

-  pytest tests/test_analysis/test_nm_tool_stats.py -k "KSTest" — 21 tests pass
-  pytest tests/ -x -q — full suite passes (1314 tests)

Closes #147