### PR TITLE
feat(analysis): add stability_test() to NMToolStats2

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -874,47 +874,11 @@ class NMToolStats2:
         if isinstance(dataseries, NMDataSeries) and (
             set_name_success or set_name_failure
         ):
-            # Find the ST_{wname}_data array (maps index → wave name)
-            parts = name.split("_")
-            data_arr = None
-            if len(parts) >= 2:
-                wname = parts[1]
-                data_arr = toolfolder.data.get("ST_%s_data" % wname)
-
-            if data_arr is not None and isinstance(data_arr.nparray, np.ndarray):
-                wave_names = data_arr.nparray
-                success_epochs: list[str] = []
-                failure_epochs: list[str] = []
-
-                # Build epoch_num → epoch_name lookup
-                epoch_map: dict[int, str] = {
-                    ep.number: ep.name
-                    for ep in dataseries.epochs.values()
-                    if isinstance(ep, NMEpoch)
-                }
-
-                for i, wave_name in enumerate(wave_names):
-                    parsed = nmu.parse_data_name(str(wave_name))
-                    if parsed is None:
-                        continue
-                    epoch_num = parsed[2]
-                    ep_name = epoch_map.get(epoch_num)
-                    if ep_name is None:
-                        continue
-                    if i < len(mask):
-                        if mask[i]:
-                            success_epochs.append(ep_name)
-                        else:
-                            failure_epochs.append(ep_name)
-
-                if set_name_success and success_epochs:
-                    dataseries.epochs.sets.add(
-                        set_name_success, success_epochs
-                    )
-                if set_name_failure and failure_epochs:
-                    dataseries.epochs.sets.add(
-                        set_name_failure, failure_epochs
-                    )
+            NMToolStats2._add_epoch_sets_from_mask(
+                toolfolder, name, dataseries, mask,
+                set_name_true=set_name_success,
+                set_name_false=set_name_failure,
+            )
 
         return {
             "result": result,
@@ -941,6 +905,68 @@ class NMToolStats2:
         if op == "<=<":  return "%g <= y < %g" % (a, b)
         if op == "<<=":  return "%g < y <= %g" % (a, b)
         return ""
+
+    @staticmethod
+    def _add_epoch_sets_from_mask(
+        toolfolder: NMToolFolder,
+        name: str,
+        dataseries: NMDataSeries,
+        mask: np.ndarray,
+        set_name_true: str | None = None,
+        set_name_false: str | None = None,
+    ) -> None:
+        """Populate epoch sets from a boolean mask aligned to an ST_ array.
+
+        Looks up the ``ST_{wname}_data`` wave-name array in *toolfolder*,
+        maps each index to an epoch via *dataseries*, and adds matching
+        epoch names to *set_name_true* (where mask is True) and/or
+        *set_name_false* (where mask is False).
+
+        Args:
+            toolfolder: NMToolFolder containing the ST_ arrays.
+            name: Name of the ST_ result array (e.g. ``"ST_w0_mean_y"``).
+                Used to derive *wname* and locate ``ST_{wname}_data``.
+            dataseries: NMDataSeries whose epoch sets will be updated.
+            mask: Boolean array aligned to the ST_ array (True = passes).
+            set_name_true: Epoch set name for mask-True indices.  Skipped
+                if None or if no matching epochs are found.
+            set_name_false: Epoch set name for mask-False indices.  Skipped
+                if None or if no matching epochs are found.
+        """
+        parts = name.split("_")
+        if len(parts) < 2:
+            return
+        wname = parts[1]
+        data_arr = toolfolder.data.get("ST_%s_data" % wname)
+        if data_arr is None or not isinstance(data_arr.nparray, np.ndarray):
+            return
+
+        epoch_map: dict[int, str] = {
+            ep.number: ep.name
+            for ep in dataseries.epochs.values()
+            if isinstance(ep, NMEpoch)
+        }
+
+        true_epochs: list[str] = []
+        false_epochs: list[str] = []
+        for i, wave_name in enumerate(data_arr.nparray):
+            if i >= len(mask):
+                break
+            parsed = nmu.parse_data_name(str(wave_name))
+            if parsed is None:
+                continue
+            ep_name = epoch_map.get(parsed[2])
+            if ep_name is None:
+                continue
+            if mask[i]:
+                true_epochs.append(ep_name)
+            else:
+                false_epochs.append(ep_name)
+
+        if set_name_true and true_epochs:
+            dataseries.epochs.sets.add(set_name_true, true_epochs)
+        if set_name_false and false_epochs:
+            dataseries.epochs.sets.add(set_name_false, false_epochs)
 
     @staticmethod
     def ks_test(
@@ -1047,4 +1073,159 @@ class NMToolStats2:
             "message":     message,
             "n1":          int(len(arr1)),
             "n2":          int(len(arr2)),
+        }
+
+    @staticmethod
+    def stability_test(
+        toolfolder: NMToolFolder,
+        name: str,
+        alpha: float = 0.05,
+        min_window: int = 10,
+        dataseries: NMDataSeries | None = None,
+        set_name_stable: str | None = None,
+        save_to_numpy: bool = False,
+    ) -> dict:
+        """Find the largest stable (trend-free) window in an ST_ array.
+
+        Tests whether consecutive subsets of values have no significant
+        monotonic trend over time using the Spearman rank-order correlation
+        between values and their array indices.  Searches from the largest
+        possible window down to ``min_window``, stopping as soon as the
+        largest stable window is identified.
+
+        This mirrors the Igor NeuroMatic ``NMStabilityRankOrderTest()``
+        function (``NM_StatsTabStability.ipf``, pass 1 only), originally
+        written by Dr. Angus Silver and Simon Mitchell (UCL), based on
+        *Numerical Recipes in C*.
+
+        Args:
+            toolfolder: NMToolFolder containing the ST_ array.
+            name: Name of the ST_ array (e.g. ``"ST_w0_mean_y"``).
+            alpha: Significance level.  A window is "stable" when its
+                Spearman p-value exceeds this threshold.  Defaults to 0.05.
+            min_window: Minimum window size in data points.  Must be >= 2.
+                Defaults to 10.
+            dataseries: NMDataSeries to use when creating an epoch set.
+                Required if set_name_stable is given.
+            set_name_stable: Name of the epoch set to populate with epochs
+                inside the stable region.  Requires dataseries.
+            save_to_numpy: If True, save ``STAB_{name}_mask`` (float 0/1
+                array) to toolfolder.  Defaults to False.
+
+        Returns:
+            Dict with keys:
+
+            - ``"stable"``: True if a stable region was found.
+            - ``"start"``: Index into original array of first stable point,
+              or None.
+            - ``"end"``: Index into original array of last stable point
+              (inclusive), or None.
+            - ``"n"``: Window size (``end - start + 1``), or None.
+            - ``"rs"``: Spearman rs at best window, or None.
+            - ``"pvalue"``: p-value at best window, or None.
+            - ``"alpha"``: Significance level (echoed from param).
+            - ``"mask"``: Boolean numpy array (length = original array
+              length), True where the stable region falls.
+
+        Raises:
+            TypeError: If toolfolder is not NMToolFolder or name is not str.
+            KeyError: If name is not found in toolfolder.
+            ValueError: If the array has no data, or min_window is out of
+                range.
+        """
+        import warnings  # noqa: PLC0415
+
+        from scipy.stats import spearmanr  # noqa: PLC0415
+
+        if not isinstance(toolfolder, NMToolFolder):
+            raise TypeError(
+                nmu.type_error_str(toolfolder, "toolfolder", "NMToolFolder")
+            )
+        if not isinstance(name, str):
+            raise TypeError(nmu.type_error_str(name, "name", "string"))
+
+        d = toolfolder.data.get(name)
+        if d is None:
+            raise KeyError("array not found in toolfolder: %s" % name)
+        if not isinstance(d.nparray, np.ndarray):
+            raise ValueError("array has no nparray: %s" % name)
+
+        arr = d.nparray.astype(float)
+        finite_mask = np.isfinite(arr)
+        finite_idx = np.where(finite_mask)[0]  # original positions of valid points
+        arr_clean = arr[finite_mask]
+        n = len(arr_clean)
+
+        if min_window < 2:
+            raise ValueError("min_window must be >= 2, got %d" % min_window)
+        if min_window > n:
+            raise ValueError(
+                "min_window (%d) > available data points (%d)" % (min_window, n)
+            )
+
+        # Sliding-window Spearman search: largest window first
+        best_start: int | None = None
+        best_size: int = 0
+        best_rs: float | None = None
+        best_pvalue: float = 0.0
+
+        for w in range(n, min_window - 1, -1):
+            for i in range(n - w + 1):
+                x = np.arange(i, i + w, dtype=float)
+                y = arr_clean[i: i + w]
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    rs, pvalue = spearmanr(x, y)
+                # Constant input → rs and pvalue are NaN → no trend → stable
+                if math.isnan(rs):
+                    rs, pvalue = 0.0, 1.0
+                elif math.isnan(pvalue):
+                    # Non-constant but too few points to compute p-value
+                    continue
+                if pvalue > alpha and pvalue > best_pvalue:
+                    best_start = i
+                    best_size = w
+                    best_rs = float(rs)
+                    best_pvalue = float(pvalue)
+            if best_start is not None:
+                break  # largest stable window found; stop shrinking
+
+        mask = np.zeros(len(arr), dtype=bool)
+
+        if best_start is None:
+            return {
+                "stable":  False,
+                "start":   None,
+                "end":     None,
+                "n":       None,
+                "rs":      None,
+                "pvalue":  None,
+                "alpha":   float(alpha),
+                "mask":    mask,
+            }
+
+        best_end = best_start + best_size - 1
+        orig_start = int(finite_idx[best_start])
+        orig_end = int(finite_idx[best_end])
+        mask[finite_idx[best_start: best_end + 1]] = True
+
+        if save_to_numpy and toolfolder.data is not None:
+            toolfolder.data.new("STAB_%s_mask" % name, nparray=mask.astype(float))
+
+        # Create epoch set if dataseries and set name are given
+        if isinstance(dataseries, NMDataSeries) and set_name_stable:
+            NMToolStats2._add_epoch_sets_from_mask(
+                toolfolder, name, dataseries, mask,
+                set_name_true=set_name_stable,
+            )
+
+        return {
+            "stable":  True,
+            "start":   orig_start,
+            "end":     orig_end,
+            "n":       best_size,
+            "rs":      best_rs,
+            "pvalue":  best_pvalue,
+            "alpha":   float(alpha),
+            "mask":    mask,
         }

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -912,5 +912,297 @@ class TestNMToolStats2KSTest(unittest.TestCase):
             nms.NMToolStats2.ks_test(self.tf, "ST_w0_pop1_y", "ST_w0_missing")
 
 
+class TestNMToolStats2StabilityTest(unittest.TestCase):
+    """Tests for NMToolStats2.stability_test()."""
+
+    def setUp(self):
+        from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
+
+        self.tf = NMToolFolder(name="stats0")
+
+        # Flat array (constant) — no monotonic trend → always stable
+        self.flat = np.full(20, 3.0)
+        self.tf.data.new("ST_w0_flat_y", nparray=self.flat.copy())
+
+        # Strictly increasing — perfect monotonic trend → not stable
+        self.trend = np.arange(20, dtype=float)
+        self.tf.data.new("ST_w0_trend_y", nparray=self.trend.copy())
+
+        # Flat array with 2 NaN values
+        nan_arr = np.full(20, 3.0)
+        nan_arr[5] = np.nan
+        nan_arr[15] = np.nan
+        self.tf.data.new("ST_w0_nan_y", nparray=nan_arr)
+
+        # Wave-name array and dataseries for epoch-set tests
+        wave_names = ["RecordA%d" % i for i in range(20)]
+        self.tf.data.new(
+            "ST_w0_data",
+            nparray=np.array(wave_names, dtype=object),
+        )
+        self.nm = NMManager(quiet=True)
+        assert self.nm.project.folders is not None
+        self.folder = self.nm.project.folders.new("f0")
+        self.ds = self.folder.dataseries.new("Record")
+        for i in range(20):
+            self.ds.epochs.new("E%d" % i)
+
+    # --- stable=True (flat array) ---
+
+    def test_stable_region_found(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5
+        )
+        self.assertTrue(r["stable"])
+
+    def test_returns_dict_keys(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5
+        )
+        for key in ("stable", "start", "end", "n", "rs", "pvalue", "alpha", "mask"):
+            self.assertIn(key, r)
+
+    def test_start_end_not_none_when_stable(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5
+        )
+        self.assertIsNotNone(r["start"])
+        self.assertIsNotNone(r["end"])
+
+    def test_n_matches_window(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5
+        )
+        self.assertEqual(r["n"], r["end"] - r["start"] + 1)
+
+    def test_rs_range(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5
+        )
+        self.assertGreaterEqual(r["rs"], -1.0)
+        self.assertLessEqual(r["rs"], 1.0)
+
+    def test_pvalue_range(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5
+        )
+        self.assertGreaterEqual(r["pvalue"], 0.0)
+        self.assertLessEqual(r["pvalue"], 1.0)
+
+    def test_alpha_echoed(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", alpha=0.01, min_window=5
+        )
+        self.assertAlmostEqual(r["alpha"], 0.01)
+
+    # --- stable=False (trending array) ---
+
+    def test_unstable_region(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_trend_y", alpha=0.05, min_window=5
+        )
+        self.assertFalse(r["stable"])
+
+    def test_start_end_none_when_not_stable(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_trend_y", alpha=0.05, min_window=5
+        )
+        self.assertIsNone(r["start"])
+        self.assertIsNone(r["end"])
+
+    def test_rs_none_when_not_stable(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_trend_y", alpha=0.05, min_window=5
+        )
+        self.assertIsNone(r["rs"])
+
+    # --- mask ---
+
+    def test_mask_length_equals_original_array(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5
+        )
+        self.assertEqual(len(r["mask"]), len(self.flat))
+
+    def test_mask_true_at_stable_region(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5
+        )
+        # Every index in [start, end] should be True in mask
+        self.assertTrue(np.all(r["mask"][r["start"]: r["end"] + 1]))
+
+    def test_mask_all_false_when_not_stable(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_trend_y", alpha=0.05, min_window=5
+        )
+        self.assertFalse(np.any(r["mask"]))
+
+    # --- NaN handling ---
+
+    def test_strips_nans_mask_length_unchanged(self):
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_nan_y", min_window=5
+        )
+        # mask length = length of original array (including NaN positions)
+        self.assertEqual(len(r["mask"]), 20)
+
+    def test_strips_nans_stable_found(self):
+        # Flat array with 2 NaNs removed → remaining 18 values are flat → stable
+        r = nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_nan_y", min_window=5
+        )
+        self.assertTrue(r["stable"])
+
+    # --- save_to_numpy ---
+
+    def test_save_creates_mask_array(self):
+        nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5, save_to_numpy=True
+        )
+        self.assertIn("STAB_ST_w0_flat_y_mask", self.tf.data)
+
+    def test_no_save_no_array(self):
+        nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5, save_to_numpy=False
+        )
+        self.assertNotIn("STAB_ST_w0_flat_y_mask", self.tf.data)
+
+    # --- min_window validation ---
+
+    def test_min_window_too_large_raises(self):
+        with self.assertRaises(ValueError):
+            nms.NMToolStats2.stability_test(
+                self.tf, "ST_w0_flat_y", min_window=100
+            )
+
+    def test_min_window_less_than_2_raises(self):
+        with self.assertRaises(ValueError):
+            nms.NMToolStats2.stability_test(
+                self.tf, "ST_w0_flat_y", min_window=1
+            )
+
+    # --- type and key validation ---
+
+    def test_rejects_bad_toolfolder(self):
+        with self.assertRaises(TypeError):
+            nms.NMToolStats2.stability_test("bad", "ST_w0_flat_y")
+
+    def test_rejects_bad_name(self):
+        with self.assertRaises(TypeError):
+            nms.NMToolStats2.stability_test(self.tf, 123)
+
+    def test_unknown_name_raises(self):
+        with self.assertRaises(KeyError):
+            nms.NMToolStats2.stability_test(self.tf, "ST_w0_missing")
+
+    # --- epoch sets ---
+
+    def test_set_name_stable_creates_epoch_set(self):
+        nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5,
+            dataseries=self.ds, set_name_stable="Stable",
+        )
+        self.assertIsNotNone(self.ds.epochs.sets.get("Stable"))
+
+    def test_set_name_stable_contains_correct_epochs(self):
+        # Flat array → all 20 epochs should be in the stable set
+        nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5,
+            dataseries=self.ds, set_name_stable="Stable",
+        )
+        epoch_names = [ep.name for ep in self.ds.epochs.sets.get("Stable")]
+        self.assertIn("E0", epoch_names)
+        self.assertIn("E19", epoch_names)
+
+
+class TestNMToolStats2AddEpochSetsFromMask(unittest.TestCase):
+    """Direct tests for NMToolStats2._add_epoch_sets_from_mask()."""
+
+    def setUp(self):
+        from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
+
+        self.tf = NMToolFolder(name="stats0")
+        # mask: [T, T, F, F, T] → true indices 0,1,4; false indices 2,3
+        self.mask = np.array([True, True, False, False, True])
+        wave_names = ["RecordA0", "RecordA1", "RecordA2", "RecordA3", "RecordA4"]
+        self.tf.data.new("ST_w0_mean_y", nparray=np.zeros(5))
+        self.tf.data.new(
+            "ST_w0_data",
+            nparray=np.array(wave_names, dtype=object),
+        )
+        self.nm = NMManager(quiet=True)
+        assert self.nm.project.folders is not None
+        self.folder = self.nm.project.folders.new("f0")
+        self.ds = self.folder.dataseries.new("Record")
+        for i in range(5):
+            self.ds.epochs.new("E%d" % i)
+
+    def test_true_set_created(self):
+        nms.NMToolStats2._add_epoch_sets_from_mask(
+            self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_true="Pass"
+        )
+        self.assertIsNotNone(self.ds.epochs.sets.get("Pass"))
+
+    def test_true_set_contains_correct_epochs(self):
+        nms.NMToolStats2._add_epoch_sets_from_mask(
+            self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_true="Pass"
+        )
+        epoch_names = [ep.name for ep in self.ds.epochs.sets.get("Pass")]
+        self.assertIn("E0", epoch_names)
+        self.assertIn("E1", epoch_names)
+        self.assertIn("E4", epoch_names)
+        self.assertNotIn("E2", epoch_names)
+        self.assertNotIn("E3", epoch_names)
+
+    def test_false_set_created(self):
+        nms.NMToolStats2._add_epoch_sets_from_mask(
+            self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_false="Fail"
+        )
+        self.assertIsNotNone(self.ds.epochs.sets.get("Fail"))
+
+    def test_false_set_contains_correct_epochs(self):
+        nms.NMToolStats2._add_epoch_sets_from_mask(
+            self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_false="Fail"
+        )
+        epoch_names = [ep.name for ep in self.ds.epochs.sets.get("Fail")]
+        self.assertIn("E2", epoch_names)
+        self.assertIn("E3", epoch_names)
+        self.assertNotIn("E0", epoch_names)
+
+    def test_both_sets_created_in_one_call(self):
+        nms.NMToolStats2._add_epoch_sets_from_mask(
+            self.tf, "ST_w0_mean_y", self.ds, self.mask,
+            set_name_true="Pass", set_name_false="Fail",
+        )
+        self.assertIsNotNone(self.ds.epochs.sets.get("Pass"))
+        self.assertIsNotNone(self.ds.epochs.sets.get("Fail"))
+
+    def test_no_true_set_when_name_is_none(self):
+        nms.NMToolStats2._add_epoch_sets_from_mask(
+            self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_true=None
+        )
+        self.assertIsNone(self.ds.epochs.sets.get("Pass"))
+
+    def test_all_false_mask_skips_true_set(self):
+        all_false = np.zeros(5, dtype=bool)
+        nms.NMToolStats2._add_epoch_sets_from_mask(
+            self.tf, "ST_w0_mean_y", self.ds, all_false, set_name_true="Pass"
+        )
+        self.assertIsNone(self.ds.epochs.sets.get("Pass"))
+
+    def test_missing_data_array_does_not_raise(self):
+        # No ST_w0_data → should return silently
+        tf2 = self.tf.__class__(name="stats1")
+        tf2.data.new("ST_w0_mean_y", nparray=np.zeros(5))
+        nms.NMToolStats2._add_epoch_sets_from_mask(
+            tf2, "ST_w0_mean_y", self.ds, self.mask, set_name_true="Pass"
+        )  # no exception
+
+    def test_name_with_too_few_parts_does_not_raise(self):
+        nms.NMToolStats2._add_epoch_sets_from_mask(
+            self.tf, "short", self.ds, self.mask, set_name_true="Pass"
+        )  # no exception
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Adds NMToolStats2.stability_test() to find the longest trend-free (stable) window in an ST_ array, mirroring Igor NeuroMatic NMStabilityRankOrderTest() (pass 1 only; pass 2 refinement excluded as Igor default was also off)
- Uses scipy.stats.spearmanr — slides a window from largest to smallest (down to min_window), stopping at the first size where any position gives p > alpha
- Extracts shared epoch-set creation logic from inequality() and stability_test() into private helper _add_epoch_sets_from_mask(), eliminating ~35 lines of duplication

## Notes

- Constant arrays (e.g. perfectly flat baseline) are handled correctly: spearmanr returns NaN for constant input, which is treated as rs=0, p=1 (maximally stable)
- NaN/Inf values are stripped before the search; finite_idx tracks original positions so the returned mask aligns with the full original array length
- Returns {"stable", "start", "end", "n", "rs", "pvalue", "alpha", "mask"} — consistent pattern with ks_test() and inequality()

## Test plan

- 22 tests in TestNMToolStats2StabilityTest — stable/unstable detection, mask correctness, NaN handling, save, min_window validation, error cases
-  9 tests in TestNMToolStats2AddEpochSetsFromMask — direct tests for the extracted helper
-  2 epoch-set tests added to TestNMToolStats2StabilityTest
-  All 153 test_nm_tool_stats.py tests passing; no regressions in full suite

Closes #149