### PR TITLE
feat(analysis): add save/load TOML to NMStatWinContainer

### DIFF
--- a/pyneuromatic/analysis/nm_stat_win.py
+++ b/pyneuromatic/analysis/nm_stat_win.py
@@ -20,7 +20,23 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 import math
+import sys
+from pathlib import Path
 from typing import Any
+
+# TOML compatibility layer (same pattern as nm_workspace.py)
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        tomllib = None  # type: ignore
+
+try:
+    import tomli_w
+except ImportError:
+    tomli_w = None  # type: ignore
 
 from pyneuromatic.analysis.nm_stat_func import (
     NMStatFunc,
@@ -568,3 +584,100 @@ class NMStatWinContainer:
     def __contains__(self, name: str) -> bool:
         """Return True if a window with the given name exists."""
         return name in self._windows
+
+    _TOML_TYPE = "stat_windows"
+    _TOML_VERSION = "1"
+
+    def to_dict(self) -> dict:
+        """Serialize the container and all windows to a plain dict.
+
+        The returned dict includes a ``[pyneuromatic]`` metadata header so
+        that saved TOML files are self-describing.  None values are omitted
+        from window dicts (TOML does not support null); ``selected_name`` is
+        omitted when None for the same reason.
+        """
+        def _strip_none(d: dict) -> dict:
+            return {k: v for k, v in d.items() if v is not None}
+
+        result: dict = {
+            "pyneuromatic": {
+                "type": self._TOML_TYPE,
+                "version": self._TOML_VERSION,
+            },
+            "prefix": self._prefix,
+            "windows": [_strip_none(w.to_dict()) for w in self._windows.values()],
+        }
+        if self.selected_name is not None:
+            result["selected_name"] = self.selected_name
+        return result
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NMStatWinContainer":
+        """Reconstruct a container from a dict produced by ``to_dict()``.
+
+        Args:
+            d: Dict with keys ``"prefix"``, ``"selected_name"``, and
+                ``"windows"`` (list of window dicts).
+
+        Returns:
+            New NMStatWinContainer populated with NMStatWin objects.
+        """
+        prefix = d.get("prefix", "w")
+        container = cls(name_prefix=prefix)
+        for wd in d.get("windows", []):
+            name = wd.get("name", "%s%d" % (prefix, container._count))
+            w = NMStatWin(name=name, win=wd)
+            container._windows[name] = w
+            container._count += 1
+        container.selected_name = d.get("selected_name")
+        return container
+
+    def save(self, filepath: str | Path) -> Path:
+        """Save the container to a TOML file.
+
+        Args:
+            filepath: Destination path (e.g. ``"my_windows.toml"``).
+
+        Returns:
+            Resolved Path of the saved file.
+
+        Raises:
+            RuntimeError: If ``tomli_w`` is not installed.
+        """
+        if tomli_w is None:
+            raise RuntimeError(
+                "TOML writing not available. Install 'tomli-w' package."
+            )
+        filepath = Path(filepath)
+        with open(filepath, "wb") as f:
+            tomli_w.dump(self.to_dict(), f)
+        return filepath
+
+    @classmethod
+    def load(cls, filepath: str | Path) -> "NMStatWinContainer":
+        """Load a container from a TOML file saved by ``save()``.
+
+        Args:
+            filepath: Path to the ``.toml`` file.
+
+        Returns:
+            New NMStatWinContainer populated from the file.
+
+        Raises:
+            RuntimeError: If ``tomllib``/``tomli`` is not available.
+            FileNotFoundError: If the file does not exist.
+        """
+        if tomllib is None:
+            raise RuntimeError(
+                "TOML support not available. "
+                "Install 'tomli' package for Python < 3.11"
+            )
+        filepath = Path(filepath)
+        with open(filepath, "rb") as f:
+            d = tomllib.load(f)
+        meta = d.get("pyneuromatic", {})
+        if meta.get("type") != cls._TOML_TYPE:
+            raise ValueError(
+                "%s is not a pyNeuroMatic stat windows file" % filepath.name
+            )
+        return cls.from_dict(d)

--- a/tests/test_analysis/test_nm_stat_win.py
+++ b/tests/test_analysis/test_nm_stat_win.py
@@ -7,7 +7,9 @@ Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
 acquiring and simulating electrophysiology data.
 """
 import math
+import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 
@@ -511,6 +513,147 @@ class TestNMStatWinContainer(unittest.TestCase):
         c = nmsw.NMStatWinContainer(name_prefix="win")
         w = c.new()
         self.assertEqual(w.name, "win0")
+
+    # --- to_dict / from_dict ---
+
+    def test_to_dict_keys(self):
+        c = nmsw.NMStatWinContainer()
+        c.new()
+        d = c.to_dict()
+        self.assertIn("pyneuromatic", d)
+        self.assertIn("prefix", d)
+        self.assertIn("selected_name", d)
+        self.assertIn("windows", d)
+
+    def test_to_dict_windows_list(self):
+        c = nmsw.NMStatWinContainer()
+        c.new()
+        c.new()
+        self.assertEqual(len(c.to_dict()["windows"]), 2)
+
+    def test_to_dict_empty_container(self):
+        c = nmsw.NMStatWinContainer()
+        d = c.to_dict()
+        self.assertEqual(d["windows"], [])
+        # selected_name is omitted when None (TOML cannot serialize null)
+        self.assertNotIn("selected_name", d)
+
+    def test_from_dict_round_trips_window_count(self):
+        c = nmsw.NMStatWinContainer()
+        c.new()
+        c.new()
+        c2 = nmsw.NMStatWinContainer.from_dict(c.to_dict())
+        self.assertEqual(len(c2), 2)
+
+    def test_from_dict_round_trips_selected_name(self):
+        c = nmsw.NMStatWinContainer()
+        c.new()
+        c.new()
+        c.selected_name = "w1"
+        c2 = nmsw.NMStatWinContainer.from_dict(c.to_dict())
+        self.assertEqual(c2.selected_name, "w1")
+
+    def test_from_dict_round_trips_prefix(self):
+        c = nmsw.NMStatWinContainer(name_prefix="win")
+        c.new()
+        c2 = nmsw.NMStatWinContainer.from_dict(c.to_dict())
+        self.assertEqual(c2._prefix, "win")
+
+    def test_from_dict_round_trips_window_params(self):
+        c = nmsw.NMStatWinContainer()
+        w = c.new()
+        w.func = {"name": "mean"}
+        w.x0 = 0.01
+        w.x1 = 0.05
+        c2 = nmsw.NMStatWinContainer.from_dict(c.to_dict())
+        self.assertEqual(c2["w0"], c["w0"])
+
+    def test_from_dict_empty(self):
+        c = nmsw.NMStatWinContainer.from_dict({"windows": []})
+        self.assertEqual(len(c), 0)
+
+    # --- save / load ---
+
+    def test_save_creates_file(self):
+        c = nmsw.NMStatWinContainer()
+        c.new()
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "wins.toml"
+            c.save(path)
+            self.assertTrue(path.exists())
+
+    def test_save_returns_path(self):
+        c = nmsw.NMStatWinContainer()
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "wins.toml"
+            result = c.save(path)
+            self.assertEqual(result, path)
+
+    def test_load_round_trips_window_count(self):
+        c = nmsw.NMStatWinContainer()
+        c.new()
+        c.new()
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "wins.toml"
+            c.save(path)
+            c2 = nmsw.NMStatWinContainer.load(path)
+        self.assertEqual(len(c2), 2)
+
+    def test_load_round_trips_selected_name(self):
+        c = nmsw.NMStatWinContainer()
+        c.new()
+        c.new()
+        c.selected_name = "w1"
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "wins.toml"
+            c.save(path)
+            c2 = nmsw.NMStatWinContainer.load(path)
+        self.assertEqual(c2.selected_name, "w1")
+
+    def test_load_round_trips_window_params(self):
+        c = nmsw.NMStatWinContainer()
+        w = c.new()
+        w.func = {"name": "mean"}
+        w.x0 = 0.01
+        w.x1 = 0.05
+        w.bsln_on = True
+        w.bsln_x0 = -0.01
+        w.bsln_x1 = 0.0
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "wins.toml"
+            c.save(path)
+            c2 = nmsw.NMStatWinContainer.load(path)
+        self.assertEqual(c2["w0"], c["w0"])
+
+    def test_load_round_trips_inf_x_bounds(self):
+        c = nmsw.NMStatWinContainer()
+        c.new()  # default x0=-inf, x1=inf
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "wins.toml"
+            c.save(path)
+            c2 = nmsw.NMStatWinContainer.load(path)
+        self.assertEqual(c2["w0"].x0, -math.inf)
+        self.assertEqual(c2["w0"].x1, math.inf)
+
+    def test_to_dict_contains_pyneuromatic_header(self):
+        c = nmsw.NMStatWinContainer()
+        d = c.to_dict()
+        self.assertIn("pyneuromatic", d)
+        self.assertEqual(d["pyneuromatic"]["type"], "stat_windows")
+        self.assertIn("version", d["pyneuromatic"])
+
+    def test_load_wrong_type_raises(self):
+        import tomli_w
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "bad.toml"
+            with open(path, "wb") as f:
+                tomli_w.dump({"pyneuromatic": {"type": "workspace"}}, f)
+            with self.assertRaises(ValueError):
+                nmsw.NMStatWinContainer.load(path)
+
+    def test_load_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            nmsw.NMStatWinContainer.load("/nonexistent/path/wins.toml")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds NMStatWinContainer.to_dict(), from_dict(), save(), and load() so users can persist and reload stat window configurations between sessions
- TOML files include a [pyneuromatic] metadata header (type = "stat_windows", version = "1") making files self-describing; load() validates the header and raises a clear ValueError for wrong file types
- Follows the same tomllib/tomli_w compat pattern as nm_workspace.py — no new dependencies

## Example
```
# Save
container.save("my_windows.toml")

# Load
container = NMStatWinContainer.load("my_windows.toml")

[pyneuromatic]
type = "stat_windows"
version = "1"

prefix = "w"
selected_name = "w0"

[[windows]]
name = "w0"
on = true
x0 = 0.01
x1 = 0.05
bsln_on = true
bsln_x0 = -0.01
bsln_x1 = 0.0

[windows.func]
name = "mean"

[windows.bsln_func]
name = "mean"
```
## Test plan

-  test_to_dict_keys, test_to_dict_windows_list, test_to_dict_empty_container, test_to_dict_contains_pyneuromatic_header
-  test_from_dict_* — round-trips for window count, selected name, prefix, window params, empty container
-  test_save_* — file created, path returned
-  test_load_* — round-trips for window count, selected name, window params, ±inf x-bounds, wrong type raises, missing file raises
-  All 68 test_nm_stat_win.py tests passing; no regressions in full suite

Closes #153 

