### PR TITLE
feat(analysis): NMToolConfig — schema-based config base class for NMTool subclasses

### DIFF
--- a/pyneuromatic/analysis/nm_tool.py
+++ b/pyneuromatic/analysis/nm_tool.py
@@ -29,6 +29,7 @@ from pyneuromatic.core.nm_dataseries import NMDataSeries
 from pyneuromatic.core.nm_channel import NMChannel
 from pyneuromatic.core.nm_epoch import NMEpoch
 from pyneuromatic.core.nm_manager import SELECT_LEVELS
+from pyneuromatic.analysis.nm_tool_config import NMToolConfig
 
 
 class NMTool:
@@ -55,6 +56,12 @@ class NMTool:
             level: None for level in SELECT_LEVELS
         }
         self._run_meta: dict = {}
+        self._config: NMToolConfig | None = None
+
+    @property
+    def config(self) -> NMToolConfig | None:
+        """Tool configuration object, or None if the tool has no config."""
+        return self._config
 
     # Read-only convenience properties for accessing selection
     @property

--- a/pyneuromatic/analysis/nm_tool_config.py
+++ b/pyneuromatic/analysis/nm_tool_config.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+"""
+NMToolConfig - Schema-based configuration base class for NMTool subclasses.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# TOML compatibility layer (same pattern as nm_workspace.py)
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    try:
+        import tomli as tomllib
+    except ImportError:
+        tomllib = None  # type: ignore
+
+try:
+    import tomli_w
+except ImportError:
+    tomli_w = None  # type: ignore
+
+
+class NMToolConfig:
+    """Schema-based configuration base class for NMTool subclasses.
+
+    Each subclass declares ``_schema`` — a class-level dict mapping parameter
+    names to a spec dict — and ``_TOML_TYPE`` (a unique string identifying the
+    config type in saved files).  The base class then provides:
+
+    - Validated attribute setting (``__setattr__``) with clear error messages.
+    - ``to_dict()`` / ``from_dict()`` serialisation.
+    - ``save()`` / ``load()`` TOML round-trip with a ``[pyneuromatic]`` header.
+
+    Spec dict keys per parameter:
+
+    - ``"type"`` *(required)*: Expected Python type (``bool``, ``int``,
+      ``float``, ``str``).
+    - ``"default"`` *(required)*: Value used when the config is constructed.
+    - ``"min"`` *(optional)*: Inclusive lower bound for numeric types.
+    - ``"max"`` *(optional)*: Inclusive upper bound for numeric types.
+    - ``"choices"`` *(optional)*: List of allowed values.
+
+    Example subclass::
+
+        class NMToolStatsConfig(NMToolConfig):
+            _TOML_TYPE = "stats_config"
+            _schema = {
+                "ignore_nans": {"type": bool, "default": True},
+                "alpha":        {"type": float, "default": 0.05,
+                                 "min": 0.0, "max": 1.0},
+            }
+    """
+
+    _TOML_TYPE: str = "tool_config"   # override in each subclass
+    _TOML_VERSION: str = "1"
+    _schema: dict = {}                 # override in each subclass
+
+    def __init__(self) -> None:
+        for key, spec in self._schema.items():
+            object.__setattr__(self, key, spec["default"])
+
+    def __repr__(self) -> str:
+        params = ", ".join(
+            "%s=%r" % (k, getattr(self, k)) for k in self._schema
+        )
+        return "%s(%s)" % (self.__class__.__name__, params)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+    def __setattr__(self, key: str, value: object) -> None:
+        if key.startswith("_"):
+            object.__setattr__(self, key, value)
+            return
+        if key not in self._schema:
+            raise AttributeError(
+                "%s: unknown config parameter '%s'"
+                % (self.__class__.__name__, key)
+            )
+        value = self._validate(key, value)
+        object.__setattr__(self, key, value)
+
+    def _validate(self, key: str, value: object) -> object:
+        """Validate *value* against the schema spec for *key*.
+
+        Raises:
+            TypeError: Wrong type (also rejects bool when int/float expected,
+                since bool is a subclass of int in Python).
+            ValueError: Out of range or not in allowed choices.
+        """
+        spec = self._schema[key]
+        expected = spec["type"]
+        # bool is a subclass of int — reject it when int/float is expected
+        if isinstance(value, bool) and expected is not bool:
+            raise TypeError(
+                "config '%s': expected %s, got bool" % (key, expected.__name__)
+            )
+        if not isinstance(value, expected):
+            raise TypeError(
+                "config '%s': expected %s, got %s"
+                % (key, expected.__name__, type(value).__name__)
+            )
+        if "min" in spec and value < spec["min"]:  # type: ignore[operator]
+            raise ValueError(
+                "config '%s': %s < minimum %s" % (key, value, spec["min"])
+            )
+        if "max" in spec and value > spec["max"]:  # type: ignore[operator]
+            raise ValueError(
+                "config '%s': %s > maximum %s" % (key, value, spec["max"])
+            )
+        if "choices" in spec and value not in spec["choices"]:
+            raise ValueError(
+                "config '%s': %r not in %s" % (key, value, spec["choices"])
+            )
+        return value
+
+    def to_dict(self) -> dict:
+        """Serialise the config to a plain dict with a ``[pyneuromatic]`` header."""
+        result: dict = {
+            "pyneuromatic": {
+                "type": self._TOML_TYPE,
+                "version": self._TOML_VERSION,
+            }
+        }
+        for key in self._schema:
+            result[key] = getattr(self, key)
+        return result
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NMToolConfig":
+        """Reconstruct a config from a dict produced by ``to_dict()``.
+
+        Unknown keys are silently ignored.  Each recognised key is validated
+        via ``__setattr__`` before being stored.
+
+        Args:
+            d: Dict — typically loaded from a TOML file.
+
+        Returns:
+            New instance of *cls* with values from *d*.
+        """
+        obj = cls()
+        for key in cls._schema:
+            if key in d:
+                setattr(obj, key, d[key])
+        return obj
+
+    def save(self, filepath: str | Path) -> Path:
+        """Save the config to a TOML file.
+
+        Args:
+            filepath: Destination path (e.g. ``"stats.toml"``).
+
+        Returns:
+            Resolved Path of the saved file.
+
+        Raises:
+            RuntimeError: If ``tomli_w`` is not installed.
+        """
+        if tomli_w is None:
+            raise RuntimeError(
+                "TOML writing not available. Install 'tomli-w' package."
+            )
+        filepath = Path(filepath)
+        with open(filepath, "wb") as f:
+            tomli_w.dump(self.to_dict(), f)
+        return filepath
+
+    @classmethod
+    def load(cls, filepath: str | Path) -> "NMToolConfig":
+        """Load a config from a TOML file saved by ``save()``.
+
+        Validates the ``[pyneuromatic]`` header before constructing the object.
+
+        Args:
+            filepath: Path to the ``.toml`` file.
+
+        Returns:
+            New instance of *cls* populated from the file.
+
+        Raises:
+            RuntimeError: If ``tomllib``/``tomli`` is not available.
+            FileNotFoundError: If the file does not exist.
+            ValueError: If the file's ``type`` does not match ``_TOML_TYPE``.
+        """
+        if tomllib is None:
+            raise RuntimeError(
+                "TOML support not available. "
+                "Install 'tomli' package for Python < 3.11"
+            )
+        filepath = Path(filepath)
+        with open(filepath, "rb") as f:
+            d = tomllib.load(f)
+        meta = d.get("pyneuromatic", {})
+        if meta.get("type") != cls._TOML_TYPE:
+            raise ValueError(
+                "%s is not a %s config file" % (filepath.name, cls._TOML_TYPE)
+            )
+        return cls.from_dict(d)
+
+

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -27,6 +27,7 @@ import numpy as np
 from pyneuromatic.analysis.nm_stat_utilities import stats
 from pyneuromatic.analysis.nm_stat_win import NMStatWinContainer  # noqa: F401
 from pyneuromatic.analysis.nm_tool import NMTool
+from pyneuromatic.analysis.nm_tool_config import NMToolConfig
 from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
 from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_dataseries import NMDataSeries
@@ -35,6 +36,32 @@ from pyneuromatic.core.nm_folder import NMFolder
 import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_preferences as nmp
 import pyneuromatic.core.nm_utilities as nmu
+
+
+class NMToolStatsConfig(NMToolConfig):
+    """Configuration for NMToolStats.
+
+    Parameters:
+        ignore_nans: If True, use NaN-ignoring numpy functions (e.g.
+            ``np.nanmean``).  Defaults to True.
+        xclip: If True, clip x0/x1 boundaries to the data x-scale limits.
+            Defaults to True.
+        results_to_history: If True, print results to history log after run.
+            Defaults to False.
+        results_to_cache: If True, save results to NMFolder tool-results cache.
+            Defaults to True.
+        results_to_numpy: If True, write results as ST_ NMData arrays.
+            Defaults to False.
+    """
+
+    _TOML_TYPE = "stats_config"
+    _schema = {
+        "ignore_nans":        {"type": bool, "default": True},
+        "xclip":              {"type": bool, "default": True},
+        "results_to_history": {"type": bool, "default": False},
+        "results_to_cache":   {"type": bool, "default": True},
+        "results_to_numpy":   {"type": bool, "default": False},
+    }
 
 
 class NMToolStats(NMTool):
@@ -57,6 +84,8 @@ class NMToolStats(NMTool):
     """
 
     def __init__(self) -> None:
+        super().__init__()
+        self._config = NMToolStatsConfig()
 
         self.__win_container = NMStatWinContainer()
         self.__win_container.new()

--- a/pyneuromatic/core/nm_configurations.py
+++ b/pyneuromatic/core/nm_configurations.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+"""
+NM Configurations - Global constants for pyNeuroMatic.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+
+# Global behaviour flags used as default parameter values throughout the
+# codebase.  Import this module as ``nmp`` to preserve existing call sites:
+#   import pyneuromatic.core.nm_configurations as nmp
+
+DATASERIES_SET_LIST = ["all", "set1", "set2", "setX"]
+QUIET = False       # suppress history/log output
+GUI = False         # GUI mode active
+NAN_EQ_NAN = True  # treat NaN == NaN (Python default is NaN != NaN)

--- a/pyneuromatic/core/nm_preferences.py
+++ b/pyneuromatic/core/nm_preferences.py
@@ -1,52 +1,15 @@
 # -*- coding: utf-8 -*-
 """
-[Module description].
+Compatibility shim — nm_preferences.py renamed to nm_configurations.py.
 
-Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
-acquiring and simulating electrophysiology data.
-
-If you use this software in your research, please cite:
-Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source 
-Software Toolkit for Acquisition, Analysis and Simulation of 
-Electrophysiological Data. Front. Neuroinform. 12:14. 
-doi: 10.3389/fninf.2018.00014
-
-Copyright (c) 2026 The Silver Lab, University College London.
-Licensed under MIT License - see LICENSE file for details.
-
-Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
-Website: https://github.com/SilverLabUCL/pyNeuroMatic
-Paper: https://doi.org/10.3389/fninf.2018.00014
+All existing ``import pyneuromatic.core.nm_preferences as nmp`` call sites
+continue to work unchanged.  New code should import nm_configurations directly.
 """
-DATASERIES_SET_LIST = ["all", "set1", "set2", "setX"]
-QUIET = False
-GUI = False
-NAN_EQ_NAN = True  # in Python nan != nan, use this flag so that nan == nan
+from pyneuromatic.core.nm_configurations import (
+    DATASERIES_SET_LIST,
+    QUIET,
+    GUI,
+    NAN_EQ_NAN,
+)
 
-
-class Configs(object):
-    """
-    NM Configs class
-    """
-
-    def __init__(self):
-        self.__quiet = QUIET
-        self.__gui = GUI
-
-    @property
-    def quiet(self):
-        return self.__quiet
-
-    @quiet.setter
-    def quiet(self, quiet):
-        if isinstance(quiet, bool):
-            self.__quiet = quiet
-
-    @property
-    def gui(self):
-        return self.__gui
-
-    @gui.setter
-    def gui(self, on):
-        if isinstance(on, bool):
-            self.__qui = on
+__all__ = ["DATASERIES_SET_LIST", "QUIET", "GUI", "NAN_EQ_NAN"]

--- a/tests/test_analysis/test_nm_tool.py
+++ b/tests/test_analysis/test_nm_tool.py
@@ -15,6 +15,7 @@ from pyneuromatic.core.nm_dataseries import NMDataSeries
 from pyneuromatic.core.nm_channel import NMChannel
 from pyneuromatic.core.nm_epoch import NMEpoch
 from pyneuromatic.analysis.nm_tool import NMTool
+from pyneuromatic.analysis.nm_tool_config import NMToolConfig
 
 QUIET = True
 
@@ -759,6 +760,17 @@ class TestNMManagerRunConfig(unittest.TestCase):
         # After reset, run_config is None so epoch_set should be None
         self.nm.run_tool()
         self.assertEqual(captured.get("run_keys"), {})
+
+
+class TestNMToolConfigProperty(unittest.TestCase):
+    """NMTool.config property returns None for base class."""
+
+    def test_base_tool_config_is_none(self):
+        class _BareTool(NMTool):
+            def __init__(self):
+                super().__init__()
+        t = _BareTool()
+        self.assertIsNone(t.config)
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis/test_nm_tool_config.py
+++ b/tests/test_analysis/test_nm_tool_config.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for nm_tool_config: NMToolConfig and NMToolStatsConfig.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+"""
+import tempfile
+import unittest
+from pathlib import Path
+
+from pyneuromatic.analysis.nm_tool_config import NMToolConfig
+
+
+# ---------------------------------------------------------------------------
+# Minimal concrete subclass for testing the base class in isolation
+# ---------------------------------------------------------------------------
+
+class _SampleConfig(NMToolConfig):
+    _TOML_TYPE = "sample_config"
+    _schema = {
+        "flag":   {"type": bool,  "default": True},
+        "count":  {"type": int,   "default": 5, "min": 0, "max": 100},
+        "ratio":  {"type": float, "default": 0.5, "min": 0.0, "max": 1.0},
+        "method": {"type": str,   "default": "auto",
+                   "choices": ["auto", "fast", "slow"]},
+    }
+
+
+# =========================================================================
+# NMToolConfig base class
+# =========================================================================
+
+class TestNMToolConfigDefaults(unittest.TestCase):
+    """NMToolConfig sets defaults from schema on construction."""
+
+    def setUp(self):
+        self.cfg = _SampleConfig()
+
+    def test_bool_default(self):
+        self.assertTrue(self.cfg.flag)
+
+    def test_int_default(self):
+        self.assertEqual(self.cfg.count, 5)
+
+    def test_float_default(self):
+        self.assertAlmostEqual(self.cfg.ratio, 0.5)
+
+    def test_str_default(self):
+        self.assertEqual(self.cfg.method, "auto")
+
+
+class TestNMToolConfigSetAttr(unittest.TestCase):
+    """NMToolConfig validates values on set."""
+
+    def setUp(self):
+        self.cfg = _SampleConfig()
+
+    def test_set_valid_bool(self):
+        self.cfg.flag = False
+        self.assertFalse(self.cfg.flag)
+
+    def test_set_valid_int(self):
+        self.cfg.count = 10
+        self.assertEqual(self.cfg.count, 10)
+
+    def test_set_valid_float(self):
+        self.cfg.ratio = 0.9
+        self.assertAlmostEqual(self.cfg.ratio, 0.9)
+
+    def test_set_valid_str_choice(self):
+        self.cfg.method = "fast"
+        self.assertEqual(self.cfg.method, "fast")
+
+    def test_unknown_key_raises_attribute_error(self):
+        with self.assertRaises(AttributeError):
+            self.cfg.nonexistent = 1
+
+    def test_wrong_type_raises_type_error(self):
+        with self.assertRaises(TypeError):
+            self.cfg.count = "ten"
+
+    def test_bool_rejected_for_int_param(self):
+        # bool is subclass of int — must be rejected when int expected
+        with self.assertRaises(TypeError):
+            self.cfg.count = True
+
+    def test_bool_rejected_for_float_param(self):
+        with self.assertRaises(TypeError):
+            self.cfg.ratio = True
+
+    def test_below_min_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self.cfg.count = -1
+
+    def test_above_max_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self.cfg.count = 101
+
+    def test_invalid_choice_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self.cfg.method = "turbo"
+
+
+class TestNMToolConfigToDict(unittest.TestCase):
+    """NMToolConfig.to_dict() produces correct output."""
+
+    def setUp(self):
+        self.cfg = _SampleConfig()
+
+    def test_pyneuromatic_header_present(self):
+        d = self.cfg.to_dict()
+        self.assertIn("pyneuromatic", d)
+
+    def test_pyneuromatic_type(self):
+        d = self.cfg.to_dict()
+        self.assertEqual(d["pyneuromatic"]["type"], "sample_config")
+
+    def test_pyneuromatic_version(self):
+        d = self.cfg.to_dict()
+        self.assertIn("version", d["pyneuromatic"])
+
+    def test_all_schema_keys_present(self):
+        d = self.cfg.to_dict()
+        for key in _SampleConfig._schema:
+            self.assertIn(key, d)
+
+    def test_values_match_attributes(self):
+        self.cfg.count = 42
+        d = self.cfg.to_dict()
+        self.assertEqual(d["count"], 42)
+
+
+class TestNMToolConfigFromDict(unittest.TestCase):
+    """NMToolConfig.from_dict() reconstructs and validates."""
+
+    def test_round_trip(self):
+        cfg = _SampleConfig()
+        cfg.count = 77
+        cfg.method = "slow"
+        cfg2 = _SampleConfig.from_dict(cfg.to_dict())
+        self.assertEqual(cfg2.count, 77)
+        self.assertEqual(cfg2.method, "slow")
+
+    def test_unknown_keys_ignored(self):
+        d = _SampleConfig().to_dict()
+        d["unknown_param"] = "ignored"
+        cfg = _SampleConfig.from_dict(d)   # no exception
+        self.assertFalse(hasattr(cfg, "unknown_param"))
+
+    def test_missing_keys_use_defaults(self):
+        cfg = _SampleConfig.from_dict({})
+        self.assertEqual(cfg.count, 5)
+
+    def test_invalid_value_raises(self):
+        d = _SampleConfig().to_dict()
+        d["count"] = -99
+        with self.assertRaises(ValueError):
+            _SampleConfig.from_dict(d)
+
+
+class TestNMToolConfigEquality(unittest.TestCase):
+
+    def test_equal_configs(self):
+        a = _SampleConfig()
+        b = _SampleConfig()
+        self.assertEqual(a, b)
+
+    def test_unequal_configs(self):
+        a = _SampleConfig()
+        b = _SampleConfig()
+        b.count = 99
+        self.assertNotEqual(a, b)
+
+    def test_different_type_not_equal(self):
+        a = _SampleConfig()
+        self.assertNotEqual(a, "not a config")
+
+
+class TestNMToolConfigRepr(unittest.TestCase):
+
+    def test_repr_contains_class_name(self):
+        self.assertIn("_SampleConfig", repr(_SampleConfig()))
+
+    def test_repr_contains_param(self):
+        self.assertIn("count=5", repr(_SampleConfig()))
+
+
+class TestNMToolConfigSaveLoad(unittest.TestCase):
+    """NMToolConfig save/load TOML round-trip."""
+
+    def test_save_creates_file(self):
+        cfg = _SampleConfig()
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "cfg.toml"
+            cfg.save(path)
+            self.assertTrue(path.exists())
+
+    def test_save_returns_path(self):
+        cfg = _SampleConfig()
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "cfg.toml"
+            result = cfg.save(path)
+            self.assertEqual(result, path)
+
+    def test_load_round_trips_values(self):
+        cfg = _SampleConfig()
+        cfg.count = 42
+        cfg.method = "slow"
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "cfg.toml"
+            cfg.save(path)
+            cfg2 = _SampleConfig.load(path)
+        self.assertEqual(cfg2.count, 42)
+        self.assertEqual(cfg2.method, "slow")
+
+    def test_load_wrong_type_raises(self):
+        import tomli_w
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "bad.toml"
+            with open(path, "wb") as f:
+                tomli_w.dump({"pyneuromatic": {"type": "wrong_type"}}, f)
+            with self.assertRaises(ValueError):
+                _SampleConfig.load(path)
+
+    def test_load_missing_file_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            _SampleConfig.load("/nonexistent/cfg.toml")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -7,7 +7,9 @@ Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
 acquiring and simulating electrophysiology data.
 """
 import math
+import tempfile
 import unittest
+from pathlib import Path
 
 import numpy as np
 
@@ -15,6 +17,7 @@ from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_manager import NMManager
 import pyneuromatic.analysis.nm_tool_stats as nms
 import pyneuromatic.analysis.nm_stat_win as nmsw
+from pyneuromatic.analysis.nm_tool_stats import NMToolStatsConfig
 
 NM = NMManager(quiet=True)
 
@@ -1202,6 +1205,62 @@ class TestNMToolStats2AddEpochSetsFromMask(unittest.TestCase):
         nms.NMToolStats2._add_epoch_sets_from_mask(
             self.tf, "short", self.ds, self.mask, set_name_true="Pass"
         )  # no exception
+
+
+class TestNMToolStatsConfig(unittest.TestCase):
+    """NMToolStatsConfig schema and defaults."""
+
+    def setUp(self):
+        self.cfg = NMToolStatsConfig()
+
+    def test_ignore_nans_default(self):
+        self.assertTrue(self.cfg.ignore_nans)
+
+    def test_xclip_default(self):
+        self.assertTrue(self.cfg.xclip)
+
+    def test_results_to_history_default(self):
+        self.assertFalse(self.cfg.results_to_history)
+
+    def test_results_to_cache_default(self):
+        self.assertTrue(self.cfg.results_to_cache)
+
+    def test_results_to_numpy_default(self):
+        self.assertFalse(self.cfg.results_to_numpy)
+
+    def test_set_ignore_nans(self):
+        self.cfg.ignore_nans = False
+        self.assertFalse(self.cfg.ignore_nans)
+
+    def test_wrong_type_raises(self):
+        with self.assertRaises(TypeError):
+            self.cfg.ignore_nans = 1  # int, not bool
+
+    def test_toml_type(self):
+        self.assertEqual(NMToolStatsConfig._TOML_TYPE, "stats_config")
+
+    def test_save_load_round_trip(self):
+        self.cfg.ignore_nans = False
+        self.cfg.results_to_numpy = True
+        with tempfile.TemporaryDirectory() as td:
+            path = Path(td) / "stats.toml"
+            self.cfg.save(path)
+            cfg2 = NMToolStatsConfig.load(path)
+        self.assertFalse(cfg2.ignore_nans)
+        self.assertTrue(cfg2.results_to_numpy)
+
+    def test_stats_tool_has_config(self):
+        t = nms.NMToolStats()
+        self.assertIsNotNone(t.config)
+
+    def test_stats_tool_config_is_stats_config(self):
+        t = nms.NMToolStats()
+        self.assertIsInstance(t.config, NMToolStatsConfig)
+
+    def test_stats_tool_config_defaults(self):
+        t = nms.NMToolStats()
+        self.assertTrue(t.config.ignore_nans)
+        self.assertTrue(t.config.xclip)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `NMToolConfig`, a schema-based configuration base class with validated
  attribute setting, TOML save/load, and equality/repr support
- Adds `NMToolStatsConfig` (first concrete subclass) in `nm_tool_stats.py`,
  wired into `NMToolStats` via a new `config` property on `NMTool`
- Moves global constants to `nm_configurations.py`; `nm_preferences.py`
  kept as a compatibility shim so all existing import sites are unaffected

## Test plan
- [ ] `test_nm_tool_config.py` — 34 tests covering `NMToolConfig` defaults,
  validation, `to_dict`/`from_dict`, TOML save/load, equality, repr
- [ ] `TestNMToolStatsConfig` in `test_nm_tool_stats.py` — 12 tests covering
  `NMToolStatsConfig` schema, defaults, type checking, TOML round-trip, and
  wiring into `NMToolStats`
- [ ] `TestNMToolConfigProperty` in `test_nm_tool.py` — `config` property
  returns `None` for bare `NMTool` subclass
- [ ] `python3 -m pytest tests/ -x -q` — all tests pass

Closes #155
