### PR TITLE
feat(core): add NMGroups for mutually exclusive epoch group assignments

### DIFF
--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
+from pyneuromatic.core.nm_group import NMGroups
 import pyneuromatic.core.nm_configurations as nmc
 import pyneuromatic.core.nm_utilities as nmu
 
@@ -181,6 +182,11 @@ class NMEpochContainer(NMObjectContainer):
     Container of NMEpochs
     """
 
+    _DEEPCOPY_SPECIAL_ATTRS: frozenset[str] = (
+        NMObjectContainer._DEEPCOPY_SPECIAL_ATTRS
+        | frozenset({"_NMEpochContainer__groups"})
+    )
+
     def __init__(
         self,
         parent: object | None = None,
@@ -196,6 +202,7 @@ class NMEpochContainer(NMObjectContainer):
             auto_name_prefix=name_prefix,
             auto_name_seq_format=name_seq_format,
         )
+        self.__groups = NMGroups(name=name + "Groups", parent=self)
 
     # override, no super
     def content_type(self) -> str:
@@ -224,3 +231,39 @@ class NMEpochContainer(NMObjectContainer):
         if super()._add(c, select=select, quiet=quiet):
             return c
         return None
+
+    def __deepcopy__(self, memo: dict) -> "NMEpochContainer":
+        result = NMObjectContainer.__deepcopy__(self, memo)
+        result._NMEpochContainer__groups = copy.deepcopy(
+            self._NMEpochContainer__groups, memo
+        )
+        result._NMEpochContainer__groups._parent = result
+        return result
+
+    @property
+    def groups(self) -> NMGroups:
+        """Group assignments for epochs in this container."""
+        return self.__groups
+
+    # override: also remove from groups when an epoch is popped
+    def pop(
+        self,
+        key: str,
+        default: object = NMObjectContainer._POPDEFAULT,
+        quiet: bool = nmc.QUIET,
+    ) -> NMEpoch | None:
+        actual_key = self._getkey(key)
+        result = super().pop(key=key, default=default, quiet=quiet)
+        if actual_key is not None:
+            self.__groups.unassign(actual_key, error=False, quiet=True)
+        return result
+
+    # override: also clear groups when the container is cleared
+    def clear(self, quiet: bool = nmc.QUIET) -> None:
+        self.__groups.clear(quiet=True)
+        super().clear(quiet=quiet)
+
+    # Note: rename() is not overridden because NMEpochContainer is constructed
+    # with rename_on=False, so NMObjectContainer.rename() raises RuntimeError
+    # before any renaming occurs. If rename_on is ever enabled, override rename()
+    # here to also call self.__groups.rename_item(old_key, new_key).

--- a/pyneuromatic/core/nm_group.py
+++ b/pyneuromatic/core/nm_group.py
@@ -1,0 +1,293 @@
+# -*- coding: utf-8 -*-
+"""
+NMGroups - Mutually exclusive integer group assignments for NMObject names.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import copy
+
+import pyneuromatic.core.nm_history as nmh
+import pyneuromatic.core.nm_configurations as nmc
+import pyneuromatic.core.nm_utilities as nmu
+
+
+class NMGroups:
+    """Mutually exclusive integer group assignments for container item names.
+
+    Stores a mapping ``{item_name: group_number}`` where each name belongs
+    to at most one group.  Group numbers are non-negative integers.
+
+    Typical use case — a repeating I-V relation of *n* voltage steps::
+
+        groups.assign_cyclic(epoch_names, n_groups=5)
+        # assigns 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, ...
+
+    Items of a single group can be retrieved for averaging or selection::
+
+        groups.get_items(0)   # → ["RecordA0", "RecordA5", ...]
+
+    Combined set+group selection (AND) is a plain Python set intersection::
+
+        set_items   = dataseries.epochs.sets.get("set1", get_keys=True)
+        group_items = dataseries.epochs.groups.get_items(0)
+        selected    = set(set_items) & set(group_items)
+    """
+
+    def __init__(
+        self,
+        name: str = "NMGroups0",
+        parent: object | None = None,
+    ) -> None:
+        self._name = name
+        self._parent = parent
+        self._map: dict[str, int] = {}  # item_name → group_number
+
+    # ------------------------------------------------------------------
+    # Identity / dunder
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def path_str(self) -> str:
+        if self._parent is not None and hasattr(self._parent, "path_str"):
+            return self._parent.path_str + ".groups"
+        return self._name
+
+    def __len__(self) -> int:
+        return len(self._map)
+
+    def __iter__(self):
+        return iter(self._map)
+
+    def __contains__(self, item_name: object) -> bool:
+        if not isinstance(item_name, str):
+            return False
+        return item_name in self._map
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, NMGroups):
+            return NotImplemented
+        return self._map == other._map
+
+    def __repr__(self) -> str:
+        return "%s(%r)" % (self.__class__.__name__, dict(self._map))
+
+    def __deepcopy__(self, memo: dict) -> "NMGroups":
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        result._name = self._name
+        result._parent = None   # parent reference not copied (same pattern as NMSets)
+        result._map = dict(self._map)   # str→int: shallow copy is sufficient
+        return result
+
+    def copy(self) -> "NMGroups":
+        """Return a deep copy (parent reference cleared)."""
+        return copy.deepcopy(self)
+
+    # ------------------------------------------------------------------
+    # Validation helpers
+
+    @staticmethod
+    def _check_group(group: object) -> None:
+        """Raise TypeError/ValueError for invalid group values."""
+        if isinstance(group, bool) or not isinstance(group, int):
+            raise TypeError(
+                "group: expected non-negative int, got %s"
+                % type(group).__name__
+            )
+        if group < 0:
+            raise ValueError("group must be >= 0, got %d" % group)
+
+    # ------------------------------------------------------------------
+    # Core operations
+
+    def assign(
+        self,
+        item_name: str,
+        group: int,
+        quiet: bool = nmc.QUIET,
+    ) -> None:
+        """Assign *item_name* to *group* (replaces any previous assignment).
+
+        Args:
+            item_name: Name of the item (e.g. epoch name).
+            group: Non-negative integer group number.
+            quiet: Suppress history output.
+
+        Raises:
+            TypeError: If *item_name* is not a string or *group* is not an int.
+            ValueError: If *group* is negative.
+        """
+        if not isinstance(item_name, str):
+            raise TypeError(nmu.type_error_str(item_name, "item_name", "string"))
+        self._check_group(group)
+        self._map[item_name] = group
+        nmh.history(
+            "groups: '%s' → %d" % (item_name, group),
+            path=self.path_str,
+            quiet=quiet,
+        )
+
+    def assign_cyclic(
+        self,
+        item_names: list[str],
+        n_groups: int,
+        quiet: bool = nmc.QUIET,
+    ) -> None:
+        """Assign *item_names* cyclically to groups ``0 … n_groups-1``.
+
+        Example::
+
+            groups.assign_cyclic(["E0","E1","E2","E3","E4","E5"], n_groups=3)
+            # E0→0, E1→1, E2→2, E3→0, E4→1, E5→2
+
+        Args:
+            item_names: Ordered list of item names.
+            n_groups: Number of groups (must be >= 1).
+            quiet: Suppress history output.
+
+        Raises:
+            TypeError: If *item_names* is not a list or *n_groups* is not an int.
+            ValueError: If *n_groups* < 1.
+        """
+        if not isinstance(item_names, list):
+            raise TypeError(nmu.type_error_str(item_names, "item_names", "list"))
+        if isinstance(n_groups, bool) or not isinstance(n_groups, int):
+            raise TypeError(nmu.type_error_str(n_groups, "n_groups", "int"))
+        if n_groups < 1:
+            raise ValueError("n_groups must be >= 1, got %d" % n_groups)
+        for i, name in enumerate(item_names):
+            self.assign(name, i % n_groups, quiet=True)
+        nmh.history(
+            "groups: cyclic assignment, %d names, %d groups"
+            % (len(item_names), n_groups),
+            path=self.path_str,
+            quiet=quiet,
+        )
+
+    def get_items(self, group: int) -> list[str]:
+        """Return item names assigned to *group*, in insertion order.
+
+        Args:
+            group: Non-negative integer group number.
+
+        Returns:
+            List of item names assigned to *group*.
+
+        Raises:
+            TypeError/ValueError: If *group* is an invalid type or negative.
+            KeyError: If *group* does not exist, with a message listing the
+                existing group numbers.
+        """
+        self._check_group(group)
+        if group not in self.group_numbers:
+            raise KeyError(
+                "group %d does not exist; existing groups: %s"
+                % (group, self.group_numbers)
+            )
+        return [name for name, g in self._map.items() if g == group]
+
+    def get_group(self, item_name: str) -> int | None:
+        """Return the group number for *item_name*, or ``None`` if unassigned.
+
+        Args:
+            item_name: Name of the item.
+
+        Raises:
+            TypeError: If *item_name* is not a string.
+        """
+        if not isinstance(item_name, str):
+            raise TypeError(nmu.type_error_str(item_name, "item_name", "string"))
+        return self._map.get(item_name)
+
+    def unassign(
+        self,
+        item_name: str,
+        error: bool = True,
+        quiet: bool = nmc.QUIET,
+    ) -> None:
+        """Remove *item_name* from its group.
+
+        Args:
+            item_name: Name of the item to unassign.
+            error: If True, raise KeyError when *item_name* is not assigned.
+            quiet: Suppress history output.
+
+        Raises:
+            TypeError: If *item_name* is not a string.
+            KeyError: If *item_name* is not assigned and *error* is True.
+        """
+        if not isinstance(item_name, str):
+            raise TypeError(nmu.type_error_str(item_name, "item_name", "string"))
+        if item_name not in self._map:
+            if error:
+                raise KeyError(
+                    "'%s' is not assigned to any group" % item_name
+                )
+            return
+        group = self._map.pop(item_name)
+        nmh.history(
+            "groups: unassigned '%s' from group %d" % (item_name, group),
+            path=self.path_str,
+            quiet=quiet,
+        )
+
+    def clear(self, quiet: bool = nmc.QUIET) -> None:
+        """Remove all group assignments.
+
+        Args:
+            quiet: Suppress history output.
+        """
+        if not self._map:
+            return
+        self._map.clear()
+        nmh.history(
+            "groups: cleared all assignments",
+            path=self.path_str,
+            quiet=quiet,
+        )
+
+    def rename_item(self, old_name: str, new_name: str) -> None:
+        """Rename an item across all group assignments.
+
+        Called automatically by the container when an item is renamed.
+        If *old_name* has no assignment, this is a no-op.
+
+        Args:
+            old_name: Current item name.
+            new_name: New item name.
+        """
+        if old_name in self._map:
+            self._map[new_name] = self._map.pop(old_name)
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def group_numbers(self) -> list[int]:
+        """Sorted list of distinct group numbers currently assigned."""
+        return sorted(set(self._map.values()))
+
+    @property
+    def n_groups(self) -> int:
+        """Number of distinct group numbers currently in use."""
+        return len(self.group_numbers)

--- a/tests/test_core/test_nm_group.py
+++ b/tests/test_core/test_nm_group.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for NMGroups and NMEpochContainer.groups.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+"""
+import copy
+import unittest
+
+from pyneuromatic.core.nm_group import NMGroups
+from pyneuromatic.core.nm_manager import NMManager
+
+QUIET = True
+
+
+# ---------------------------------------------------------------------------
+# Shared setup helper
+# ---------------------------------------------------------------------------
+
+def _make_groups(n=6):
+    """Return an NMGroups with n item names pre-assigned cyclically to 3 groups."""
+    g = NMGroups(name="TestGroups", parent=None)
+    names = ["E%d" % i for i in range(n)]
+    g.assign_cyclic(names, n_groups=3, quiet=QUIET)
+    return g, names
+
+
+# =========================================================================
+# NMGroups — init
+# =========================================================================
+
+class TestNMGroupsInit(unittest.TestCase):
+
+    def test_empty_on_construction(self):
+        g = NMGroups()
+        self.assertEqual(len(g), 0)
+
+    def test_name_default(self):
+        g = NMGroups()
+        self.assertEqual(g.name, "NMGroups0")
+
+    def test_name_custom(self):
+        g = NMGroups(name="MyGroups")
+        self.assertEqual(g.name, "MyGroups")
+
+    def test_path_str_no_parent(self):
+        g = NMGroups(name="G")
+        self.assertEqual(g.path_str, "G")
+
+    def test_n_groups_empty(self):
+        g = NMGroups()
+        self.assertEqual(g.n_groups, 0)
+
+
+# =========================================================================
+# NMGroups — assign
+# =========================================================================
+
+class TestNMGroupsAssign(unittest.TestCase):
+
+    def setUp(self):
+        self.g = NMGroups(parent=None)
+
+    def test_assign_single(self):
+        self.g.assign("E0", 0, quiet=QUIET)
+        self.assertEqual(self.g.get_group("E0"), 0)
+
+    def test_assign_replaces_previous(self):
+        self.g.assign("E0", 0, quiet=QUIET)
+        self.g.assign("E0", 2, quiet=QUIET)
+        self.assertEqual(self.g.get_group("E0"), 2)
+
+    def test_assign_multiple(self):
+        for i in range(5):
+            self.g.assign("E%d" % i, i, quiet=QUIET)
+        self.assertEqual(len(self.g), 5)
+
+    def test_assign_group_zero(self):
+        self.g.assign("E0", 0, quiet=QUIET)
+        self.assertEqual(self.g.get_group("E0"), 0)
+
+    def test_assign_bad_name_type_raises(self):
+        with self.assertRaises(TypeError):
+            self.g.assign(0, 1, quiet=QUIET)
+
+    def test_assign_bool_group_raises(self):
+        with self.assertRaises(TypeError):
+            self.g.assign("E0", True, quiet=QUIET)
+
+    def test_assign_float_group_raises(self):
+        with self.assertRaises(TypeError):
+            self.g.assign("E0", 1.0, quiet=QUIET)
+
+    def test_assign_negative_group_raises(self):
+        with self.assertRaises(ValueError):
+            self.g.assign("E0", -1, quiet=QUIET)
+
+    def test_assign_none_group_raises(self):
+        with self.assertRaises(TypeError):
+            self.g.assign("E0", None, quiet=QUIET)
+
+
+# =========================================================================
+# NMGroups — assign_cyclic
+# =========================================================================
+
+class TestNMGroupsAssignCyclic(unittest.TestCase):
+
+    def test_cyclic_3_groups_6_names(self):
+        g = NMGroups()
+        names = ["E%d" % i for i in range(6)]
+        g.assign_cyclic(names, n_groups=3, quiet=QUIET)
+        self.assertEqual(g.get_group("E0"), 0)
+        self.assertEqual(g.get_group("E1"), 1)
+        self.assertEqual(g.get_group("E2"), 2)
+        self.assertEqual(g.get_group("E3"), 0)
+        self.assertEqual(g.get_group("E4"), 1)
+        self.assertEqual(g.get_group("E5"), 2)
+
+    def test_cyclic_5_groups_iv_relation(self):
+        g = NMGroups()
+        names = ["E%d" % i for i in range(15)]
+        g.assign_cyclic(names, n_groups=5, quiet=QUIET)
+        for i in range(15):
+            self.assertEqual(g.get_group("E%d" % i), i % 5)
+
+    def test_cyclic_1_group(self):
+        g = NMGroups()
+        names = ["E0", "E1", "E2"]
+        g.assign_cyclic(names, n_groups=1, quiet=QUIET)
+        for name in names:
+            self.assertEqual(g.get_group(name), 0)
+
+    def test_cyclic_empty_list(self):
+        g = NMGroups()
+        g.assign_cyclic([], n_groups=3, quiet=QUIET)
+        self.assertEqual(len(g), 0)
+
+    def test_cyclic_bad_names_type_raises(self):
+        g = NMGroups()
+        with self.assertRaises(TypeError):
+            g.assign_cyclic("E0", n_groups=3, quiet=QUIET)
+
+    def test_cyclic_bad_n_groups_type_raises(self):
+        g = NMGroups()
+        with self.assertRaises(TypeError):
+            g.assign_cyclic(["E0"], n_groups=1.0, quiet=QUIET)
+
+    def test_cyclic_bool_n_groups_raises(self):
+        g = NMGroups()
+        with self.assertRaises(TypeError):
+            g.assign_cyclic(["E0"], n_groups=True, quiet=QUIET)
+
+    def test_cyclic_zero_n_groups_raises(self):
+        g = NMGroups()
+        with self.assertRaises(ValueError):
+            g.assign_cyclic(["E0"], n_groups=0, quiet=QUIET)
+
+    def test_cyclic_negative_n_groups_raises(self):
+        g = NMGroups()
+        with self.assertRaises(ValueError):
+            g.assign_cyclic(["E0"], n_groups=-1, quiet=QUIET)
+
+
+# =========================================================================
+# NMGroups — get_items
+# =========================================================================
+
+class TestNMGroupsGetItems(unittest.TestCase):
+
+    def setUp(self):
+        self.g, self.names = _make_groups(n=6)
+
+    def test_group_0_members(self):
+        self.assertEqual(self.g.get_items(0), ["E0", "E3"])
+
+    def test_group_1_members(self):
+        self.assertEqual(self.g.get_items(1), ["E1", "E4"])
+
+    def test_group_2_members(self):
+        self.assertEqual(self.g.get_items(2), ["E2", "E5"])
+
+    def test_nonexistent_group_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            self.g.get_items(99)
+
+    def test_key_error_message_lists_existing_groups(self):
+        try:
+            self.g.get_items(99)
+        except KeyError as e:
+            self.assertIn("does not exist", str(e))
+            self.assertIn("[0, 1, 2]", str(e))
+
+    def test_bad_type_raises(self):
+        with self.assertRaises(TypeError):
+            self.g.get_items("0")
+
+    def test_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.g.get_items(True)
+
+    def test_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.g.get_items(-1)
+
+
+# =========================================================================
+# NMGroups — get_group
+# =========================================================================
+
+class TestNMGroupsGetGroup(unittest.TestCase):
+
+    def setUp(self):
+        self.g, _ = _make_groups(n=3)
+
+    def test_returns_correct_group(self):
+        self.assertEqual(self.g.get_group("E0"), 0)
+        self.assertEqual(self.g.get_group("E1"), 1)
+        self.assertEqual(self.g.get_group("E2"), 2)
+
+    def test_unassigned_returns_none(self):
+        self.assertIsNone(self.g.get_group("E99"))
+
+    def test_bad_type_raises(self):
+        with self.assertRaises(TypeError):
+            self.g.get_group(0)
+
+
+# =========================================================================
+# NMGroups — unassign
+# =========================================================================
+
+class TestNMGroupsUnassign(unittest.TestCase):
+
+    def setUp(self):
+        self.g, _ = _make_groups(n=3)
+
+    def test_unassign_removes_entry(self):
+        self.g.unassign("E0", quiet=QUIET)
+        self.assertIsNone(self.g.get_group("E0"))
+
+    def test_unassign_reduces_len(self):
+        before = len(self.g)
+        self.g.unassign("E0", quiet=QUIET)
+        self.assertEqual(len(self.g), before - 1)
+
+    def test_unassign_unknown_error_true_raises(self):
+        with self.assertRaises(KeyError):
+            self.g.unassign("E99", error=True, quiet=QUIET)
+
+    def test_unassign_unknown_error_false_silent(self):
+        self.g.unassign("E99", error=False, quiet=QUIET)  # no exception
+
+    def test_unassign_bad_type_raises(self):
+        with self.assertRaises(TypeError):
+            self.g.unassign(0, quiet=QUIET)
+
+
+# =========================================================================
+# NMGroups — clear
+# =========================================================================
+
+class TestNMGroupsClear(unittest.TestCase):
+
+    def test_clear_empties_all(self):
+        g, _ = _make_groups(n=6)
+        g.clear(quiet=QUIET)
+        self.assertEqual(len(g), 0)
+
+    def test_clear_already_empty_no_error(self):
+        g = NMGroups()
+        g.clear(quiet=QUIET)  # no exception
+
+    def test_get_group_after_clear_returns_none(self):
+        g, _ = _make_groups(n=3)
+        g.clear(quiet=QUIET)
+        self.assertIsNone(g.get_group("E0"))
+
+
+# =========================================================================
+# NMGroups — rename_item
+# =========================================================================
+
+class TestNMGroupsRenameItem(unittest.TestCase):
+
+    def test_rename_updates_key(self):
+        g, _ = _make_groups(n=3)
+        g.rename_item("E0", "E0_new")
+        self.assertEqual(g.get_group("E0_new"), 0)
+        self.assertIsNone(g.get_group("E0"))
+
+    def test_rename_preserves_group_number(self):
+        g, _ = _make_groups(n=3)
+        g.rename_item("E2", "E2_renamed")
+        self.assertEqual(g.get_group("E2_renamed"), 2)
+
+    def test_rename_unknown_is_noop(self):
+        g, _ = _make_groups(n=3)
+        g.rename_item("E99", "E99_new")  # no exception, no change
+        self.assertEqual(len(g), 3)
+
+
+# =========================================================================
+# NMGroups — n_groups
+# =========================================================================
+
+class TestNMGroupsGroupNumbers(unittest.TestCase):
+
+    def test_group_numbers_cyclic(self):
+        g, _ = _make_groups(n=6)
+        self.assertEqual(g.group_numbers, [0, 1, 2])
+
+    def test_group_numbers_sorted(self):
+        g = NMGroups()
+        g.assign("E0", 2, quiet=QUIET)
+        g.assign("E1", 0, quiet=QUIET)
+        g.assign("E2", 1, quiet=QUIET)
+        self.assertEqual(g.group_numbers, [0, 1, 2])
+
+    def test_group_numbers_empty(self):
+        g = NMGroups()
+        self.assertEqual(g.group_numbers, [])
+
+    def test_group_numbers_after_unassign(self):
+        g, _ = _make_groups(n=3)   # groups 0, 1, 2
+        g.unassign("E2", quiet=QUIET)   # group 2 now empty
+        self.assertEqual(g.group_numbers, [0, 1])
+
+
+class TestNMGroupsNGroups(unittest.TestCase):
+
+    def test_n_groups_cyclic(self):
+        g, _ = _make_groups(n=6)
+        self.assertEqual(g.n_groups, 3)
+
+    def test_n_groups_after_unassign(self):
+        g, _ = _make_groups(n=3)   # groups 0, 1, 2 each have 1 member
+        g.unassign("E2", quiet=QUIET)   # group 2 now empty
+        self.assertEqual(g.n_groups, 2)
+
+    def test_n_groups_one_group(self):
+        g = NMGroups()
+        g.assign_cyclic(["E0", "E1", "E2"], n_groups=1, quiet=QUIET)
+        self.assertEqual(g.n_groups, 1)
+
+
+# =========================================================================
+# NMGroups — contains / iter / len
+# =========================================================================
+
+class TestNMGroupsCollectionProtocol(unittest.TestCase):
+
+    def setUp(self):
+        self.g, self.names = _make_groups(n=3)
+
+    def test_contains_assigned(self):
+        self.assertIn("E0", self.g)
+
+    def test_not_contains_unassigned(self):
+        self.assertNotIn("E99", self.g)
+
+    def test_contains_non_string_false(self):
+        self.assertNotIn(0, self.g)
+
+    def test_len(self):
+        self.assertEqual(len(self.g), 3)
+
+    def test_iter(self):
+        self.assertEqual(set(self.g), {"E0", "E1", "E2"})
+
+
+# =========================================================================
+# NMGroups — equality
+# =========================================================================
+
+class TestNMGroupsEquality(unittest.TestCase):
+
+    def test_equal_empty(self):
+        self.assertEqual(NMGroups(), NMGroups())
+
+    def test_equal_same_assignments(self):
+        g1, _ = _make_groups(n=3)
+        g2, _ = _make_groups(n=3)
+        self.assertEqual(g1, g2)
+
+    def test_unequal_different_assignments(self):
+        g1, _ = _make_groups(n=3)
+        g2, _ = _make_groups(n=3)
+        g2.assign("E0", 2, quiet=QUIET)
+        self.assertNotEqual(g1, g2)
+
+    def test_not_equal_to_non_nmgroups(self):
+        g, _ = _make_groups(n=3)
+        self.assertNotEqual(g, "not a group")
+
+
+# =========================================================================
+# NMGroups — deepcopy
+# =========================================================================
+
+class TestNMGroupsDeepCopy(unittest.TestCase):
+
+    def test_deepcopy_preserves_assignments(self):
+        g, _ = _make_groups(n=6)
+        g2 = copy.deepcopy(g)
+        self.assertEqual(g, g2)
+
+    def test_deepcopy_is_independent(self):
+        g, _ = _make_groups(n=3)
+        g2 = copy.deepcopy(g)
+        g2.assign("E0", 2, quiet=QUIET)
+        self.assertEqual(g.get_group("E0"), 0)  # original unchanged
+
+    def test_deepcopy_parent_cleared(self):
+        class _FakeParent:
+            path_str = "root"
+        g = NMGroups(parent=_FakeParent())
+        g2 = copy.deepcopy(g)
+        self.assertIsNone(g2._parent)
+
+    def test_copy_method(self):
+        g, _ = _make_groups(n=3)
+        g2 = g.copy()
+        self.assertEqual(g, g2)
+
+
+# =========================================================================
+# NMEpochContainer.groups integration
+# =========================================================================
+
+class TestNMEpochContainerGroups(unittest.TestCase):
+    """groups property lives on NMEpochContainer and syncs with container ops."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=QUIET)
+        folder = self.nm.project.folders.new("f0")
+        self.ds = folder.dataseries.new("Record")
+        # Create 6 epochs
+        for i in range(6):
+            self.ds.epochs.new("E%d" % i)
+        self.epoch_names = ["E%d" % i for i in range(6)]
+        self.ds.epochs.groups.assign_cyclic(
+            self.epoch_names, n_groups=3, quiet=QUIET
+        )
+
+    def test_groups_property_exists(self):
+        self.assertIsInstance(self.ds.epochs.groups, NMGroups)
+
+    def test_groups_cyclic_assignment(self):
+        grp = self.ds.epochs.groups
+        for i, name in enumerate(self.epoch_names):
+            self.assertEqual(grp.get_group(name), i % 3)
+
+    def test_get_items_returns_correct_epochs(self):
+        grp = self.ds.epochs.groups
+        members = grp.get_items(0)
+        self.assertEqual(members, ["E0", "E3"])
+
+    def test_pop_removes_from_groups(self):
+        self.ds.epochs.pop("E0", quiet=QUIET)
+        self.assertIsNone(self.ds.epochs.groups.get_group("E0"))
+
+    def test_pop_unassigned_epoch_no_error(self):
+        # Create epoch not in any group
+        self.ds.epochs.new(quiet=QUIET)   # E6
+        self.ds.epochs.pop("E6", quiet=QUIET)   # no exception
+
+    def test_clear_removes_all_group_assignments(self):
+        self.ds.epochs.clear(quiet=QUIET)
+        self.assertEqual(len(self.ds.epochs.groups), 0)
+
+    def test_deepcopy_includes_groups(self):
+        ds2 = copy.deepcopy(self.ds)
+        grp2 = ds2.epochs.groups
+        for i, name in enumerate(self.epoch_names):
+            self.assertEqual(grp2.get_group(name), i % 3)
+
+    def test_deepcopy_groups_independent(self):
+        ds2 = copy.deepcopy(self.ds)
+        ds2.epochs.groups.assign("E0", 2, quiet=QUIET)
+        self.assertEqual(self.ds.epochs.groups.get_group("E0"), 0)
+
+    def test_rename_epoch_raises_runtime_error(self):
+        # Epochs are not renameable (rename_on=False); groups are therefore
+        # never left with stale keys via the standard API
+        with self.assertRaises(RuntimeError):
+            self.ds.epochs.rename("E0", "E0_new")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Adds `NMGroups` class (`pyneuromatic/core/nm_group.py`) — mutually exclusive
  integer group assignments for epoch names, stored as `dict[str, int]`
- Key methods: `assign()`, `assign_cyclic()`, `get_items()`, `get_group()`,
  `unassign()`, `clear()`, `rename_item()`; properties: `group_numbers`, `n_groups`
- `get_items(group)` raises `KeyError` with informative message listing existing
  group numbers when an unknown group is requested
- `NMEpochContainer` gains a `groups` property; `pop()` and `clear()` keep groups
  in sync; `deepcopy` preserves group assignments independently
- 74 new tests in `tests/test_core/test_nm_group.py`

## Test plan
- [ ] `python3 -m pytest tests/test_core/test_nm_group.py -v`
- [ ] `python3 -m pytest tests/ -x -q`
