### PR TITLE
feat(core): add NMDataSeries.get_data_for_epochs() for batch epoch retrieval

### DIFF
--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -209,6 +209,41 @@ class NMDataSeries(NMObject):
                     dlist.append(d)
         return dlist
 
+    def get_data_for_epochs(
+        self,
+        epoch_names: list[str],
+        channel: str | None = None,
+        get_keys: bool = False,
+    ) -> list["NMData"] | list[str]:
+        """Get NMData for a list of epoch names and a channel.
+
+        Args:
+            epoch_names: List of epoch names (e.g. ["E0", "E2", "E5"]).
+            channel: Channel name (e.g. "A"). If None, uses selected channel.
+            get_keys: If True, return data names instead of NMData objects.
+
+        Returns:
+            List of NMData objects (or their names if get_keys=True), in the
+            same order as epoch_names. Epochs with no data at the channel are
+            silently skipped.
+
+        Raises:
+            TypeError: If epoch_names is not a list.
+            KeyError: If channel is specified but does not exist.
+        """
+        if not isinstance(epoch_names, list):
+            raise TypeError(nmu.type_error_str(epoch_names, "epoch_names", "list"))
+        if channel is not None:
+            c = self.channels.get(channel)
+            if c is None:
+                raise KeyError("channel '%s' does not exist" % channel)
+        result: list = []
+        for epoch_name in epoch_names:
+            d = self.get_data(channel=channel, epoch=epoch_name)
+            if d is not None:
+                result.append(d.name if get_keys else d)
+        return result
+
     def get_data(
         self,
         channel: str | None = None,

--- a/tests/test_core/test_nm_dataseries.py
+++ b/tests/test_core/test_nm_dataseries.py
@@ -157,6 +157,79 @@ class TestNMDataSeriesWithData(unittest.TestCase):
         self.assertIsNone(result)
 
 
+class TestNMDataSeriesGetDataForEpochs(unittest.TestCase):
+    """Tests for NMDataSeries.get_data_for_epochs()."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=True)
+        self.ds = NMDataSeries(parent=self.nm, name="Record")
+
+        self.chan_a = self.ds.channels.new()
+        self.chan_b = self.ds.channels.new()
+
+        self.epoch_0 = self.ds.epochs.new()
+        self.epoch_1 = self.ds.epochs.new()
+        self.epoch_2 = self.ds.epochs.new()
+
+        self.data = {}
+        for ch_name, channel in [("A", self.chan_a), ("B", self.chan_b)]:
+            for i, epoch in enumerate([self.epoch_0, self.epoch_1, self.epoch_2]):
+                name = f"Record{ch_name}{i}"
+                d = NMData(parent=self.nm, name=name)
+                self.data[name] = d
+                channel.data.append(d)
+                epoch.data.append(d)
+
+        self.ds.channels.selected_name = "A"
+
+    def test_returns_data_objects(self):
+        result = self.ds.get_data_for_epochs(["E0", "E2"], channel="A")
+        self.assertEqual(len(result), 2)
+        self.assertIsInstance(result[0], NMData)
+        self.assertEqual(result[0].name, "RecordA0")
+        self.assertEqual(result[1].name, "RecordA2")
+
+    def test_returns_keys_when_get_keys_true(self):
+        result = self.ds.get_data_for_epochs(["E0", "E1", "E2"], channel="B", get_keys=True)
+        self.assertEqual(result, ["RecordB0", "RecordB1", "RecordB2"])
+
+    def test_uses_selected_channel_when_none(self):
+        result = self.ds.get_data_for_epochs(["E1"], channel=None, get_keys=True)
+        self.assertEqual(result, ["RecordA1"])
+
+    def test_preserves_epoch_order(self):
+        result = self.ds.get_data_for_epochs(["E2", "E0", "E1"], channel="A", get_keys=True)
+        self.assertEqual(result, ["RecordA2", "RecordA0", "RecordA1"])
+
+    def test_skips_missing_epoch_silently(self):
+        result = self.ds.get_data_for_epochs(["E0", "E99", "E2"], channel="A", get_keys=True)
+        self.assertEqual(result, ["RecordA0", "RecordA2"])
+
+    def test_empty_list_returns_empty(self):
+        result = self.ds.get_data_for_epochs([], channel="A")
+        self.assertEqual(result, [])
+
+    def test_invalid_channel_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            self.ds.get_data_for_epochs(["E0"], channel="Z")
+
+    def test_rejects_non_list_epoch_names(self):
+        with self.assertRaises(TypeError):
+            self.ds.get_data_for_epochs("E0", channel="A")
+
+    def test_set_and_group_intersection(self):
+        """Combined set + group selection → get_data_for_epochs."""
+        from pyneuromatic.core.nm_epoch import NMEpochContainer
+        self.ds.epochs.sets.add("evens", ["E0", "E2"])
+        self.ds.epochs.groups.assign_cyclic(["E0", "E1", "E2"], n_groups=2)
+        # group 0 → E0, E2; evens → E0, E2; intersection → {E0, E2}
+        set_items = set(self.ds.epochs.sets.get("evens", get_keys=True))
+        group_items = set(self.ds.epochs.groups.get_items(0))
+        epoch_names = sorted(set_items & group_items)
+        result = self.ds.get_data_for_epochs(epoch_names, channel="A", get_keys=True)
+        self.assertEqual(set(result), {"RecordA0", "RecordA2"})
+
+
 class TestNMDataSeriesBulkDimensions(unittest.TestCase):
     """Tests for bulk dimension setting methods."""
 


### PR DESCRIPTION
## Summary
- Adds `get_data_for_epochs(epoch_names, channel, get_keys)` to `NMDataSeries`
- Returns `NMData` objects (or names) for a list of epoch names and a channel,
  preserving epoch order and silently skipping epochs with no data at that channel
- Raises `KeyError` if an explicit channel name does not exist
- Enables set + group intersection workflows:
  ```python
  epoch_names = (
      set(dataseries.epochs.sets.get("set1", get_keys=True))
      & set(dataseries.epochs.groups.get_items(0))
  )
  data = dataseries.get_data_for_epochs(list(epoch_names), channel="A")
```
## Test plan

-  python3 -m pytest tests/test_core/test_nm_dataseries.py -v -k "GetDataForEpochs"
-  python3 -m pytest tests/ -x -q