### PR TITLE
refactor(sets): replace MutableMapping base class with plain class (#163)

### DIFF
--- a/pyneuromatic/core/nm_group.py
+++ b/pyneuromatic/core/nm_group.py
@@ -44,7 +44,7 @@ class NMGroups:
 
     Combined set+group selection (AND) is a plain Python set intersection::
 
-        set_items   = dataseries.epochs.sets.get("set1", get_keys=True)
+        set_items   = dataseries.epochs.sets.get_items("set1", get_keys=True)
         group_items = dataseries.epochs.groups.get_items(0)
         selected    = set(set_items) & set(group_items)
     """

--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -989,7 +989,7 @@ class NMObjectContainer(NMObject, MutableMapping):
             key = self.sets._getkey(self.__run_target_name)
             if key is None:
                 return []
-            s = self.sets.get(key)
+            s = self.sets.get_items(key)
             if s is None:
                 return []
             return list(s)  # s is already a list[NMObject] from NMSets.get()
@@ -1114,7 +1114,7 @@ class NMObjectContainer(NMObject, MutableMapping):
             if target.lower() == self.__run_target_name.lower():
                 return True
             # Check if target is in the set
-            s = self.sets.get(self.__run_target_name)
+            s = self.sets.get_items(self.__run_target_name)
             if s is not None:
                 return target in s
         return False

--- a/pyneuromatic/core/nm_sets.py
+++ b/pyneuromatic/core/nm_sets.py
@@ -20,7 +20,6 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 import copy
-from collections.abc import MutableMapping
 from typing import Callable, Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -35,7 +34,7 @@ import pyneuromatic.core.nm_utilities as nmu
 EQUATION_OPERATORS = ("and", "or")
 
 
-class NMSets(MutableMapping):
+class NMSets:
     """Named groups of items within a container, with AND/OR set algebra.
 
     Internally stores string keys (NMObject names), resolving to NMObject
@@ -106,10 +105,8 @@ class NMSets(MutableMapping):
         result._resolve_fxn = result._nmobjects_default
         return result
 
-    # MutableMapping abstract methods
-
     def __getitem__(self, key: str) -> Any:
-        return self.get(key)
+        return self.get_items(key)
 
     def __setitem__(
         self,
@@ -127,14 +124,26 @@ class NMSets(MutableMapping):
     def __len__(self):
         return len(self._map)
 
-    # MutableMapping mixin overrides
+    def keys(self):
+        return list(self._map.keys())
+
+    def values(self):
+        return list(self._map.values())
+
+    def items(self):
+        return list(self._map.items())
+
+    def update(self, mapping: dict) -> None:
+        """Add/replace sets from a dict of {set_name: item_list}."""
+        for key, value in mapping.items():
+            self.__setitem__(key, value)
 
     def __contains__(self, key: object) -> bool:
         if not isinstance(key, str):
             return False
         return self._getkey(key) is not None
 
-    def get(
+    def get_items(
         self,
         key: str,
         default=None,
@@ -153,8 +162,8 @@ class NMSets(MutableMapping):
 
             assert isinstance(value, tuple)
             operator, set1_key, set2_key = value
-            set1_items = self.get(set1_key, get_keys=True)
-            set2_items = self.get(set2_key, get_keys=True)
+            set1_items = self.get_items(set1_key, get_keys=True)
+            set2_items = self.get_items(set2_key, get_keys=True)
             if not isinstance(set1_items, list) or not isinstance(set2_items, list):
                 return []
 
@@ -194,7 +203,7 @@ class NMSets(MutableMapping):
         for s_key in s_keys:
             s_value = self._map[s_key]
             if NMSets.tuple_is_equation(s_value):
-                o_eq = other.get(s_key, get_equation=True)
+                o_eq = other.get_items(s_key, get_equation=True)
                 if not NMSets.tuple_is_equation(o_eq):
                     return False
                 assert isinstance(s_value, tuple) and isinstance(o_eq, tuple)
@@ -205,7 +214,7 @@ class NMSets(MutableMapping):
                 if s_value[2].lower() != o_eq[2].lower():
                     return False
             else:
-                o_keys = other.get(s_key, get_keys=True)
+                o_keys = other.get_items(s_key, get_keys=True)
                 if not isinstance(o_keys, list):
                     return False
                 assert isinstance(s_value, list)
@@ -219,16 +228,6 @@ class NMSets(MutableMapping):
         nmh.history("removed set '%s'" % key, path=self.path_str, quiet=quiet)
         return value
 
-    def popitem(self) -> tuple[str, Any] | None:
-        if len(self._map) == 0:
-            return None
-        klist = list(self._map.keys())
-        key = klist[-1]
-        value = self.pop(key=key)
-        if value is not None:
-            return (key, value)
-        return None
-
     def clear(self, quiet: bool = nmc.QUIET) -> None:
         if len(self._map) == 0:
             return
@@ -237,15 +236,6 @@ class NMSets(MutableMapping):
         nmh.history(
             "cleared all sets: %s" % names, path=self.path_str, quiet=quiet
         )
-
-    def setdefault(self, key, default=None):
-        k = self._getkey(key)
-        if k is None:
-            if default is None:
-                return None
-            self.__setitem__(key, default)
-            return default
-        return self.get(key)
 
     # Key lookup helpers
 
@@ -520,7 +510,7 @@ class NMSets(MutableMapping):
             items = [self._to_key(o) for o in olist]
         else:
             return False
-        klist = self.get(key, get_keys=True)
+        klist = self.get_items(key, get_keys=True)
         if not isinstance(klist, list):
             return False
         for item_key in items:

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -689,7 +689,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
             set_name_success="Successes",
             save_to_numpy=False,
         )
-        set_epochs = self.ds.epochs.sets.get("Successes")
+        set_epochs = self.ds.epochs.sets.get_items("Successes")
         self.assertIsNotNone(set_epochs)
 
     def test_set_name_success_contains_correct_epochs(self):
@@ -700,7 +700,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
             set_name_success="Pass",
             save_to_numpy=False,
         )
-        set_epochs = self.ds.epochs.sets.get("Pass")
+        set_epochs = self.ds.epochs.sets.get_items("Pass")
         epoch_names = [ep.name for ep in set_epochs]
         self.assertIn("E3", epoch_names)
         self.assertIn("E4", epoch_names)
@@ -714,7 +714,7 @@ class TestNMToolStats2Inequality(unittest.TestCase):
             set_name_failure="Fail",
             save_to_numpy=False,
         )
-        set_epochs = self.ds.epochs.sets.get("Fail")
+        set_epochs = self.ds.epochs.sets.get_items("Fail")
         epoch_names = [ep.name for ep in set_epochs]
         self.assertIn("E0", epoch_names)
         self.assertIn("E1", epoch_names)
@@ -1105,7 +1105,7 @@ class TestNMToolStats2StabilityTest(unittest.TestCase):
             self.tf, "ST_w0_flat_y", min_window=5,
             dataseries=self.ds, set_name_stable="Stable",
         )
-        self.assertIsNotNone(self.ds.epochs.sets.get("Stable"))
+        self.assertIsNotNone(self.ds.epochs.sets.get_items("Stable"))
 
     def test_set_name_stable_contains_correct_epochs(self):
         # Flat array → all 20 epochs should be in the stable set
@@ -1113,7 +1113,7 @@ class TestNMToolStats2StabilityTest(unittest.TestCase):
             self.tf, "ST_w0_flat_y", min_window=5,
             dataseries=self.ds, set_name_stable="Stable",
         )
-        epoch_names = [ep.name for ep in self.ds.epochs.sets.get("Stable")]
+        epoch_names = [ep.name for ep in self.ds.epochs.sets.get_items("Stable")]
         self.assertIn("E0", epoch_names)
         self.assertIn("E19", epoch_names)
 
@@ -1144,13 +1144,13 @@ class TestNMToolStats2AddEpochSetsFromMask(unittest.TestCase):
         nms.NMToolStats2._add_epoch_sets_from_mask(
             self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_true="Pass"
         )
-        self.assertIsNotNone(self.ds.epochs.sets.get("Pass"))
+        self.assertIsNotNone(self.ds.epochs.sets.get_items("Pass"))
 
     def test_true_set_contains_correct_epochs(self):
         nms.NMToolStats2._add_epoch_sets_from_mask(
             self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_true="Pass"
         )
-        epoch_names = [ep.name for ep in self.ds.epochs.sets.get("Pass")]
+        epoch_names = [ep.name for ep in self.ds.epochs.sets.get_items("Pass")]
         self.assertIn("E0", epoch_names)
         self.assertIn("E1", epoch_names)
         self.assertIn("E4", epoch_names)
@@ -1161,13 +1161,13 @@ class TestNMToolStats2AddEpochSetsFromMask(unittest.TestCase):
         nms.NMToolStats2._add_epoch_sets_from_mask(
             self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_false="Fail"
         )
-        self.assertIsNotNone(self.ds.epochs.sets.get("Fail"))
+        self.assertIsNotNone(self.ds.epochs.sets.get_items("Fail"))
 
     def test_false_set_contains_correct_epochs(self):
         nms.NMToolStats2._add_epoch_sets_from_mask(
             self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_false="Fail"
         )
-        epoch_names = [ep.name for ep in self.ds.epochs.sets.get("Fail")]
+        epoch_names = [ep.name for ep in self.ds.epochs.sets.get_items("Fail")]
         self.assertIn("E2", epoch_names)
         self.assertIn("E3", epoch_names)
         self.assertNotIn("E0", epoch_names)
@@ -1177,21 +1177,21 @@ class TestNMToolStats2AddEpochSetsFromMask(unittest.TestCase):
             self.tf, "ST_w0_mean_y", self.ds, self.mask,
             set_name_true="Pass", set_name_false="Fail",
         )
-        self.assertIsNotNone(self.ds.epochs.sets.get("Pass"))
-        self.assertIsNotNone(self.ds.epochs.sets.get("Fail"))
+        self.assertIsNotNone(self.ds.epochs.sets.get_items("Pass"))
+        self.assertIsNotNone(self.ds.epochs.sets.get_items("Fail"))
 
     def test_no_true_set_when_name_is_none(self):
         nms.NMToolStats2._add_epoch_sets_from_mask(
             self.tf, "ST_w0_mean_y", self.ds, self.mask, set_name_true=None
         )
-        self.assertIsNone(self.ds.epochs.sets.get("Pass"))
+        self.assertIsNone(self.ds.epochs.sets.get_items("Pass"))
 
     def test_all_false_mask_skips_true_set(self):
         all_false = np.zeros(5, dtype=bool)
         nms.NMToolStats2._add_epoch_sets_from_mask(
             self.tf, "ST_w0_mean_y", self.ds, all_false, set_name_true="Pass"
         )
-        self.assertIsNone(self.ds.epochs.sets.get("Pass"))
+        self.assertIsNone(self.ds.epochs.sets.get_items("Pass"))
 
     def test_missing_data_array_does_not_raise(self):
         # No ST_w0_data → should return silently

--- a/tests/test_core/test_nm_dataseries.py
+++ b/tests/test_core/test_nm_dataseries.py
@@ -223,7 +223,7 @@ class TestNMDataSeriesGetDataForEpochs(unittest.TestCase):
         self.ds.epochs.sets.add("evens", ["E0", "E2"])
         self.ds.epochs.groups.assign_cyclic(["E0", "E1", "E2"], n_groups=2)
         # group 0 → E0, E2; evens → E0, E2; intersection → {E0, E2}
-        set_items = set(self.ds.epochs.sets.get("evens", get_keys=True))
+        set_items = set(self.ds.epochs.sets.get_items("evens", get_keys=True))
         group_items = set(self.ds.epochs.groups.get_items(0))
         epoch_names = sorted(set_items & group_items)
         result = self.ds.get_data_for_epochs(epoch_names, channel="A", get_keys=True)
@@ -567,7 +567,7 @@ class TestNMDataSeriesSets(unittest.TestCase):
         self.ds.channels.sets.add("set1", ["C", "D"])
         self.ds.channels.sets.define_or("set2", "set0", "set1")
 
-        result = self.ds.channels.sets.get("set2", get_keys=True)
+        result = self.ds.channels.sets.get_items("set2", get_keys=True)
         self.assertEqual(set(result), {"A", "B", "C", "D"})
 
     def test_epoch_sets(self):
@@ -578,10 +578,10 @@ class TestNMDataSeriesSets(unittest.TestCase):
         for i in range(1, 10, 2):
             self.ds.epochs.sets.add("odd", f"E{i}")
 
-        even_result = self.ds.epochs.sets.get("even", get_keys=True)
+        even_result = self.ds.epochs.sets.get_items("even", get_keys=True)
         self.assertEqual(len(even_result), 5)
 
-        odd_result = self.ds.epochs.sets.get("odd", get_keys=True)
+        odd_result = self.ds.epochs.sets.get_items("odd", get_keys=True)
         self.assertEqual(len(odd_result), 5)
 
 

--- a/tests/test_core/test_nm_folder.py
+++ b/tests/test_core/test_nm_folder.py
@@ -65,7 +65,7 @@ class TestNMFolderInit(NMFolderTestBase):
         self.folder.data.sets.add("odd", ["data1", "data3"])
         self.folder.data.sets.define_or("all", "even", "odd")
 
-        result = self.folder.data.sets.get("all", get_keys=True)
+        result = self.folder.data.sets.get_items("all", get_keys=True)
         self.assertEqual(sorted(result), ["data0", "data1", "data2", "data3"])
 
 

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -773,7 +773,7 @@ class TestNMObjectContainerRenameUpdatesSets(NMObjectContainerTestBase):
         self.map0.sets.add("myset", [ONLIST0[0], ONLIST0[1]])
         self.map0.pop(ONLIST0[3])
         self.map0.rename(ONLIST0[0], ONLIST0[3])
-        keys = self.map0.sets.get("myset", get_keys=True)
+        keys = self.map0.sets.get_items("myset", get_keys=True)
         self.assertIn(ONLIST0[3], keys)
         self.assertNotIn(ONLIST0[0], keys)
         self.assertIn(ONLIST0[1], keys)

--- a/tests/test_core/test_nm_project.py
+++ b/tests/test_core/test_nm_project.py
@@ -70,8 +70,8 @@ class NMProjectTest(unittest.TestCase):
         self.assertEqual(folders.selected_name, FNLIST0[-1])
 
         self.assertEqual(len(folders.sets), len(FSETS_NLIST0))
-        self.assertEqual(folders.sets.get(FSETS_NLIST0[2]), self.folist0)
-        self.assertEqual(folders.sets.get(FSETS_NLIST0[2], get_keys=True), FNLIST0)
+        self.assertEqual(folders.sets.get_items(FSETS_NLIST0[2]), self.folist0)
+        self.assertEqual(folders.sets.get_items(FSETS_NLIST0[2], get_keys=True), FNLIST0)
 
         folders = self.project1.folders
         self.assertTrue(isinstance(folders, NMFolderContainer))
@@ -80,8 +80,8 @@ class NMProjectTest(unittest.TestCase):
         self.assertEqual(folders.selected_name, FNLIST1[-1])
 
         self.assertEqual(len(folders.sets), len(FSETS_NLIST1))
-        self.assertEqual(folders.sets.get(FSETS_NLIST1[2]), self.folist1)
-        self.assertEqual(folders.sets.get(FSETS_NLIST1[2], get_keys=True), FNLIST1)
+        self.assertEqual(folders.sets.get_items(FSETS_NLIST1[2]), self.folist1)
+        self.assertEqual(folders.sets.get_items(FSETS_NLIST1[2], get_keys=True), FNLIST1)
 
     def test01_eq(self):
         # args: other
@@ -120,7 +120,7 @@ class NMProjectTest(unittest.TestCase):
         # self.assertFalse(self.project0 == project0)
 
         for s in self.project0.folders.sets.keys():
-            olist = self.project0.folders.sets.get(s, get_equation=True, get_keys=True)
+            olist = self.project0.folders.sets.get_items(s, get_equation=True, get_keys=True)
             project0.folders.sets.add(s, olist)
 
         self.assertTrue(self.project0 == project0)

--- a/tests/test_core/test_nm_sets.py
+++ b/tests/test_core/test_nm_sets.py
@@ -70,35 +70,35 @@ class TestNMSetsBasicOperations(NMSetsTestBase):
 
     def test_add_single_item(self):
         self.sets.add("set0", "obj0")
-        self.assertIn("obj0", self.sets.get("set0", get_keys=True))
+        self.assertIn("obj0", self.sets.get_items("set0", get_keys=True))
 
     def test_add_multiple_items(self):
         self.sets.add("set0", ["obj0", "obj1", "obj2"])
-        keys = self.sets.get("set0", get_keys=True)
+        keys = self.sets.get_items("set0", get_keys=True)
         self.assertIn("obj0", keys)
         self.assertIn("obj1", keys)
         self.assertIn("obj2", keys)
 
     def test_add_nmobject_directly(self):
         self.sets.add("set0", self.objects["obj0"])
-        self.assertIn(self.objects["obj0"], self.sets.get("set0"))
+        self.assertIn(self.objects["obj0"], self.sets.get_items("set0"))
 
     def test_get_returns_nmobjects(self):
         self.sets.add("set0", ["obj0", "obj1"])
-        result = self.sets.get("set0")
+        result = self.sets.get_items("set0")
         self.assertIsInstance(result, list)
         self.assertTrue(all(isinstance(o, NMObject) for o in result))
 
     def test_get_keys_returns_strings(self):
         self.sets.add("set0", ["obj0", "obj1"])
-        result = self.sets.get("set0", get_keys=True)
+        result = self.sets.get_items("set0", get_keys=True)
         self.assertIsInstance(result, list)
         self.assertTrue(all(isinstance(k, str) for k in result))
 
     def test_get_nonexistent_returns_default(self):
-        result = self.sets.get("nonexistent")
+        result = self.sets.get_items("nonexistent")
         self.assertIsNone(result)
-        result = self.sets.get("nonexistent", default="default")
+        result = self.sets.get_items("nonexistent", default="default")
         self.assertEqual(result, "default")
 
     def test_contains(self):
@@ -135,23 +135,6 @@ class TestNMSetsBasicOperations(NMSetsTestBase):
         self.assertIsInstance(result, tuple)
         self.assertEqual(result[0], "and")
 
-    def test_popitem(self):
-        self.sets.add("set0", ["obj0"])
-        self.sets.add("set1", ["obj1"])
-        key, value = self.sets.popitem()
-        self.assertEqual(key, "set1")  # Last item
-        self.assertFalse("set1" in self.sets)
-
-    def test_popitem_equation(self):
-        self.sets.add("setA", ["obj0", "obj1"])
-        self.sets.add("setB", ["obj1", "obj2"])
-        self.sets.define_and("setC", "setA", "setB")
-        key, value = self.sets.popitem()
-        self.assertEqual(key, "setC")  # Last item
-        # Should return the equation tuple
-        self.assertIsInstance(value, tuple)
-        self.assertEqual(value[0], "and")
-
     def test_clear(self):
         self.sets.add("set0", [])
         self.sets.add("set1", [])
@@ -162,7 +145,7 @@ class TestNMSetsBasicOperations(NMSetsTestBase):
         self.sets.add("Set0", ["obj0"])
         self.assertTrue("set0" in self.sets)
         self.assertTrue("SET0" in self.sets)
-        result = self.sets.get("SET0", get_keys=True)
+        result = self.sets.get_items("SET0", get_keys=True)
         self.assertIn("obj0", result)
 
 
@@ -177,36 +160,36 @@ class TestNMSetsEquations(NMSetsTestBase):
 
     def test_define_and(self):
         self.sets.define_and("setC", "setA", "setB")
-        result = self.sets.get("setC", get_keys=True)
+        result = self.sets.get_items("setC", get_keys=True)
         # AND should give intersection: obj2, obj3
         self.assertEqual(set(result), {"obj2", "obj3"})
 
     def test_define_or(self):
         self.sets.define_or("setC", "setA", "setB")
-        result = self.sets.get("setC", get_keys=True)
+        result = self.sets.get_items("setC", get_keys=True)
         # OR should give union: obj0, obj1, obj2, obj3, obj4, obj5
         self.assertEqual(set(result), {"obj0", "obj1", "obj2", "obj3", "obj4", "obj5"})
 
     def test_equation_via_setitem(self):
         self.sets["setC"] = ("and", "setA", "setB")
-        result = self.sets.get("setC", get_keys=True)
+        result = self.sets.get_items("setC", get_keys=True)
         self.assertEqual(set(result), {"obj2", "obj3"})
 
     def test_equation_get_equation(self):
         self.sets.define_and("setC", "setA", "setB")
-        eq = self.sets.get("setC", get_equation=True)
+        eq = self.sets.get_items("setC", get_equation=True)
         self.assertIsInstance(eq, tuple)
         self.assertEqual(eq[0], "and")
 
     def test_equation_dynamic_evaluation(self):
         # Define equation first
         self.sets.define_and("setC", "setA", "setB")
-        result1 = set(self.sets.get("setC", get_keys=True))
+        result1 = set(self.sets.get_items("setC", get_keys=True))
         self.assertEqual(result1, {"obj2", "obj3"})
 
         # Modify source set
         self.sets.add("setA", "obj4")
-        result2 = set(self.sets.get("setC", get_keys=True))
+        result2 = set(self.sets.get_items("setC", get_keys=True))
         # Now intersection should include obj4
         self.assertEqual(result2, {"obj2", "obj3", "obj4"})
 
@@ -306,7 +289,7 @@ class TestNMSetsCopy(NMSetsTestBase):
 
         # Check equation is preserved
         self.assertTrue(sets_copy.is_equation("setC"))
-        eq = sets_copy.get("setC", get_equation=True)
+        eq = sets_copy.get_items("setC", get_equation=True)
         self.assertEqual(eq, ("and", "setA", "setB"))
 
 
@@ -317,7 +300,7 @@ class TestNMSetsRemove(NMSetsTestBase):
         self.sets.add("set0", ["obj0", "obj1", "obj2"])
         removed = self.sets.remove("set0", "obj1")
         self.assertEqual(len(removed), 1)
-        self.assertNotIn("obj1", self.sets.get("set0", get_keys=True))
+        self.assertNotIn("obj1", self.sets.get_items("set0", get_keys=True))
 
     def test_remove_by_object(self):
         self.sets.add("set0", ["obj0", "obj1", "obj2"])
@@ -338,8 +321,8 @@ class TestNMSetsRemove(NMSetsTestBase):
         self.sets.add("set0", ["obj0", "obj1"])
         self.sets.add("set1", ["obj0", "obj2"])
         self.sets.remove_from_all("obj0")
-        self.assertNotIn("obj0", self.sets.get("set0", get_keys=True))
-        self.assertNotIn("obj0", self.sets.get("set1", get_keys=True))
+        self.assertNotIn("obj0", self.sets.get_items("set0", get_keys=True))
+        self.assertNotIn("obj0", self.sets.get_items("set1", get_keys=True))
 
 
 class TestNMSetsRenameItem(NMSetsTestBase):
@@ -350,7 +333,7 @@ class TestNMSetsRenameItem(NMSetsTestBase):
         self.objects["obj_new"] = self.objects.pop("obj0")
         self.objects["obj_new"]._name_set(newname="obj_new", quiet=True)
         self.sets.rename_item("obj0", "obj_new")
-        keys = self.sets.get("set0", get_keys=True)
+        keys = self.sets.get_items("set0", get_keys=True)
         self.assertNotIn("obj0", keys)
         self.assertIn("obj_new", keys)
 
@@ -360,14 +343,14 @@ class TestNMSetsRenameItem(NMSetsTestBase):
         self.objects["obj_new"] = self.objects.pop("obj0")
         self.objects["obj_new"]._name_set(newname="obj_new", quiet=True)
         self.sets.rename_item("obj0", "obj_new")
-        self.assertIn("obj_new", self.sets.get("set0", get_keys=True))
-        self.assertIn("obj_new", self.sets.get("set1", get_keys=True))
+        self.assertIn("obj_new", self.sets.get_items("set0", get_keys=True))
+        self.assertIn("obj_new", self.sets.get_items("set1", get_keys=True))
 
     def test_rename_item_not_in_set(self):
         self.sets.add("set0", ["obj1", "obj2"])
         # Renaming obj0 shouldn't affect set0
         self.sets.rename_item("obj0", "obj_new")
-        keys = self.sets.get("set0", get_keys=True)
+        keys = self.sets.get_items("set0", get_keys=True)
         self.assertEqual(keys, ["obj1", "obj2"])
 
 
@@ -391,8 +374,8 @@ class TestNMSetsNew(NMSetsTestBase):
         key, olist = self.sets.duplicate("set0", "set0_copy")
         self.assertEqual(key, "set0_copy")
         self.assertEqual(
-            self.sets.get("set0", get_keys=True),
-            self.sets.get("set0_copy", get_keys=True)
+            self.sets.get_items("set0", get_keys=True),
+            self.sets.get_items("set0_copy", get_keys=True)
         )
 
     def test_duplicate_equation(self):
@@ -404,8 +387,8 @@ class TestNMSetsNew(NMSetsTestBase):
         # Should duplicate the equation, not the evaluated result
         self.assertTrue(self.sets.is_equation("setC_copy"))
         self.assertEqual(
-            self.sets.get("setC", get_equation=True),
-            self.sets.get("setC_copy", get_equation=True)
+            self.sets.get_items("setC", get_equation=True),
+            self.sets.get_items("setC_copy", get_equation=True)
         )
 
 
@@ -424,10 +407,10 @@ class TestNMSetsRename(NMSetsTestBase):
         self.sets.define_and("setC", "setA", "setB")
         self.sets.rename("setA", "setX")
         # Equation should now reference "setX" instead of "setA"
-        eq = self.sets.get("setC", get_equation=True)
+        eq = self.sets.get_items("setC", get_equation=True)
         self.assertEqual(eq, ("and", "setX", "setB"))
         # Equation should still evaluate correctly
-        result = set(self.sets.get("setC", get_keys=True))
+        result = set(self.sets.get_items("setC", get_keys=True))
         self.assertEqual(result, {"obj1"})
 
     def test_rename_updates_equations_second_operand(self):
@@ -435,7 +418,7 @@ class TestNMSetsRename(NMSetsTestBase):
         self.sets.add("setB", ["obj1", "obj2"])
         self.sets.define_or("setC", "setA", "setB")
         self.sets.rename("setB", "setY")
-        eq = self.sets.get("setC", get_equation=True)
+        eq = self.sets.get_items("setC", get_equation=True)
         self.assertEqual(eq, ("or", "setA", "setY"))
 
     def test_reorder(self):
@@ -453,7 +436,7 @@ class TestNMSetsEmpty(NMSetsTestBase):
     def test_empty(self):
         self.sets.add("set0", ["obj0", "obj1"])
         self.sets.empty("set0")
-        self.assertEqual(self.sets.get("set0"), [])
+        self.assertEqual(self.sets.get_items("set0"), [])
 
     def test_empty_equation(self):
         self.sets.add("setA", ["obj0", "obj1"])
@@ -463,23 +446,23 @@ class TestNMSetsEmpty(NMSetsTestBase):
         self.sets.empty("setC")
         # After emptying, it should no longer be an equation
         self.assertFalse(self.sets.is_equation("setC"))
-        self.assertEqual(self.sets.get("setC"), [])
+        self.assertEqual(self.sets.get_items("setC"), [])
 
     def test_empty_all(self):
         self.sets.add("set0", ["obj0"])
         self.sets.add("set1", ["obj1"])
         self.sets.empty_all()
-        self.assertEqual(self.sets.get("set0"), [])
-        self.assertEqual(self.sets.get("set1"), [])
+        self.assertEqual(self.sets.get_items("set0"), [])
+        self.assertEqual(self.sets.get_items("set1"), [])
 
     def test_empty_all_with_equation(self):
         self.sets.add("setA", ["obj0", "obj1"])
         self.sets.add("setB", ["obj1", "obj2"])
         self.sets.define_and("setC", "setA", "setB")
         self.sets.empty_all()
-        self.assertEqual(self.sets.get("setA"), [])
-        self.assertEqual(self.sets.get("setB"), [])
-        self.assertEqual(self.sets.get("setC"), [])
+        self.assertEqual(self.sets.get_items("setA"), [])
+        self.assertEqual(self.sets.get_items("setB"), [])
+        self.assertEqual(self.sets.get_items("setC"), [])
         self.assertFalse(self.sets.is_equation("setC"))
 
 


### PR DESCRIPTION
## Summary
- Remove `MutableMapping` inheritance from `NMSets` — almost all mixin methods were overridden, and the protocol locked the `get()` method name
- Rename `get()` → `get_items()` for consistency with `NMGroups.get_items()`
- Add `keys()`, `values()`, `items()`, `update()` explicitly as plain methods
- Remove unused `popitem()` and `setdefault()` cargo methods
- Update all call sites in production code and tests

## Test plan
- [ ] All 1492 existing tests pass (`python3 -m pytest tests/ -x -q`)
- [ ] No `sets.get(` call sites remain in production code or tests

Closes #163