### PR TITLE
feat(groups): add __getitem__, __setitem__, __delitem__ to NMGroups (#165)

### DIFF
--- a/pyneuromatic/core/nm_group.py
+++ b/pyneuromatic/core/nm_group.py
@@ -82,6 +82,18 @@ class NMGroups:
             return False
         return item_name in self._map
 
+    def __getitem__(self, item_name: str) -> int:
+        result = self.get_group(item_name)
+        if result is None:
+            raise KeyError(item_name)
+        return result
+
+    def __setitem__(self, item_name: str, group: int) -> None:
+        self.assign(item_name, group)
+
+    def __delitem__(self, item_name: str) -> None:
+        self.unassign(item_name)
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, NMGroups):
             return NotImplemented

--- a/tests/test_core/test_nm_group.py
+++ b/tests/test_core/test_nm_group.py
@@ -372,6 +372,40 @@ class TestNMGroupsCollectionProtocol(unittest.TestCase):
 
 
 # =========================================================================
+# NMGroups — dict-like dunder access
+# =========================================================================
+
+class TestNMGroupsDunderAccess(unittest.TestCase):
+
+    def setUp(self):
+        self.g, self.names = _make_groups(n=3)  # E0→0, E1→1, E2→2
+
+    def test_getitem_returns_group(self):
+        self.assertEqual(self.g["E0"], 0)
+        self.assertEqual(self.g["E1"], 1)
+
+    def test_getitem_missing_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            _ = self.g["E99"]
+
+    def test_setitem_assigns(self):
+        self.g["E0"] = 2
+        self.assertEqual(self.g.get_group("E0"), 2)
+
+    def test_setitem_bad_group_raises(self):
+        with self.assertRaises((TypeError, ValueError)):
+            self.g["E0"] = -1
+
+    def test_delitem_unassigns(self):
+        del self.g["E0"]
+        self.assertNotIn("E0", self.g)
+
+    def test_delitem_missing_raises_key_error(self):
+        with self.assertRaises(KeyError):
+            del self.g["E99"]
+
+
+# =========================================================================
 # NMGroups — equality
 # =========================================================================
 


### PR DESCRIPTION
## Summary
- Add dict-like dunder methods to `NMGroups` for consistency with `NMSets`:
  - `groups["E0"]` → group number (raises `KeyError` if unassigned)
  - `groups["E0"] = 2` → assign epoch to group
  - `del groups["E0"]` → unassign epoch from group

## Test plan
- [ ] 6 new tests in `TestNMGroupsDunderAccess` all pass
- [ ] Full test suite passes (`python3 -m pytest tests/ -x -q`)

Closes #165