### PR TITLE
feat(manager): support epoch group run targets via "group{N}" syntax (#167)

### DIFF
--- a/pyneuromatic/core/nm_epoch.py
+++ b/pyneuromatic/core/nm_epoch.py
@@ -203,6 +203,7 @@ class NMEpochContainer(NMObjectContainer):
             auto_name_seq_format=name_seq_format,
         )
         self.__groups = NMGroups(name=name + "Groups", parent=self)
+        self.__run_group: int | None = None  # set when run_target = "group{N}"
 
     # override, no super
     def content_type(self) -> str:
@@ -244,6 +245,41 @@ class NMEpochContainer(NMObjectContainer):
     def groups(self) -> NMGroups:
         """Group assignments for epochs in this container."""
         return self.__groups
+
+    @property
+    def run_target(self) -> str:
+        """Override to return 'group{N}' when an epoch group is active."""
+        if self.__run_group is not None:
+            return "group" + str(self.__run_group)
+        return super().run_target
+
+    @run_target.setter
+    def run_target(self, target: str | None) -> None:
+        """Override to intercept 'group{N}' before passing to parent."""
+        if isinstance(target, str):
+            t = target.lower()
+            if t.startswith("group") and t[5:].isdigit():
+                self.__run_group = int(t[5:])
+                return
+        self.__run_group = None
+        NMObjectContainer.run_target.fset(self, target)  # type: ignore[arg-type]
+
+    @property
+    def run_targets(self) -> list:
+        """Override to resolve epoch group run targets."""
+        if self.__run_group is not None:
+            n = self.__run_group
+            if n not in self.__groups.group_numbers:
+                return []
+            result = []
+            for name in self.__groups.get_items(n):
+                key = self._getkey(name)
+                if key is not None:
+                    obj = self[key]
+                    if obj is not None:
+                        result.append(obj)
+            return result
+        return super().run_targets
 
     # override: also remove from groups when an epoch is popped
     def pop(

--- a/tests/test_core/test_nm_manager.py
+++ b/tests/test_core/test_nm_manager.py
@@ -82,6 +82,8 @@ class NMManagerTestBase(unittest.TestCase):
                         e = ds.epochs.new(select=False)
                 ds.channels.sets.add("set0", ["A", "B"])
                 ds.epochs.sets.add("set0", ["E0", "E1"])
+                epoch_names = list(ds.epochs.keys())
+                ds.epochs.groups.assign_cyclic(epoch_names, n_groups=3, quiet=QUIET)
             self.data_set0 = ["data0", "avg0", "stim0"]
             f.data.sets.add("set0", self.data_set0)
             f.dataseries.sets.add("set0", ["data", "avg"])
@@ -408,6 +410,71 @@ class TestNMManagerRunKeysSet(NMManagerTestBase):
         self.assertEqual(len(elist), 1)
         self.assertEqual(elist[0]["folder"], "folder1")
         self.assertEqual(elist[0]["data"], "data0")
+
+
+class TestNMManagerRunGroupTarget(NMManagerTestBase):
+    """Tests for epoch group run targets in run_keys_set."""
+
+    def test_group0_expands_to_correct_count(self):
+        # folder1 uses DATASERIES[2]="stim", NUMEPOCHS[2]=7, n_groups=3
+        # group0 gets epochs 0,3,6 → 3 epochs
+        e0 = {
+            "folder": "folder1",
+            "dataseries": "stim",
+            "channel": "A",
+            "epoch": "group0",
+        }
+        elist = self.nm.run_keys_set(e0)
+        expected = (NUMEPOCHS[2] + 2) // 3  # ceil(7/3) = 3
+        self.assertEqual(len(elist), expected)
+
+    def test_group1_expands_to_correct_count(self):
+        e0 = {
+            "folder": "folder1",
+            "dataseries": "stim",
+            "channel": "A",
+            "epoch": "group1",
+        }
+        elist = self.nm.run_keys_set(e0)
+        expected = (NUMEPOCHS[2] + 1) // 3  # floor((7+1)/3) = 2 or 3
+        self.assertGreater(len(elist), 0)
+
+    def test_group_target_string_is_preserved_in_run_target(self):
+        p = self.nm.project
+        f = p.folders.get("folder1")
+        ds = f.dataseries.get("stim")
+        ds.epochs.run_target = "group0"
+        self.assertEqual(ds.epochs.run_target, "group0")
+
+    def test_group_uppercase_accepted(self):
+        e0 = {
+            "folder": "folder1",
+            "dataseries": "stim",
+            "channel": "A",
+            "epoch": "GROUP0",
+        }
+        elist = self.nm.run_keys_set(e0)
+        self.assertGreater(len(elist), 0)
+
+    def test_group_all_folders_expands(self):
+        e0 = {
+            "folder": "all",
+            "dataseries": "stim",
+            "channel": "A",
+            "epoch": "group0",
+        }
+        elist = self.nm.run_keys_set(e0)
+        self.assertGreater(len(elist), 0)
+
+    def test_unknown_group_raises(self):
+        e0 = {
+            "folder": "folder1",
+            "dataseries": "stim",
+            "channel": "A",
+            "epoch": "group99",
+        }
+        elist = self.nm.run_keys_set(e0)
+        self.assertEqual(len(elist), 0)  # group 99 doesn't exist → no targets
 
 
 class TestNMManagerRunMaxTargets(NMManagerTestBase):


### PR DESCRIPTION
## Summary
- Add `"group{N}"` as a valid epoch run target in `NMManager.run_keys_set()`,
  e.g. `{"epoch": "group0"}` expands to all epochs assigned to group 0
- Group logic is self-contained in `NMEpochContainer`: private `__run_group`
  attribute, overridden `run_target` getter/setter, and overridden `run_targets`
- `NMObjectContainer` and `RunMode` are unchanged — no base-class leakage
- Add `assign_cyclic()` group setup to `NMManagerTestBase.setUp()`

## Test plan
- [ ] 6 new tests in `TestNMManagerRunGroupTarget` all pass
- [ ] Full test suite passes (`python3 -m pytest tests/ -x -q`)

Closes #167 