### PR TITLE
feat(analysis): implement NMToolMain with Average and Scale operations

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -1,0 +1,293 @@
+# -*- coding: utf-8 -*-
+"""
+NMMainOp — operation classes for NMToolMain.
+
+Provides a base class NMMainOp and concrete subclasses (NMMainOpAverage,
+NMMainOpScale) following the same pattern as nm_transform.py:
+one class per operation, a module-level registry, and a lookup helper.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiology Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from pyneuromatic.core.nm_data import NMData
+from pyneuromatic.core.nm_folder import NMFolder
+import pyneuromatic.core.nm_utilities as nmu
+
+
+# =========================================================================
+# Base class
+# =========================================================================
+
+
+class NMMainOp:
+    """Base class for NMToolMain operations.
+
+    Mirrors the NMTransform pattern: one subclass per operation, a
+    module-level registry, and a ``run_all()`` primary interface.
+
+    The default ``run_all()`` provides a ``run_init → run × N → run_finish``
+    lifecycle suitable for pointwise operations (e.g. Scale).
+    Aggregating operations (e.g. Average) override ``run_all()`` directly
+    to receive the complete data list at once.
+
+    Subclasses should set the class attribute ``name`` to a short lowercase
+    string matching the registry key (e.g. ``"scale"``).
+    """
+
+    name: str = ""
+
+    def run_all(
+        self,
+        data_items: list[tuple[NMData, str | None, str | None]],
+        folder: NMFolder | None,
+    ) -> None:
+        """Process all data items.
+
+        Default implementation calls ``run_init()``, then ``run()`` for each
+        item, then ``run_finish()``.  Aggregating ops (e.g. Average) override
+        this method instead of ``run()``.
+
+        Args:
+            data_items: List of ``(NMData, channel_name, prefix)`` triples.
+                channel_name and prefix may be ``None`` when running in
+                direct-data mode (no dataseries context); ops then fall back
+                to parsing these from the data name.
+            folder: The NMFolder that owns the source data.  Passed to
+                ``run_finish()`` so ops can write output there.
+        """
+        self.run_init()
+        for data, channel_name, prefix in data_items:
+            self.run(data, channel_name)
+        self.run_finish(folder)
+
+    def run_init(self) -> None:
+        """Called once before the per-item loop.  Override to reset state."""
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Called for each data item.  Override for pointwise operations.
+
+        Args:
+            data: The NMData object to process.
+            channel_name: Channel name from the selection context, or None.
+
+        Raises:
+            NotImplementedError: If the subclass does not override this method
+                and does not override ``run_all()``.
+        """
+        raise NotImplementedError(
+            "%s.run() not implemented" % self.__class__.__name__
+        )
+
+    def run_finish(self, folder: NMFolder | None) -> None:
+        """Called once after the per-item loop.  Override to write results."""
+
+
+# =========================================================================
+# Average
+# =========================================================================
+
+
+class NMMainOpAverage(NMMainOp):
+    """Average selected data waves per channel.
+
+    Accumulates arrays by channel across the data_items list, truncates all
+    arrays to the shortest length, and writes the mean as a new NMData wave
+    ``Avg_{prefix}{channel}`` (e.g. ``Avg_RecordA``) into the source folder.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nanmean``; otherwise
+            ``np.mean`` (NaN propagates to the result).
+    """
+
+    name = "average"
+
+    def __init__(self, ignore_nans: bool = True) -> None:
+        if not isinstance(ignore_nans, bool):
+            raise TypeError(
+                nmu.type_error_str(ignore_nans, "ignore_nans", "boolean")
+            )
+        self._ignore_nans = ignore_nans
+        self._results: dict[str, str] = {}  # channel → output name
+
+    @property
+    def ignore_nans(self) -> bool:
+        """If True, NaN values are excluded from the mean (np.nanmean)."""
+        return self._ignore_nans
+
+    @ignore_nans.setter
+    def ignore_nans(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
+        self._ignore_nans = value
+
+    @property
+    def results(self) -> dict[str, str]:
+        """Read-only dict mapping channel name → output NMData name."""
+        return dict(self._results)
+
+    def run_all(
+        self,
+        data_items: list[tuple[NMData, str | None, str | None]],
+        folder: NMFolder | None,
+    ) -> None:
+        """Average all data items per channel and write results to folder.
+
+        Args:
+            data_items: List of ``(NMData, channel_name, prefix)`` triples.
+            folder: Destination NMFolder for the averaged waves.
+        """
+        self._results.clear()
+
+        # Phase 1: accumulate per channel
+        accum: dict[str, list[np.ndarray]] = {}
+        xscales: dict[str, dict] = {}
+        yscales: dict[str, dict] = {}
+        prefix: str | None = None
+
+        for data, channel_name, item_prefix in data_items:
+            if not isinstance(data.nparray, np.ndarray):
+                continue
+
+            # Determine channel
+            if channel_name is None:
+                parsed = nmu.parse_data_name(data.name)
+                channel_name = parsed[1] if parsed is not None else "A"
+
+            # Capture prefix: use dataseries name if provided, else parse from
+            # first wave name (direct-data mode fallback)
+            if prefix is None:
+                if item_prefix is not None:
+                    prefix = item_prefix
+                else:
+                    parsed = nmu.parse_data_name(data.name)
+                    prefix = parsed[0] if parsed is not None else ""
+
+            # First encounter for this channel: record scale metadata
+            if channel_name not in accum:
+                accum[channel_name] = []
+                xscales[channel_name] = data.xscale.to_dict()
+                yscales[channel_name] = data.yscale.to_dict()
+
+            accum[channel_name].append(data.nparray.astype(float).copy())
+
+        if not accum or folder is None:
+            return
+
+        # Phase 2: compute mean and save per channel
+        pfx = prefix if prefix is not None else ""
+        for cname, arrays in accum.items():
+            min_len = min(len(a) for a in arrays)
+            stack = np.stack([a[:min_len] for a in arrays])
+            if self._ignore_nans:
+                avg = np.nanmean(stack, axis=0)
+            else:
+                avg = np.mean(stack, axis=0)
+
+            out_name = "Avg_" + pfx + cname
+            folder.data.new(
+                out_name,
+                nparray=avg,
+                xscale=xscales[cname],
+                yscale=yscales[cname],
+            )
+            self._results[cname] = out_name
+
+
+# =========================================================================
+# Scale
+# =========================================================================
+
+
+class NMMainOpScale(NMMainOp):
+    """Multiply each selected wave by a scalar factor (in-place).
+
+    Parameters:
+        factor: Multiplication factor (default 1.0).  Must be int or float
+            (not bool).
+    """
+
+    name = "scale"
+
+    def __init__(self, factor: float = 1.0) -> None:
+        self.factor = factor  # use setter for validation
+
+    @property
+    def factor(self) -> float:
+        """Multiplication factor applied to each wave."""
+        return self._factor
+
+    @factor.setter
+    def factor(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "factor", "float"))
+        self._factor = float(value)
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Multiply data.nparray by self.factor in-place.
+
+        Args:
+            data: The NMData object to scale.
+            channel_name: Unused; present for API consistency.
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        data.nparray = data.nparray * self._factor
+
+
+# =========================================================================
+# Registry and lookup
+# =========================================================================
+
+
+_OP_REGISTRY: dict[str, type[NMMainOp]] = {
+    "average": NMMainOpAverage,
+    "scale": NMMainOpScale,
+}
+
+
+def op_from_name(name: str) -> NMMainOp:
+    """Instantiate an NMMainOp subclass by name.
+
+    Args:
+        name: Case-insensitive op name (e.g. ``"average"``, ``"scale"``).
+
+    Returns:
+        A new NMMainOp instance with default parameters.
+
+    Raises:
+        TypeError: If name is not a string.
+        ValueError: If name is not in the registry.
+    """
+    if not isinstance(name, str):
+        raise TypeError(nmu.type_error_str(name, "name", "string"))
+    cls = _OP_REGISTRY.get(name.lower())
+    if cls is None:
+        raise ValueError(
+            "unknown op: '%s'; valid ops: %s" % (name, sorted(_OP_REGISTRY))
+        )
+    return cls()

--- a/pyneuromatic/analysis/nm_tool.py
+++ b/pyneuromatic/analysis/nm_tool.py
@@ -28,7 +28,7 @@ from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_dataseries import NMDataSeries
 from pyneuromatic.core.nm_channel import NMChannel
 from pyneuromatic.core.nm_epoch import NMEpoch
-from pyneuromatic.core.nm_manager import SELECT_LEVELS
+from pyneuromatic.core.nm_manager import HIERARCHY_SELECT_KEYS
 from pyneuromatic.analysis.nm_tool_config import NMToolConfig
 
 
@@ -41,7 +41,7 @@ class NMTool:
     specific analysis.
 
     Selection is set by NMManager - tools have read-only access to
-    individual levels (folder, data, dataseries, channel, epoch).
+    individual hierarchy tier select keys (folder, data, dataseries, channel, epoch).
 
     Example:
         class MyTool(NMTool):
@@ -53,7 +53,7 @@ class NMTool:
 
     def __init__(self) -> None:
         self._select: dict[str, NMObject | None] = {
-            level: None for level in SELECT_LEVELS
+            tier: None for tier in HIERARCHY_SELECT_KEYS
         }
         self._run_meta: dict = {}
         self._config: NMToolConfig | None = None
@@ -107,19 +107,19 @@ class NMTool:
         Called by NMManager.run_tool() to set the context for run execution.
 
         Args:
-            values: Dictionary mapping level names to NMObjects.
-                    Keys should be from SELECT_LEVELS.
+            values: Dictionary mapping hierarchy tier select keys to NMObjects.
+                    Keys should be from HIERARCHY_SELECT_KEYS.
         """
-        for level in SELECT_LEVELS:
-            if level in values:
-                self._select[level] = values[level]
+        for tier in HIERARCHY_SELECT_KEYS:
+            if tier in values:
+                self._select[tier] = values[tier]
 
     @property
     def select_keys(self) -> dict[str, str | None]:
         """Get the current selection as a dictionary of names."""
         return {
-            level: (obj.name if isinstance(obj, NMObject) else None)
-            for level, obj in self._select.items()
+            key: (obj.name if isinstance(obj, NMObject) else None)
+            for key, obj in self._select.items()
         }
 
     @property
@@ -143,6 +143,25 @@ class NMTool:
         if "run_keys" in meta:
             meta["run_keys"] = dict(meta["run_keys"])
         return meta
+
+    def _update_run_meta(self, target: dict) -> None:
+        """Update run_meta lists with unique names from a single target dict.
+
+        Called once per target during run_all(). Tracks folder, dataseries,
+        channel, and epoch names (not data).
+
+        Args:
+            target: Selection dict mapping tier names to NMObjects.
+        """
+        for tier, meta_key in (
+            ("folder",     "folders"),
+            ("dataseries", "dataseries"),
+            ("channel",    "channels"),
+            ("epoch",      "epochs"),
+        ):
+            obj = target.get(tier)
+            if isinstance(obj, NMObject) and obj.name not in self._run_meta[meta_key]:
+                self._run_meta[meta_key].append(obj.name)
 
     def run_init(self) -> bool:
         """Called once before run loop. Override in subclass."""
@@ -177,7 +196,7 @@ class NMTool:
         can access it from ``run_init()``, ``run()``, and ``run_finish()``.
 
         Args:
-            targets: List of selection dicts mapping level names to
+            targets: List of selection dicts mapping hierarchy tier keys to
                 NMObjects, as returned by ``NMManager.run_values()``.
             run_keys: Optional run configuration dict as passed to
                 ``NMManager.run_keys_set()`` (e.g.
@@ -200,15 +219,7 @@ class NMTool:
             return False
         for target in targets:
             self.select_values = target
-            for level, meta_key in (
-                ("folder", "folders"),
-                ("dataseries", "dataseries"),
-                ("channel", "channels"),
-                ("epoch", "epochs"),
-            ):
-                obj = target.get(level)
-                if isinstance(obj, NMObject) and obj.name not in self._run_meta[meta_key]:
-                    self._run_meta[meta_key].append(obj.name)
+            self._update_run_meta(target)
             if not self.run():
                 break
         return self.run_finish()

--- a/pyneuromatic/analysis/nm_tool_main.py
+++ b/pyneuromatic/analysis/nm_tool_main.py
@@ -20,16 +20,144 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 
+import datetime
+
+from pyneuromatic.analysis.nm_main_op import NMMainOp, NMMainOpAverage, op_from_name
 from pyneuromatic.analysis.nm_tool import NMTool
+from pyneuromatic.core.nm_data import NMData
+from pyneuromatic.core.nm_folder import NMFolder
+from pyneuromatic.core.nm_object import NMObject
+import pyneuromatic.core.nm_utilities as nmu
 
 
 class NMToolMain(NMTool):
-    """
-    Main NM Tool - always loaded by default.
+    """Main NM Tool — always loaded by default.
 
-    Provides core functionality that is always available regardless
-    of which other tools are enabled in the workspace.
+    Provides core waveform operations (Average, Scale, …) via a pluggable
+    ``op`` property.  Setting ``op`` to a string name (e.g. ``"average"``)
+    looks up and instantiates the corresponding :class:`NMMainOp` subclass
+    from the registry.  Setting it to an :class:`NMMainOp` instance allows
+    full parameter control::
+
+        tool = NMToolMain()
+        tool.op = NMMainOpScale(factor=2.0)
+        nm.run_tool(tool)
+
+    Overrides :meth:`run_all` (rather than the per-item ``run()``) to
+    collect the full data list first, then delegate to
+    ``self.op.run_all(data_items, folder)``.  This lets aggregating ops
+    (Average) receive all data at once while pointwise ops (Scale) use the
+    default per-item loop in :class:`NMMainOp`.
     """
 
     def __init__(self) -> None:
         super().__init__()
+        self._op: NMMainOp = NMMainOpAverage()
+
+    # ------------------------------------------------------------------
+    # op property
+
+    @property
+    def op(self) -> NMMainOp:
+        """Current operation (NMMainOp instance)."""
+        return self._op
+
+    @op.setter
+    def op(self, value: NMMainOp | str) -> None:
+        """Set the current operation.
+
+        Args:
+            value: An :class:`NMMainOp` instance, or a string name looked up
+                in the op registry (e.g. ``"average"``, ``"scale"``).
+
+        Raises:
+            TypeError: If value is neither an NMMainOp nor a string.
+            ValueError: If value is a string not in the registry.
+        """
+        if isinstance(value, str):
+            self._op = op_from_name(value)
+        elif isinstance(value, NMMainOp):
+            self._op = value
+        else:
+            raise TypeError(
+                nmu.type_error_str(value, "op", "NMMainOp or string")
+            )
+
+    # ------------------------------------------------------------------
+    # run_all override
+
+    def run_all(
+        self,
+        targets: list[dict[str, NMObject]],
+        run_keys: dict[str, str] | None = None,
+    ) -> bool:
+        """Run the current op over a list of selection targets.
+
+        Collects ``(NMData, channel_name)`` pairs from all targets, then
+        calls ``self.op.run_all(data_items, folder)``.  Populates
+        ``run_meta`` in the same format as :meth:`NMTool.run_all`.
+
+        Args:
+            targets: List of selection dicts as returned by
+                ``NMManager.run_values()``.
+            run_keys: Optional run configuration dict (recorded in
+                ``run_meta``).
+
+        Returns:
+            True on success.
+        """
+        # 1. Populate run_meta
+        self._run_meta = {
+            "date": datetime.datetime.now().isoformat(" ", "seconds"),
+            "run_keys": dict(run_keys) if run_keys else {},
+            "folders": [],
+            "dataseries": [],
+            "channels": [],
+            "epochs": [],
+        }
+
+        # 2. Collect (data, channel_name, prefix) triples; track meta
+        data_items: list[tuple[NMData, str | None, str | None]] = []
+        folder: NMFolder | None = None
+
+        for target in targets:
+            self.select_values = target
+
+            self._update_run_meta(target)
+
+            d = self._get_current_data()
+            if d is not None:
+                channel_name = (
+                    self.channel.name if self.channel is not None else None
+                )
+                prefix = (
+                    self.dataseries.name if self.dataseries is not None else None
+                )
+                data_items.append((d, channel_name, prefix))
+
+            if folder is None and self.folder is not None:
+                folder = self.folder
+
+        # 3. Delegate to op
+        self._op.run_all(data_items, folder)
+        return True
+
+    # ------------------------------------------------------------------
+    # Helper
+
+    def _get_current_data(self) -> NMData | None:
+        """Return NMData for the current selection.
+
+        Dataseries mode (folder + dataseries + channel + epoch in select):
+        calls ``dataseries.get_data(channel, epoch)``.
+        Direct data mode (folder + data in select): returns ``self.data``.
+        """
+        if (
+            self.dataseries is not None
+            and self.channel is not None
+            and self.epoch is not None
+        ):
+            return self.dataseries.get_data(
+                self.channel.name, self.epoch.name
+            )
+        return self.data

--- a/pyneuromatic/core/nm_manager.py
+++ b/pyneuromatic/core/nm_manager.py
@@ -44,8 +44,8 @@ if TYPE_CHECKING:
 
 nm = None  # holds Manager, accessed via console
 
-# Hierarchy levels for selection (folder down to epoch)
-SELECT_LEVELS = ("folder", "data", "dataseries", "channel", "epoch")
+# Hierarchy tier selection keys (folder down to epoch)
+HIERARCHY_SELECT_KEYS = ("folder", "data", "dataseries", "channel", "epoch")
 
 # Run target constants (consistent with RunMode in NMObjectContainer)
 RUN_SELECTED = "selected"
@@ -242,15 +242,15 @@ class NMManager:
 
     def _iter_select_hierarchy(self):
         """
-        Generator yielding (level_name, container, selected_value) tuples.
+        Generator yielding (tier_name, container, selected_value) tuples.
 
         Traverses the selection hierarchy from folder down to epoch.
         Stops when a required parent container has no selection.
 
         Yields:
-            Tuples of (level_name, container, selected_value) where:
-            - level_name: one of SELECT_LEVELS
-            - container: the NMObjectContainer at this level
+            Tuples of (tier_name, container, selected_value) where:
+            - tier_name: one of HIERARCHY_SELECT_KEYS
+            - container: the NMObjectContainer at this tier
             - selected_value: the currently selected object (or None)
         """
         folders = self.__project.folders
@@ -263,7 +263,7 @@ class NMManager:
         if not isinstance(f, NMFolder):
             return
 
-        # Data and DataSeries are siblings at folder level
+        # Data and DataSeries are siblings at folder tier
         yield ("data", f.data, f.data.selected_value)
 
         ds = f.dataseries.selected_value
@@ -272,25 +272,25 @@ class NMManager:
         if not isinstance(ds, NMDataSeries):
             return
 
-        # Channel and Epoch are siblings at dataseries level
+        # Channel and Epoch are siblings at dataseries tier
         yield ("channel", ds.channels, ds.channels.selected_value)
         yield ("epoch", ds.epochs, ds.epochs.selected_value)
 
     @property
     def select_values(self) -> dict[str, NMObject | None]:
-        """Get the currently selected object at each hierarchy level."""
-        result: dict[str, NMObject | None] = {level: None for level in SELECT_LEVELS}
-        for level, container, value in self._iter_select_hierarchy():
-            result[level] = value
+        """Get the currently selected object at each hierarchy tier."""
+        result: dict[str, NMObject | None] = {tier: None for tier in HIERARCHY_SELECT_KEYS}
+        for tier, container, value in self._iter_select_hierarchy():
+            result[tier] = value
         return result
 
     @property
     def select_keys(self) -> dict[str, str | None]:
-        """Get the names of currently selected objects at each hierarchy level."""
-        result: dict[str, str | None] = {level: None for level in SELECT_LEVELS}
-        for level, container, value in self._iter_select_hierarchy():
+        """Get the names of currently selected objects at each hierarchy tier."""
+        result: dict[str, str | None] = {tier: None for tier in HIERARCHY_SELECT_KEYS}
+        for tier, container, value in self._iter_select_hierarchy():
             if isinstance(value, NMObject):
-                result[level] = value.name
+                result[tier] = value.name
         return result
 
     @select_keys.setter
@@ -299,35 +299,35 @@ class NMManager:
 
     def _select_keys_set(self, select: dict[str, str]) -> None:
         """
-        Set selection at each hierarchy level by name.
+        Set selection at each hierarchy tier by name.
 
         Args:
-            select: Dictionary mapping level names to object names.
-                    Keys must be from SELECT_LEVELS (folder, data, dataseries,
-                    channel, epoch).
+            select: Dictionary mapping tier names to object names.
+                    Keys must be from HIERARCHY_SELECT_KEYS (folder, data,
+                    dataseries, channel, epoch).
 
         Raises:
             TypeError: If select is not a dict or values aren't strings
-            KeyError: If a key is not a valid selection level
+            KeyError: If a key is not a valid selection tier
         """
         if not isinstance(select, dict):
             raise TypeError(nmu.type_error_str(select, "select", "dictionary"))
 
-        for key, value in select.items():
-            if not isinstance(key, str):
-                raise TypeError(nmu.type_error_str(key, "key", "string"))
+        for tier, value in select.items():
+            if not isinstance(tier, str):
+                raise TypeError(nmu.type_error_str(tier, "key", "string"))
 
         # Normalize keys to lowercase for case-insensitive matching
         select = {k.lower(): v for k, v in select.items()}
 
-        for key, value in select.items():
+        for tier, value in select.items():
             if value is not None and not isinstance(value, str):
                 raise TypeError(nmu.type_error_str(value, "value", "string"))
-            if key not in SELECT_LEVELS:
-                raise KeyError(f"'{key}' is not a valid selection level. "
-                               f"Valid levels: {SELECT_LEVELS}")
+            if tier not in HIERARCHY_SELECT_KEYS:
+                raise KeyError(f"'{tier}' is not a valid selection tier. "
+                               f"Valid tiers: {HIERARCHY_SELECT_KEYS}")
 
-        # Traverse hierarchy, setting values as we go so subsequent levels
+        # Traverse hierarchy, setting values as we go so subsequent tiers
         # use the newly selected parent
         folders = self.__project.folders
         if folders is None:
@@ -358,7 +358,7 @@ class NMManager:
         Set selection by object reference, auto-populating parent hierarchy.
 
         Traverses up the parent chain from the given object to set selection
-        at each hierarchy level. Items below the specified level retain their
+        at each hierarchy tier. Items below the specified tier retain their
         current selection within the newly selected parent.
 
         Args:
@@ -497,10 +497,10 @@ class NMManager:
         max_targets: int | None = 1000
     ) -> list[dict[str, str]]:
         """
-        Set run targets at each hierarchy level.
+        Set run targets at each hierarchy tier.
 
         Args:
-            run: Dictionary mapping level names to target values.
+            run: Dictionary mapping tier names to target values.
                     Values can be: "select"/"selected", "all", a specific name,
                     or a set name.
                     Must include "folder" and either "data" or "dataseries".
@@ -513,22 +513,22 @@ class NMManager:
 
         Raises:
             TypeError: If run is not a dict or values aren't strings
-            KeyError: If a key is not a valid selection level
+            KeyError: If a key is not a valid selection tier
             ValueError: If target count exceeds max_targets
         """
         if not isinstance(run, dict):
             raise TypeError(nmu.type_error_str(run, "run", "dictionary"))
 
-        for key, value in run.items():
-            if not isinstance(key, str):
-                raise TypeError(nmu.type_error_str(key, "key", "string"))
+        for tier, value in run.items():
+            if not isinstance(tier, str):
+                raise TypeError(nmu.type_error_str(tier, "key", "string"))
 
         # Normalize keys to lowercase for case-insensitive matching
         run = {k.lower(): v for k, v in run.items()}
 
-        for key, value in run.items():
-            if key not in SELECT_LEVELS:
-                raise KeyError(f"unknown run key '{key}'")
+        for tier, value in run.items():
+            if tier not in HIERARCHY_SELECT_KEYS:
+                raise KeyError(f"unknown selection tier '{tier}'")
             if not isinstance(value, str):
                 raise TypeError(nmu.type_error_str(value, "value", "string"))
 
@@ -571,7 +571,7 @@ class NMManager:
                     f.data.run_target = run["data"]
 
             result = self.run_keys(dataseries_priority=False)
-            self._check_max_targets(result, max_targets)
+            self._run_check_max_targets(result, max_targets)
             self.__run_config = dict(run)
             return result
 
@@ -594,11 +594,11 @@ class NMManager:
                     ds.epochs.run_target = run["epoch"]
 
         result = self.run_keys(dataseries_priority=True)
-        self._check_max_targets(result, max_targets)
+        self._run_check_max_targets(result, max_targets)
         self.__run_config = dict(run)
         return result
 
-    def _check_max_targets(
+    def _run_check_max_targets(
         self,
         result: list,
         max_targets: int | None
@@ -612,7 +612,7 @@ class NMManager:
             )
 
     def run_reset_all(self) -> None:
-        """Reset all run targets to use the selected item at each level."""
+        """Reset all run targets to use the selected item at each tier."""
         p = self.__project
         folders = p.folders
         if folders is None:

--- a/tests/test_analysis/test_nm_tool.py
+++ b/tests/test_analysis/test_nm_tool.py
@@ -7,7 +7,7 @@ acquiring and simulating electrophysiology data.
 """
 import unittest
 
-from pyneuromatic.core.nm_manager import NMManager, SELECT_LEVELS
+from pyneuromatic.core.nm_manager import NMManager, HIERARCHY_SELECT_KEYS
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_folder import NMFolder
 from pyneuromatic.core.nm_data import NMData
@@ -26,12 +26,12 @@ class TestNMToolInit(unittest.TestCase):
     def test_init_creates_select_dict(self):
         tool = NMTool()
         self.assertIsInstance(tool._select, dict)
-        self.assertEqual(set(tool._select.keys()), set(SELECT_LEVELS))
+        self.assertEqual(set(tool._select.keys()), set(HIERARCHY_SELECT_KEYS))
 
     def test_init_all_values_none(self):
         tool = NMTool()
-        for level in SELECT_LEVELS:
-            self.assertIsNone(tool._select[level])
+        for tier in HIERARCHY_SELECT_KEYS:
+            self.assertIsNone(tool._select[tier])
 
 
 class TestNMToolProperties(unittest.TestCase):
@@ -135,9 +135,9 @@ class TestNMToolSelectValues(unittest.TestCase):
         values = self.tool.select_values
         self.assertIsNot(values, self.tool._select)
 
-    def test_select_values_getter_has_all_levels(self):
+    def test_select_values_getter_has_all_tiers(self):
         values = self.tool.select_values
-        self.assertEqual(set(values.keys()), set(SELECT_LEVELS))
+        self.assertEqual(set(values.keys()), set(HIERARCHY_SELECT_KEYS))
 
     def test_select_values_getter_returns_current_values(self):
         self.tool._select["folder"] = self.folder
@@ -206,8 +206,8 @@ class TestNMToolSelectKeys(unittest.TestCase):
 
     def test_select_keys_returns_none_for_empty(self):
         keys = self.tool.select_keys
-        for level in SELECT_LEVELS:
-            self.assertIsNone(keys[level])
+        for tier in HIERARCHY_SELECT_KEYS:
+            self.assertIsNone(keys[tier])
 
     def test_select_keys_returns_names(self):
         self.tool._select["folder"] = self.folder
@@ -220,9 +220,9 @@ class TestNMToolSelectKeys(unittest.TestCase):
         self.assertIsNone(keys["channel"])
         self.assertIsNone(keys["epoch"])
 
-    def test_select_keys_has_all_levels(self):
+    def test_select_keys_has_all_tiers(self):
         keys = self.tool.select_keys
-        self.assertEqual(set(keys.keys()), set(SELECT_LEVELS))
+        self.assertEqual(set(keys.keys()), set(HIERARCHY_SELECT_KEYS))
 
 
 class TestNMToolRunMethods(unittest.TestCase):

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for nm_main_op and NMToolMain.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+"""
+import math
+import unittest
+
+import numpy as np
+
+from pyneuromatic.core.nm_data import NMData
+from pyneuromatic.core.nm_folder import NMFolder
+from pyneuromatic.core.nm_manager import NMManager
+from pyneuromatic.analysis.nm_main_op import (
+    NMMainOp,
+    NMMainOpAverage,
+    NMMainOpScale,
+    op_from_name,
+)
+from pyneuromatic.analysis.nm_tool_main import NMToolMain
+
+NM = NMManager(quiet=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_data(name, values, xstart=0.0, xdelta=1.0):
+    """Return NMData with the given array values."""
+    return NMData(
+        NM,
+        name=name,
+        nparray=np.array(values, dtype=float),
+        xscale={"start": xstart, "delta": xdelta, "label": "Time", "units": "ms"},
+        yscale={"label": "Vm", "units": "mV"},
+    )
+
+
+def _make_folder_with_data(arrays_by_name):
+    """Build NMFolder + direct-data target list from {name: array} dict.
+
+    Returns (folder, targets) where targets is a list of
+    {'folder': folder, 'data': nmdata} dicts.
+    """
+    folder = NMFolder(name="folder0")
+    targets = []
+    for name, arr in arrays_by_name.items():
+        d = folder.data.new(
+            name, nparray=np.array(arr, dtype=float)
+        )
+        targets.append({"folder": folder, "data": d})
+    return folder, targets
+
+
+def _run_op_directly(op, arrays_by_name):
+    """Build folder + data_items, call op.run_all(), return folder."""
+    folder = NMFolder(name="folder0")
+    data_items = []
+    for name, arr in arrays_by_name.items():
+        d = folder.data.new(name, nparray=np.array(arr, dtype=float))
+        data_items.append((d, None, None))   # channel_name, prefix=None → parsed from name
+    op.run_all(data_items, folder)
+    return folder
+
+
+# ===========================================================================
+# TestNMMainOpAverage
+# ===========================================================================
+
+class TestNMMainOpAverage(unittest.TestCase):
+    """Test NMMainOpAverage directly (no NMToolMain machinery)."""
+
+    def setUp(self):
+        self.op = NMMainOpAverage()
+        # Three A-channel waves; expected average = [4, 4, 4]
+        self.arrays = {
+            "RecordA0": [2.0, 2.0, 2.0],
+            "RecordA1": [4.0, 4.0, 4.0],
+            "RecordA2": [6.0, 6.0, 6.0],
+        }
+
+    def _run(self, arrays=None):
+        if arrays is None:
+            arrays = self.arrays
+        return _run_op_directly(self.op, arrays)
+
+    # --- correct values ---
+
+    def test_correct_values(self):
+        folder = self._run()
+        out = folder.data.get("Avg_RecordA")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_almost_equal(out.nparray, [4.0, 4.0, 4.0])
+
+    # --- output naming and results dict ---
+
+    def test_output_in_folder(self):
+        self._run()
+        self.assertIsNotNone(self.op.results)
+        self.assertIn("A", self.op.results)
+
+    def test_output_name_in_results(self):
+        self._run()
+        self.assertEqual(self.op.results["A"], "Avg_RecordA")
+
+    def test_results_populated_after_run(self):
+        self._run()
+        self.assertTrue(len(self.op.results) > 0)
+
+    # --- NaN handling ---
+
+    def test_nanmean_ignores_nan(self):
+        arrays = {
+            "RecordA0": [2.0, math.nan, 2.0],
+            "RecordA1": [4.0, 4.0,      4.0],
+        }
+        folder = self._run(arrays)
+        out = folder.data.get("Avg_RecordA")
+        self.assertIsNotNone(out)
+        # nanmean of [2, nan] and [4, 4] at index 1 = mean([4]) = 4.0
+        self.assertTrue(np.isfinite(out.nparray[1]))
+
+    def test_mean_nan_propagates(self):
+        self.op.ignore_nans = False
+        arrays = {
+            "RecordA0": [2.0, math.nan, 2.0],
+            "RecordA1": [4.0, 4.0,      4.0],
+        }
+        folder = self._run(arrays)
+        out = folder.data.get("Avg_RecordA")
+        self.assertIsNotNone(out)
+        self.assertTrue(math.isnan(out.nparray[1]))
+
+    # --- unequal lengths ---
+
+    def test_unequal_lengths_truncates(self):
+        arrays = {
+            "RecordA0": [1.0, 2.0, 3.0],
+            "RecordA1": [1.0, 2.0],
+        }
+        folder = self._run(arrays)
+        out = folder.data.get("Avg_RecordA")
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out.nparray), 2)
+
+    # --- two channels ---
+
+    def test_two_channels(self):
+        arrays = {
+            "RecordA0": [1.0, 2.0],
+            "RecordA1": [3.0, 4.0],
+            "RecordB0": [5.0, 6.0],
+            "RecordB1": [7.0, 8.0],
+        }
+        folder = self._run(arrays)
+        self.assertIsNotNone(folder.data.get("Avg_RecordA"))
+        self.assertIsNotNone(folder.data.get("Avg_RecordB"))
+
+    # --- state reset ---
+
+    def test_run_all_clears_previous_results(self):
+        self._run()   # Avg_RecordA
+        # Second run with different prefix — results should reflect new output name
+        arrays2 = {"StimulusA0": [10.0], "StimulusA1": [20.0]}
+        _run_op_directly(self.op, arrays2)
+        # Channel is still "A" but prefix changed → output name differs
+        self.assertEqual(self.op.results.get("A"), "Avg_StimulusA")
+
+    # --- ignore_nans property ---
+
+    def test_ignore_nans_default_true(self):
+        self.assertTrue(self.op.ignore_nans)
+
+    def test_ignore_nans_setter(self):
+        self.op.ignore_nans = False
+        self.assertFalse(self.op.ignore_nans)
+
+    def test_ignore_nans_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.ignore_nans = 1
+
+    def test_ignore_nans_rejects_in_init(self):
+        with self.assertRaises(TypeError):
+            NMMainOpAverage(ignore_nans="yes")
+
+    # --- no folder / no data ---
+
+    def test_no_folder_is_graceful(self):
+        # run_all with folder=None → no crash, no results
+        data_items = [(_make_data("RecordA0", [1.0, 2.0]), None, None)]
+        self.op.run_all(data_items, None)
+        self.assertEqual(self.op.results, {})
+
+    def test_data_without_nparray_is_skipped(self):
+        folder = NMFolder(name="folder0")
+        d = folder.data.new("RecordA0")   # no nparray
+        self.op.run_all([(d, None, None)], folder)
+        self.assertEqual(self.op.results, {})
+
+
+# ===========================================================================
+# TestNMMainOpScale
+# ===========================================================================
+
+class TestNMMainOpScale(unittest.TestCase):
+    """Test NMMainOpScale directly."""
+
+    def setUp(self):
+        self.op = NMMainOpScale()
+        self.data = _make_data("RecordA0", [1.0, 2.0, 3.0])
+
+    def _run_single(self, data=None):
+        if data is None:
+            data = self.data
+        self.op.run(data)
+
+    # --- factor property ---
+
+    def test_factor_default(self):
+        self.assertEqual(self.op.factor, 1.0)
+
+    def test_factor_setter(self):
+        self.op.factor = 2.5
+        self.assertEqual(self.op.factor, 2.5)
+
+    def test_factor_accepts_int(self):
+        self.op.factor = 3
+        self.assertEqual(self.op.factor, 3.0)
+        self.assertIsInstance(self.op.factor, float)
+
+    def test_factor_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.factor = True
+
+    def test_factor_rejects_str(self):
+        with self.assertRaises(TypeError):
+            self.op.factor = "2.0"
+
+    # --- scaling values ---
+
+    def test_scale_by_2(self):
+        self.op.factor = 2.0
+        self._run_single()
+        np.testing.assert_array_almost_equal(self.data.nparray, [2.0, 4.0, 6.0])
+
+    def test_scale_by_1_no_change(self):
+        self.op.factor = 1.0
+        self._run_single()
+        np.testing.assert_array_almost_equal(self.data.nparray, [1.0, 2.0, 3.0])
+
+    def test_scale_by_0(self):
+        self.op.factor = 0.0
+        self._run_single()
+        np.testing.assert_array_almost_equal(self.data.nparray, [0.0, 0.0, 0.0])
+
+    def test_scale_by_negative(self):
+        self.op.factor = -1.0
+        self._run_single()
+        np.testing.assert_array_almost_equal(self.data.nparray, [-1.0, -2.0, -3.0])
+
+    def test_scale_modifies_nparray_in_place(self):
+        original_obj = self.data
+        self.op.factor = 2.0
+        self._run_single()
+        # Same NMData object, modified array
+        self.assertIs(self.data, original_obj)
+        self.assertEqual(self.data.nparray[0], 2.0)
+
+    # --- skip if no nparray ---
+
+    def test_data_without_nparray_is_skipped(self):
+        d = NMData(NM, name="RecordA0")   # nparray=None
+        self.op.factor = 2.0
+        self.op.run(d)   # should not raise
+
+
+# ===========================================================================
+# TestOpFromName (registry)
+# ===========================================================================
+
+class TestOpFromName(unittest.TestCase):
+
+    def test_average_by_name(self):
+        op = op_from_name("average")
+        self.assertIsInstance(op, NMMainOpAverage)
+
+    def test_scale_by_name(self):
+        op = op_from_name("scale")
+        self.assertIsInstance(op, NMMainOpScale)
+
+    def test_case_insensitive(self):
+        op = op_from_name("AVERAGE")
+        self.assertIsInstance(op, NMMainOpAverage)
+
+    def test_unknown_name_raises(self):
+        with self.assertRaises(ValueError):
+            op_from_name("badop")
+
+    def test_non_string_raises(self):
+        with self.assertRaises(TypeError):
+            op_from_name(42)
+
+
+# ===========================================================================
+# TestNMToolMain
+# ===========================================================================
+
+class TestNMToolMain(unittest.TestCase):
+    """Test NMToolMain.op property and end-to-end run_all()."""
+
+    def setUp(self):
+        self.tool = NMToolMain()
+
+    # --- op property defaults ---
+
+    def test_op_default_is_average(self):
+        self.assertIsInstance(self.tool.op, NMMainOpAverage)
+
+    # --- op setter ---
+
+    def test_op_setter_accepts_instance(self):
+        self.tool.op = NMMainOpScale()
+        self.assertIsInstance(self.tool.op, NMMainOpScale)
+
+    def test_op_setter_accepts_string_average(self):
+        self.tool.op = "average"
+        self.assertIsInstance(self.tool.op, NMMainOpAverage)
+
+    def test_op_setter_accepts_string_scale(self):
+        self.tool.op = "scale"
+        self.assertIsInstance(self.tool.op, NMMainOpScale)
+
+    def test_op_setter_rejects_unknown_string(self):
+        with self.assertRaises(ValueError):
+            self.tool.op = "normalize"
+
+    def test_op_setter_rejects_bad_type(self):
+        with self.assertRaises(TypeError):
+            self.tool.op = 42
+
+    # --- end-to-end: average ---
+
+    def test_run_all_average_end_to_end(self):
+        folder, targets = _make_folder_with_data({
+            "RecordA0": [2.0, 4.0],
+            "RecordA1": [4.0, 8.0],
+        })
+        self.tool.op = NMMainOpAverage()
+        self.tool.run_all(targets)
+        out = folder.data.get("Avg_RecordA")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_almost_equal(out.nparray, [3.0, 6.0])
+
+    # --- end-to-end: scale ---
+
+    def test_run_all_scale_end_to_end(self):
+        folder, targets = _make_folder_with_data({
+            "RecordA0": [1.0, 2.0, 3.0],
+        })
+        self.tool.op = NMMainOpScale(factor=3.0)
+        self.tool.run_all(targets)
+        d = folder.data.get("RecordA0")
+        np.testing.assert_array_almost_equal(d.nparray, [3.0, 6.0, 9.0])
+
+    # --- run_meta populated ---
+
+    def test_run_meta_populated_after_run(self):
+        _, targets = _make_folder_with_data({"RecordA0": [1.0]})
+        self.tool.run_all(targets)
+        meta = self.tool.run_meta
+        self.assertIn("date", meta)
+        self.assertIn("folders", meta)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -121,9 +121,9 @@ class TestNMToolStats(unittest.TestCase):
     def _setup_folder(self):
         """Create a real NMFolder and wire it into the tool's selection."""
         from pyneuromatic.core.nm_folder import NMFolder
-        from pyneuromatic.analysis.nm_tool import SELECT_LEVELS
+        from pyneuromatic.analysis.nm_tool import HIERARCHY_SELECT_KEYS
         folder = NMFolder(name="TestFolder")
-        self.tool._select = {level: None for level in SELECT_LEVELS}
+        self.tool._select = {tier: None for tier in HIERARCHY_SELECT_KEYS}
         self.tool._select["folder"] = folder
         return folder
 
@@ -299,8 +299,8 @@ class TestNMToolStats(unittest.TestCase):
         self.assertEqual(n, "ST_w0_rt_p_dx")
 
     def test_results_to_numpy_no_folder_returns_none(self):
-        from pyneuromatic.analysis.nm_tool import SELECT_LEVELS
-        self.tool._select = {level: None for level in SELECT_LEVELS}
+        from pyneuromatic.analysis.nm_tool import HIERARCHY_SELECT_KEYS
+        self.tool._select = {tier: None for tier in HIERARCHY_SELECT_KEYS}
         # folder is None — should return None
         result = self.tool._results_to_numpy()
         self.assertIsNone(result)

--- a/tests/test_core/test_nm_manager.py
+++ b/tests/test_core/test_nm_manager.py
@@ -578,7 +578,7 @@ class TestNMManagerSelectValueSet(NMManagerTestBase):
         self.assertEqual(self.nm.select_keys["folder"], "folder1")
         self.assertEqual(self.nm.select_keys["data"], "data5")
 
-    def test_preserves_lower_level_selection(self):
+    def test_preserves_lower_tier_selection(self):
         # First set a specific selection
         self.nm.select_keys = {
             "folder": "folder0",


### PR DESCRIPTION
## Summary
- New `nm_main_op.py`: `NMMainOp` base class + `NMMainOpAverage`, `NMMainOpScale` subclasses + op registry (mirrors `nm_transform.py` pattern)
- `NMToolMain`: `op` property (accepts string name or `NMMainOp` instance); overrides `run_all()` to collect all data before delegating to op, enabling aggregating ops like Average
- Average output wave named `Avg_{dataseries}{channel}` (e.g. `Avg_RecordA`); prefix sourced from `dataseries.name` in dataseries mode, parsed from wave name in direct-data mode
- Factored `NMTool._update_run_meta()` helper to eliminate duplicated meta-tracking loop
- Renamed `SELECT_LEVELS` → `HIERARCHY_SELECT_KEYS` to avoid confusion with Stats `FindLevels`

## Test plan
- [ ] 40 new tests in `test_nm_tool_main.py` covering `NMMainOpAverage`, `NMMainOpScale`, op registry, and `NMToolMain` end-to-end
- [ ] All existing tests pass (`pytest tests/ -q`)

Closes #169 
