### PR TITLE
refactor(analysis): move prefix out of data_items tuple in NMMainOp.run_all()

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -55,8 +55,9 @@ class NMMainOp:
 
     def run_all(
         self,
-        data_items: list[tuple[NMData, str | None, str | None]],
+        data_items: list[tuple[NMData, str | None]],
         folder: NMFolder | None,
+        prefix: str | None = None,
     ) -> None:
         """Process all data items.
 
@@ -65,15 +66,17 @@ class NMMainOp:
         this method instead of ``run()``.
 
         Args:
-            data_items: List of ``(NMData, channel_name, prefix)`` triples.
-                channel_name and prefix may be ``None`` when running in
-                direct-data mode (no dataseries context); ops then fall back
-                to parsing these from the data name.
+            data_items: List of ``(NMData, channel_name)`` pairs.  The
+                channel_name may be ``None`` when running in direct-data mode
+                (no dataseries context).
             folder: The NMFolder that owns the source data.  Passed to
                 ``run_finish()`` so ops can write output there.
+            prefix: Dataseries name to use as the output wave prefix.  If
+                ``None``, ops fall back to parsing the prefix from the data
+                name.
         """
         self.run_init()
-        for data, channel_name, prefix in data_items:
+        for data, channel_name in data_items:
             self.run(data, channel_name)
         self.run_finish(folder)
 
@@ -148,14 +151,17 @@ class NMMainOpAverage(NMMainOp):
 
     def run_all(
         self,
-        data_items: list[tuple[NMData, str | None, str | None]],
+        data_items: list[tuple[NMData, str | None]],
         folder: NMFolder | None,
+        prefix: str | None = None,
     ) -> None:
         """Average all data items per channel and write results to folder.
 
         Args:
-            data_items: List of ``(NMData, channel_name, prefix)`` triples.
+            data_items: List of ``(NMData, channel_name)`` pairs.
             folder: Destination NMFolder for the averaged waves.
+            prefix: Dataseries name used as the output wave prefix.  If
+                ``None``, the prefix is parsed from the first wave name.
         """
         self._results.clear()
 
@@ -163,9 +169,9 @@ class NMMainOpAverage(NMMainOp):
         accum: dict[str, list[np.ndarray]] = {}
         xscales: dict[str, dict] = {}
         yscales: dict[str, dict] = {}
-        prefix: str | None = None
+        resolved_prefix: str | None = prefix  # None → parse from first wave
 
-        for data, channel_name, item_prefix in data_items:
+        for data, channel_name in data_items:
             if not isinstance(data.nparray, np.ndarray):
                 continue
 
@@ -174,14 +180,10 @@ class NMMainOpAverage(NMMainOp):
                 parsed = nmu.parse_data_name(data.name)
                 channel_name = parsed[1] if parsed is not None else "A"
 
-            # Capture prefix: use dataseries name if provided, else parse from
-            # first wave name (direct-data mode fallback)
-            if prefix is None:
-                if item_prefix is not None:
-                    prefix = item_prefix
-                else:
-                    parsed = nmu.parse_data_name(data.name)
-                    prefix = parsed[0] if parsed is not None else ""
+            # Resolve prefix from first wave name if not supplied
+            if resolved_prefix is None:
+                parsed = nmu.parse_data_name(data.name)
+                resolved_prefix = parsed[0] if parsed is not None else ""
 
             # First encounter for this channel: record scale metadata
             if channel_name not in accum:
@@ -195,7 +197,7 @@ class NMMainOpAverage(NMMainOp):
             return
 
         # Phase 2: compute mean and save per channel
-        pfx = prefix if prefix is not None else ""
+        pfx = resolved_prefix if resolved_prefix is not None else ""
         for cname, arrays in accum.items():
             min_len = min(len(a) for a in arrays)
             stack = np.stack([a[:min_len] for a in arrays])

--- a/pyneuromatic/analysis/nm_tool_main.py
+++ b/pyneuromatic/analysis/nm_tool_main.py
@@ -116,48 +116,35 @@ class NMToolMain(NMTool):
             "epochs": [],
         }
 
-        # 2. Collect (data, channel_name, prefix) triples; track meta
-        data_items: list[tuple[NMData, str | None, str | None]] = []
+        # 2. Collect (data, channel_name) pairs; track meta
+        data_items: list[tuple[NMData, str | None]] = []
         folder: NMFolder | None = None
+        prefix: str | None = None
 
         for target in targets:
             self.select_values = target
 
             self._update_run_meta(target)
 
-            d = self._get_current_data()
+            if (self.dataseries is not None
+                    and self.channel is not None
+                    and self.epoch is not None):
+                d = self.dataseries.get_data(self.channel.name, self.epoch.name)
+            else:
+                d = self.data
             if d is not None:
                 channel_name = (
                     self.channel.name if self.channel is not None else None
                 )
-                prefix = (
-                    self.dataseries.name if self.dataseries is not None else None
-                )
-                data_items.append((d, channel_name, prefix))
+                data_items.append((d, channel_name))
 
             if folder is None and self.folder is not None:
                 folder = self.folder
 
+            if prefix is None and self.dataseries is not None:
+                prefix = self.dataseries.name
+
         # 3. Delegate to op
-        self._op.run_all(data_items, folder)
+        self._op.run_all(data_items, folder, prefix=prefix)
         return True
 
-    # ------------------------------------------------------------------
-    # Helper
-
-    def _get_current_data(self) -> NMData | None:
-        """Return NMData for the current selection.
-
-        Dataseries mode (folder + dataseries + channel + epoch in select):
-        calls ``dataseries.get_data(channel, epoch)``.
-        Direct data mode (folder + data in select): returns ``self.data``.
-        """
-        if (
-            self.dataseries is not None
-            and self.channel is not None
-            and self.epoch is not None
-        ):
-            return self.dataseries.get_data(
-                self.channel.name, self.epoch.name
-            )
-        return self.data

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -62,7 +62,7 @@ def _run_op_directly(op, arrays_by_name):
     data_items = []
     for name, arr in arrays_by_name.items():
         d = folder.data.new(name, nparray=np.array(arr, dtype=float))
-        data_items.append((d, None, None))   # channel_name, prefix=None → parsed from name
+        data_items.append((d, None))   # channel_name=None → parsed from name
     op.run_all(data_items, folder)
     return folder
 
@@ -191,14 +191,14 @@ class TestNMMainOpAverage(unittest.TestCase):
 
     def test_no_folder_is_graceful(self):
         # run_all with folder=None → no crash, no results
-        data_items = [(_make_data("RecordA0", [1.0, 2.0]), None, None)]
+        data_items = [(_make_data("RecordA0", [1.0, 2.0]), None)]
         self.op.run_all(data_items, None)
         self.assertEqual(self.op.results, {})
 
     def test_data_without_nparray_is_skipped(self):
         folder = NMFolder(name="folder0")
         d = folder.data.new("RecordA0")   # no nparray
-        self.op.run_all([(d, None, None)], folder)
+        self.op.run_all([(d, None)], folder)
         self.assertEqual(self.op.results, {})
 
 


### PR DESCRIPTION
## Summary
- `prefix` (dataseries name) moved from per-item `data_items` tuple to a separate
  `run_all(data_items, folder, prefix=None)` parameter — consistent with how
  `folder` is already passed separately, since both are run-level context, not
  per-item data
- `data_items` reverted to clean `(NMData, channel_name)` 2-tuples
- `NMToolMain.run_all()` captures `prefix` once from the first dataseries name
  and passes it as a keyword argument
- Inlined `_get_selected_data()` helper into `run_all()` loop (single-use private
  method)

## Test plan
- [ ] All 40 tests in `test_nm_tool_main.py` pass
- [ ] Full test suite passes (`pytest tests/ -q`)

Closes #171 