### PR TITLE
feat(analysis): add Redimension, InsertPoints, DeletePoints ops to NMMainOp (#175)

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -267,12 +267,228 @@ class NMMainOpScale(NMMainOp):
 
 
 # =========================================================================
+# Redimension
+# =========================================================================
+
+
+class NMMainOpRedimension(NMMainOp):
+    """Change the number of points in each selected wave (in-place).
+
+    Truncates when ``n_points`` < current length; pads with ``fill`` when
+    ``n_points`` > current length.  Equivalent to Igor's ``Redimension/N=``.
+
+    Parameters:
+        n_points: New number of points (>= 1).  Default 0 means no change.
+        fill: Value used to pad when extending (default 0.0).
+    """
+
+    name = "redimension"
+
+    def __init__(self, n_points: int = 0, fill: float = 0.0) -> None:
+        self.n_points = n_points  # setters for validation
+        self.fill = fill
+
+    @property
+    def n_points(self) -> int:
+        """New number of points (0 = no change)."""
+        return self._n_points
+
+    @n_points.setter
+    def n_points(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "n_points", "int"))
+        if value < 0:
+            raise ValueError("n_points must be >= 0, got %d" % value)
+        self._n_points = value
+
+    @property
+    def fill(self) -> float:
+        """Pad value used when extending a wave."""
+        return self._fill
+
+    @fill.setter
+    def fill(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "fill", "float"))
+        self._fill = float(value)
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Resize data.nparray to n_points in-place.
+
+        Args:
+            data: The NMData object to resize.
+            channel_name: Unused; present for API consistency.
+        """
+        if not isinstance(data.nparray, np.ndarray) or self._n_points == 0:
+            return
+        arr = data.nparray
+        n = self._n_points
+        if n <= len(arr):
+            data.nparray = arr[:n]
+        else:
+            data.nparray = np.concatenate([arr, np.full(n - len(arr), self._fill)])
+
+
+# =========================================================================
+# Insert points
+# =========================================================================
+
+
+class NMMainOpInsertPoints(NMMainOp):
+    """Insert points into each selected wave at a given index (in-place).
+
+    Points at and after ``index`` are shifted right.  Equivalent to Igor's
+    ``InsertPoints pos, n, wave``.
+
+    Parameters:
+        index: Position at which to insert (0-based, default 0).
+        n_points: Number of points to insert (default 1).
+        fill: Value for the inserted points (default 0.0).
+    """
+
+    name = "insert_points"
+
+    def __init__(self, index: int = 0, n_points: int = 1, fill: float = 0.0) -> None:
+        self.index = index  # setters for validation
+        self.n_points = n_points
+        self.fill = fill
+
+    @property
+    def index(self) -> int:
+        """Insertion position (0-based)."""
+        return self._index
+
+    @index.setter
+    def index(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "index", "int"))
+        if value < 0:
+            raise ValueError("index must be >= 0, got %d" % value)
+        self._index = value
+
+    @property
+    def n_points(self) -> int:
+        """Number of points to insert."""
+        return self._n_points
+
+    @n_points.setter
+    def n_points(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "n_points", "int"))
+        if value < 1:
+            raise ValueError("n_points must be >= 1, got %d" % value)
+        self._n_points = value
+
+    @property
+    def fill(self) -> float:
+        """Value assigned to the inserted points."""
+        return self._fill
+
+    @fill.setter
+    def fill(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "fill", "float"))
+        self._fill = float(value)
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Insert n_points at index in data.nparray in-place.
+
+        Args:
+            data: The NMData object to modify.
+            channel_name: Unused; present for API consistency.
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        data.nparray = np.insert(
+            data.nparray, self._index, np.full(self._n_points, self._fill)
+        )
+
+
+# =========================================================================
+# Delete points
+# =========================================================================
+
+
+class NMMainOpDeletePoints(NMMainOp):
+    """Delete points from each selected wave at a given index (in-place).
+
+    Equivalent to Igor's ``DeletePoints pos, n, wave``.
+
+    Parameters:
+        index: Position of the first point to delete (0-based, default 0).
+        n_points: Number of points to delete (default 1).
+    """
+
+    name = "delete_points"
+
+    def __init__(self, index: int = 0, n_points: int = 1) -> None:
+        self.index = index  # setters for validation
+        self.n_points = n_points
+
+    @property
+    def index(self) -> int:
+        """Position of the first point to delete (0-based)."""
+        return self._index
+
+    @index.setter
+    def index(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "index", "int"))
+        if value < 0:
+            raise ValueError("index must be >= 0, got %d" % value)
+        self._index = value
+
+    @property
+    def n_points(self) -> int:
+        """Number of points to delete."""
+        return self._n_points
+
+    @n_points.setter
+    def n_points(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "n_points", "int"))
+        if value < 1:
+            raise ValueError("n_points must be >= 1, got %d" % value)
+        self._n_points = value
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Delete n_points starting at index from data.nparray in-place.
+
+        Args:
+            data: The NMData object to modify.
+            channel_name: Unused; present for API consistency.
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        if self._index >= len(data.nparray):
+            return  # nothing to delete
+        data.nparray = np.delete(
+            data.nparray, np.arange(self._index, self._index + self._n_points)
+        )
+
+
+# =========================================================================
 # Registry and lookup
 # =========================================================================
 
 
 _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "average": NMMainOpAverage,
+    "delete_points": NMMainOpDeletePoints,
+    "insert_points": NMMainOpInsertPoints,
+    "redimension": NMMainOpRedimension,
     "scale": NMMainOpScale,
 }
 

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -17,6 +17,9 @@ from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.analysis.nm_main_op import (
     NMMainOp,
     NMMainOpAverage,
+    NMMainOpDeletePoints,
+    NMMainOpInsertPoints,
+    NMMainOpRedimension,
     NMMainOpScale,
     op_from_name,
 )
@@ -279,6 +282,216 @@ class TestNMMainOpScale(unittest.TestCase):
 
 
 # ===========================================================================
+# TestNMMainOpRedimension
+# ===========================================================================
+
+class TestNMMainOpRedimension(unittest.TestCase):
+    """Test NMMainOpRedimension directly."""
+
+    def setUp(self):
+        self.op = NMMainOpRedimension()
+        self.data = _make_data("RecordA0", [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def _run(self):
+        self.op.run(self.data)
+
+    # --- truncate ---
+
+    def test_truncate(self):
+        self.op.n_points = 3
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0])
+
+    # --- extend ---
+
+    def test_extend_with_zeros(self):
+        self.op.n_points = 7
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 4.0, 5.0, 0.0, 0.0])
+
+    def test_extend_with_fill(self):
+        self.op.n_points = 7
+        self.op.fill = 9.0
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 4.0, 5.0, 9.0, 9.0])
+
+    # --- edge cases ---
+
+    def test_noop_when_n_points_zero(self):
+        self.op.n_points = 0
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def test_same_length_no_change(self):
+        self.op.n_points = 5
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def test_skips_non_ndarray(self):
+        d = NMData(NM, name="RecordA0")
+        self.op.n_points = 3
+        self.op.run(d)   # should not raise
+
+    # --- validation ---
+
+    def test_n_points_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.n_points = True
+
+    def test_n_points_rejects_float(self):
+        with self.assertRaises(TypeError):
+            self.op.n_points = 3.0
+
+    def test_n_points_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            self.op.n_points = -1
+
+    def test_fill_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.fill = True
+
+    def test_fill_accepts_int(self):
+        self.op.fill = 2
+        self.assertEqual(self.op.fill, 2.0)
+        self.assertIsInstance(self.op.fill, float)
+
+
+# ===========================================================================
+# TestNMMainOpInsertPoints
+# ===========================================================================
+
+class TestNMMainOpInsertPoints(unittest.TestCase):
+    """Test NMMainOpInsertPoints directly."""
+
+    def setUp(self):
+        self.op = NMMainOpInsertPoints()
+        self.data = _make_data("RecordA0", [1.0, 2.0, 3.0])
+
+    def _run(self):
+        self.op.run(self.data)
+
+    # --- insertion ---
+
+    def test_insert_at_start(self):
+        self.op.index = 0
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [0.0, 1.0, 2.0, 3.0])
+
+    def test_insert_at_end(self):
+        self.op.index = 3
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 0.0])
+
+    def test_insert_in_middle(self):
+        self.op.index = 1
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 0.0, 2.0, 3.0])
+
+    def test_insert_multiple(self):
+        self.op.index = 1
+        self.op.n_points = 2
+        self.op.fill = 9.0
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 9.0, 9.0, 2.0, 3.0])
+
+    def test_insert_with_fill(self):
+        self.op.fill = 7.0
+        self._run()
+        self.assertEqual(self.data.nparray[0], 7.0)
+
+    # --- edge cases ---
+
+    def test_skips_non_ndarray(self):
+        d = NMData(NM, name="RecordA0")
+        self.op.run(d)   # should not raise
+
+    # --- validation ---
+
+    def test_index_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.index = True
+
+    def test_index_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            self.op.index = -1
+
+    def test_n_points_rejects_zero(self):
+        with self.assertRaises(ValueError):
+            self.op.n_points = 0
+
+    def test_fill_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.fill = False
+
+
+# ===========================================================================
+# TestNMMainOpDeletePoints
+# ===========================================================================
+
+class TestNMMainOpDeletePoints(unittest.TestCase):
+    """Test NMMainOpDeletePoints directly."""
+
+    def setUp(self):
+        self.op = NMMainOpDeletePoints()
+        self.data = _make_data("RecordA0", [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def _run(self):
+        self.op.run(self.data)
+
+    # --- deletion ---
+
+    def test_delete_at_start(self):
+        self.op.index = 0
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [2.0, 3.0, 4.0, 5.0])
+
+    def test_delete_at_end(self):
+        self.op.index = 4
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 4.0])
+
+    def test_delete_in_middle(self):
+        self.op.index = 2
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 4.0, 5.0])
+
+    def test_delete_multiple(self):
+        self.op.index = 1
+        self.op.n_points = 3
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 5.0])
+
+    def test_index_out_of_range_no_change(self):
+        self.op.index = 10
+        self._run()
+        np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    # --- edge cases ---
+
+    def test_skips_non_ndarray(self):
+        d = NMData(NM, name="RecordA0")
+        self.op.run(d)   # should not raise
+
+    # --- validation ---
+
+    def test_index_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.index = True
+
+    def test_index_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            self.op.index = -1
+
+    def test_n_points_rejects_zero(self):
+        with self.assertRaises(ValueError):
+            self.op.n_points = 0
+
+    def test_n_points_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.n_points = True
+
+
+# ===========================================================================
 # TestOpFromName (registry)
 # ===========================================================================
 
@@ -291,6 +504,18 @@ class TestOpFromName(unittest.TestCase):
     def test_scale_by_name(self):
         op = op_from_name("scale")
         self.assertIsInstance(op, NMMainOpScale)
+
+    def test_redimension_by_name(self):
+        op = op_from_name("redimension")
+        self.assertIsInstance(op, NMMainOpRedimension)
+
+    def test_insert_points_by_name(self):
+        op = op_from_name("insert_points")
+        self.assertIsInstance(op, NMMainOpInsertPoints)
+
+    def test_delete_points_by_name(self):
+        op = op_from_name("delete_points")
+        self.assertIsInstance(op, NMMainOpDeletePoints)
 
     def test_case_insensitive(self):
         op = op_from_name("AVERAGE")


### PR DESCRIPTION
## Summary

- Adds NMMainOpRedimension(n_points, fill=0.0) — truncate or pad a wave to a new length (np.concatenate / slice)
- Adds NMMainOpInsertPoints(index, n_points=1, fill=0.0) — insert points at a position (np.insert)
- Adds NMMainOpDeletePoints(index, n_points=1) — delete points at a position (np.delete); silently skips if index is out of range
- All three registered in _OP_REGISTRY and accessible via op_from_name()

## Test plan

-  34 new tests across TestNMMainOpRedimension, TestNMMainOpInsertPoints, TestNMMainOpDeletePoints
-  3 new registry tests in TestOpFromName
-  Full suite: python3 -m pytest tests/ -x -q (1578 passed)

Closes #174