### PR TITLE
feat(analysis): add NMMainOpBaseline for per-wave and average baseline subtraction

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -480,12 +480,201 @@ class NMMainOpDeletePoints(NMMainOp):
 
 
 # =========================================================================
+# Baseline helper
+# =========================================================================
+
+
+def _time_to_slice(arr: np.ndarray, xscale_dict: dict, t_begin: float, t_end: float) -> slice:
+    """Convert a time window to an array slice using xscale start/delta.
+
+    Clips to valid range; returns an empty slice if the window is fully outside.
+    """
+    start = xscale_dict.get("start", 0.0)
+    delta = xscale_dict.get("delta", 1.0)
+    if delta == 0:
+        return slice(0, 0)
+    i0 = int(round((t_begin - start) / delta))
+    i1 = int(round((t_end - start) / delta)) + 1  # inclusive end
+    i0 = max(0, i0)
+    i1 = min(len(arr), i1)
+    return slice(i0, i1)
+
+
+# =========================================================================
+# Baseline
+# =========================================================================
+
+
+class NMMainOpBaseline(NMMainOp):
+    """Subtract a baseline from each selected wave.
+
+    Two modes are supported:
+
+    - **per_wave**: Each wave's own baseline (mean of the window) is subtracted
+      from that wave independently.
+    - **average**: A single shared baseline per channel is computed as the mean
+      of all per-wave baselines for that channel, then subtracted from every
+      wave in that channel.
+
+    Parameters:
+        t_begin: Baseline window start in time units (default 0.0).
+        t_end: Baseline window end in time units (default 0.0).  Must be >=
+            ``t_begin``.
+        mode: ``"per_wave"`` (default) or ``"average"``.
+        ignore_nans: If True (default) use ``np.nanmean``; otherwise ``np.mean``
+            (NaN propagates to the result).
+    """
+
+    name = "baseline"
+
+    _VALID_MODES = {"per_wave", "average"}
+
+    def __init__(
+        self,
+        t_begin: float = 0.0,
+        t_end: float = 0.0,
+        mode: str = "per_wave",
+        ignore_nans: bool = True,
+    ) -> None:
+        self.t_begin = t_begin
+        self.t_end = t_end
+        self.mode = mode
+        self.ignore_nans = ignore_nans
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def t_begin(self) -> float:
+        """Baseline window start (time units)."""
+        return self._t_begin
+
+    @t_begin.setter
+    def t_begin(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "t_begin", "float"))
+        self._t_begin = float(value)
+
+    @property
+    def t_end(self) -> float:
+        """Baseline window end (time units)."""
+        return self._t_end
+
+    @t_end.setter
+    def t_end(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "t_end", "float"))
+        self._t_end = float(value)
+
+    @property
+    def mode(self) -> str:
+        """Subtraction mode: ``'per_wave'`` or ``'average'``."""
+        return self._mode
+
+    @mode.setter
+    def mode(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "mode", "string"))
+        if value not in self._VALID_MODES:
+            raise ValueError(
+                "mode must be one of %s, got %r" % (sorted(self._VALID_MODES), value)
+            )
+        self._mode = value
+
+    @property
+    def ignore_nans(self) -> bool:
+        """If True, NaN values are excluded from baseline mean (np.nanmean)."""
+        return self._ignore_nans
+
+    @ignore_nans.setter
+    def ignore_nans(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
+        self._ignore_nans = value
+
+    # ------------------------------------------------------------------
+    # Validation helper
+
+    def _validate_window(self) -> None:
+        if self._t_end < self._t_begin:
+            raise ValueError(
+                "t_end (%g) must be >= t_begin (%g)" % (self._t_end, self._t_begin)
+            )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run_init(self) -> None:
+        """Reset per-run accumulators."""
+        self._validate_window()
+        self._baseline_accum: dict[str, list[float]] = {}
+        self._data_refs: dict[str, list[NMData]] = {}
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Compute and (optionally) apply baseline for one wave.
+
+        Args:
+            data: The NMData object to process.
+            channel_name: Channel name from the selection context, or None
+                (parsed from data.name as a fallback).
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+
+        if channel_name is None:
+            parsed = nmu.parse_data_name(data.name)
+            channel_name = parsed[1] if parsed is not None else "A"
+
+        sl = _time_to_slice(
+            data.nparray, data.xscale.to_dict(), self._t_begin, self._t_end
+        )
+        segment = data.nparray[sl].astype(float)
+        if len(segment) == 0:
+            baseline = 0.0
+        elif self._ignore_nans:
+            baseline = float(np.nanmean(segment))
+        else:
+            baseline = float(np.mean(segment))
+
+        if self._mode == "per_wave":
+            data.nparray = data.nparray.astype(float) - baseline
+        else:  # "average"
+            self._baseline_accum.setdefault(channel_name, []).append(baseline)
+            self._data_refs.setdefault(channel_name, []).append(data)
+
+    def run_finish(
+        self,
+        folder: NMFolder | None = None,
+        prefix: str | None = None,
+    ) -> None:
+        """Apply averaged baseline (average mode only).
+
+        In ``per_wave`` mode this is a no-op (subtraction was done in ``run()``).
+        In ``average`` mode the mean of all per-wave baselines for each channel
+        is computed and subtracted from every wave in that channel.
+        """
+        if self._mode == "per_wave":
+            return
+        for channel_name, baselines in self._baseline_accum.items():
+            avg_baseline = float(
+                np.nanmean(baselines) if self._ignore_nans else np.mean(baselines)
+            )
+            for d in self._data_refs[channel_name]:
+                d.nparray = d.nparray.astype(float) - avg_baseline
+
+
+# =========================================================================
 # Registry and lookup
 # =========================================================================
 
 
 _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "average": NMMainOpAverage,
+    "baseline": NMMainOpBaseline,
     "delete_points": NMMainOpDeletePoints,
     "insert_points": NMMainOpInsertPoints,
     "redimension": NMMainOpRedimension,

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -17,6 +17,7 @@ from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.analysis.nm_main_op import (
     NMMainOp,
     NMMainOpAverage,
+    NMMainOpBaseline,
     NMMainOpDeletePoints,
     NMMainOpInsertPoints,
     NMMainOpRedimension,
@@ -517,6 +518,10 @@ class TestOpFromName(unittest.TestCase):
         op = op_from_name("delete_points")
         self.assertIsInstance(op, NMMainOpDeletePoints)
 
+    def test_baseline_by_name(self):
+        op = op_from_name("baseline")
+        self.assertIsInstance(op, NMMainOpBaseline)
+
     def test_case_insensitive(self):
         op = op_from_name("AVERAGE")
         self.assertIsInstance(op, NMMainOpAverage)
@@ -528,6 +533,152 @@ class TestOpFromName(unittest.TestCase):
     def test_non_string_raises(self):
         with self.assertRaises(TypeError):
             op_from_name(42)
+
+
+# ===========================================================================
+# TestNMMainOpBaseline
+# ===========================================================================
+
+
+class TestNMMainOpBaseline(unittest.TestCase):
+    """Tests for NMMainOpBaseline (per_wave and average modes)."""
+
+    # ------------------------------------------------------------------
+    # per_wave mode
+
+    def test_per_wave_subtracts_correct_baseline(self):
+        # window [0,1] covers first 2 points [2,2] → baseline=2
+        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="per_wave")
+        d = _make_data("RecordA0", [2.0, 2.0, 4.0, 4.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [0.0, 0.0, 2.0, 2.0])
+
+    def test_per_wave_different_baselines(self):
+        # Two waves with different values in baseline window → independent shifts
+        op = NMMainOpBaseline(t_begin=0.0, t_end=0.0, mode="per_wave")
+        d1 = _make_data("RecordA0", [1.0, 5.0], xstart=0.0, xdelta=1.0)
+        d2 = _make_data("RecordA1", [3.0, 7.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d1)
+        op.run(d2)
+        np.testing.assert_array_almost_equal(d1.nparray, [0.0, 4.0])
+        np.testing.assert_array_almost_equal(d2.nparray, [0.0, 4.0])
+
+    def test_per_wave_nan_ignored(self):
+        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="per_wave", ignore_nans=True)
+        d = _make_data("RecordA0", [np.nan, 2.0, 5.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        # nanmean([nan, 2.0]) = 2.0 → subtracted
+        self.assertTrue(math.isfinite(float(d.nparray[2])))
+        self.assertAlmostEqual(float(d.nparray[2]), 3.0)
+
+    def test_per_wave_nan_propagates(self):
+        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="per_wave", ignore_nans=False)
+        d = _make_data("RecordA0", [np.nan, 2.0, 5.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        # mean([nan, 2.0]) = nan → all points become nan
+        self.assertTrue(np.all(np.isnan(d.nparray)))
+
+    def test_window_out_of_range_no_subtraction(self):
+        # Window is past end of array → empty slice → baseline=0 → no change
+        op = NMMainOpBaseline(t_begin=100.0, t_end=200.0, mode="per_wave")
+        d = _make_data("RecordA0", [5.0, 6.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [5.0, 6.0])
+
+    def test_window_partial_clip(self):
+        # Window extends beyond array end — only existing samples used
+        op = NMMainOpBaseline(t_begin=1.0, t_end=10.0, mode="per_wave")
+        # xdelta=1, array=[0,1,2,3]; window 1..10 clips to indices 1..4
+        d = _make_data("RecordA0", [0.0, 2.0, 4.0, 6.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        # baseline = mean([2,4,6]) = 4.0
+        np.testing.assert_array_almost_equal(d.nparray, [-4.0, -2.0, 0.0, 2.0])
+
+    # ------------------------------------------------------------------
+    # average mode
+
+    def test_average_mode_shared_baseline(self):
+        # 3 waves [2,2], [4,4], [6,6]; window covers full wave → baselines 2,4,6
+        # avg baseline = 4; all shifted by -4
+        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="average")
+        d1 = _make_data("RecordA0", [2.0, 2.0], xstart=0.0, xdelta=1.0)
+        d2 = _make_data("RecordA1", [4.0, 4.0], xstart=0.0, xdelta=1.0)
+        d3 = _make_data("RecordA2", [6.0, 6.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d1, "A")
+        op.run(d2, "A")
+        op.run(d3, "A")
+        op.run_finish()
+        np.testing.assert_array_almost_equal(d1.nparray, [-2.0, -2.0])
+        np.testing.assert_array_almost_equal(d2.nparray, [0.0, 0.0])
+        np.testing.assert_array_almost_equal(d3.nparray, [2.0, 2.0])
+
+    def test_average_mode_per_channel(self):
+        # Channel A: baselines 2,4 → avg=3; Channel B: baseline 10 → avg=10
+        op = NMMainOpBaseline(t_begin=0.0, t_end=0.0, mode="average")
+        a0 = _make_data("RecordA0", [2.0, 8.0], xstart=0.0, xdelta=1.0)
+        a1 = _make_data("RecordA1", [4.0, 8.0], xstart=0.0, xdelta=1.0)
+        b0 = _make_data("RecordB0", [10.0, 5.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(a0, "A")
+        op.run(a1, "A")
+        op.run(b0, "B")
+        op.run_finish()
+        # A: avg baseline = (2+4)/2 = 3
+        np.testing.assert_array_almost_equal(a0.nparray, [-1.0, 5.0])
+        np.testing.assert_array_almost_equal(a1.nparray, [1.0, 5.0])
+        # B: avg baseline = 10
+        np.testing.assert_array_almost_equal(b0.nparray, [0.0, -5.0])
+
+    def test_average_mode_nan_ignored(self):
+        # NaN in baseline window → nanmean used, result finite
+        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="average", ignore_nans=True)
+        d = _make_data("RecordA0", [np.nan, 4.0, 10.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d, "A")
+        op.run_finish()
+        # nanmean([nan, 4]) = 4 → subtract 4
+        self.assertAlmostEqual(float(d.nparray[2]), 6.0)
+
+    # ------------------------------------------------------------------
+    # validation
+
+    def test_mode_rejects_unknown(self):
+        with self.assertRaises(ValueError):
+            NMMainOpBaseline(mode="median")
+
+    def test_mode_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            NMMainOpBaseline(mode=1)
+
+    def test_t_end_before_t_begin_raises(self):
+        op = NMMainOpBaseline(t_begin=5.0, t_end=2.0)
+        with self.assertRaises(ValueError):
+            op.run_init()  # calls _validate_window → raises
+
+    def test_t_begin_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpBaseline(t_begin=True)
+
+    def test_t_end_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpBaseline(t_end=True)
+
+    def test_ignore_nans_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpBaseline(ignore_nans=1)
+
+    def test_skips_non_ndarray(self):
+        op = NMMainOpBaseline()
+        d = NMData(NM, name="RecordA0")  # no nparray
+        op.run_init()
+        op.run(d)  # should not raise
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Adds `NMMainOpBaseline` to `nm_main_op.py` with two subtraction modes:
  `per_wave` (each wave's own baseline) and `average` (shared per-channel
  baseline computed as the mean of all per-wave baselines)
- Adds module-level `_time_to_slice()` helper to convert a time window
  (`t_begin`, `t_end`) to an array slice via xscale start/delta, clipping
  to valid range
- Registers `"baseline"` in `_OP_REGISTRY`
- Adds 17 tests in `TestNMMainOpBaseline` covering both modes, NaN
  handling, window clipping, out-of-range windows, and all validation paths

Closes #177

## Test plan

- [x] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py -v` — 91 passed
- [x] `python3 -m pytest tests/ -x -q` — 1595 passed

🤖 Generated with Claude Code
