### PR TITLE
feat(analysis): add NMData notes and NMHistory logging to NMMainOp

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -109,6 +109,12 @@ class NMMainOp:
     ) -> None:
         """Called once after the per-item loop.  Override to write results."""
 
+    def _add_note(self, data: NMData, text: str) -> None:
+        """Append a timestamped note to data.notes if available."""
+        notes = getattr(data, "notes", None)
+        if notes is not None:
+            notes.add(text)
+
 
 # =========================================================================
 # Average
@@ -157,6 +163,7 @@ class NMMainOpAverage(NMMainOp):
         """Reset accumulation state for a new run."""
         self._results.clear()
         self._accum: dict[str, list[np.ndarray]] = {}
+        self._data_names: dict[str, list[str]] = {}
         self._xscales: dict[str, dict] = {}
         self._yscales: dict[str, dict] = {}
         self._parsed_prefix: str | None = None  # fallback if prefix not passed
@@ -190,6 +197,7 @@ class NMMainOpAverage(NMMainOp):
             self._yscales[channel_name] = data.yscale.to_dict()
 
         self._accum[channel_name].append(data.nparray.astype(float).copy())
+        self._data_names.setdefault(channel_name, []).append(data.name)
 
     def run_finish(
         self,
@@ -218,6 +226,28 @@ class NMMainOpAverage(NMMainOp):
                 xscale=self._xscales[cname],
                 yscale=self._yscales[cname],
             )
+            out_data = folder.data.get(out_name)
+            if out_data is not None:
+                n = len(arrays)
+                ds_name = prefix if prefix is not None else (self._parsed_prefix or "")
+                epoch_nums = []
+                for dname in self._data_names.get(cname, []):
+                    parsed = nmu.parse_data_name(dname)
+                    epoch_nums.append(str(parsed[2]) if parsed is not None else dname)
+                try:
+                    ints = [int(e) for e in epoch_nums]
+                    lo, hi = min(ints), max(ints)
+                    if len(ints) > 1 and ints == list(range(lo, hi + 1)):
+                        epoch_str = "%d-%d" % (lo, hi)
+                    else:
+                        epoch_str = "[" + ",".join(epoch_nums) + "]"
+                except ValueError:
+                    epoch_str = "[" + ",".join(epoch_nums) + "]"
+                self._add_note(
+                    out_data,
+                    "NMAverage(folder=%s,dataseries=%s,channel=%s,epochs=%s,n_epochs=%d)"
+                    % (folder.name, ds_name, cname, epoch_str, n),
+                )
             self._results[cname] = out_name
 
 
@@ -264,6 +294,7 @@ class NMMainOpScale(NMMainOp):
         if not isinstance(data.nparray, np.ndarray):
             return
         data.nparray = data.nparray * self._factor
+        self._add_note(data, "NMScale(factor=%.6g)" % self._factor)
 
 
 # =========================================================================
@@ -327,10 +358,13 @@ class NMMainOpRedimension(NMMainOp):
             return
         arr = data.nparray
         n = self._n_points
-        if n <= len(arr):
+        old_len = len(arr)
+        if n <= old_len:
             data.nparray = arr[:n]
+            self._add_note(data, "NMRedimension(n_points=%d)" % n)
         else:
-            data.nparray = np.concatenate([arr, np.full(n - len(arr), self._fill)])
+            data.nparray = np.concatenate([arr, np.full(n - old_len, self._fill)])
+            self._add_note(data, "NMRedimension(n_points=%d,fill=%.6g)" % (n, self._fill))
 
 
 # =========================================================================
@@ -410,6 +444,11 @@ class NMMainOpInsertPoints(NMMainOp):
         data.nparray = np.insert(
             data.nparray, self._index, np.full(self._n_points, self._fill)
         )
+        self._add_note(
+            data,
+            "NMInsertPoints(index=%d,n_points=%d,fill=%.6g)"
+            % (self._index, self._n_points, self._fill),
+        )
 
 
 # =========================================================================
@@ -476,6 +515,10 @@ class NMMainOpDeletePoints(NMMainOp):
             return  # nothing to delete
         data.nparray = np.delete(
             data.nparray, np.arange(self._index, self._index + self._n_points)
+        )
+        self._add_note(
+            data,
+            "NMDeletePoints(index=%d,n_points=%d)" % (self._index, self._n_points),
         )
 
 
@@ -642,6 +685,11 @@ class NMMainOpBaseline(NMMainOp):
 
         if self._mode == "per_wave":
             data.nparray = data.nparray.astype(float) - baseline
+            self._add_note(
+                data,
+                "NMBaseline(t_begin=%.6g,t_end=%.6g,mode=per_wave,baseline=%.6g)"
+                % (self._t_begin, self._t_end, baseline),
+            )
         else:  # "average"
             self._baseline_accum.setdefault(channel_name, []).append(baseline)
             self._data_refs.setdefault(channel_name, []).append(data)
@@ -665,6 +713,11 @@ class NMMainOpBaseline(NMMainOp):
             )
             for d in self._data_refs[channel_name]:
                 d.nparray = d.nparray.astype(float) - avg_baseline
+                self._add_note(
+                    d,
+                    "NMBaseline(t_begin=%.6g,t_end=%.6g,mode=average,channel=%s,baseline=%.6g)"
+                    % (self._t_begin, self._t_end, channel_name, avg_baseline),
+                )
 
 
 # =========================================================================

--- a/pyneuromatic/analysis/nm_tool_main.py
+++ b/pyneuromatic/analysis/nm_tool_main.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from pyneuromatic.analysis.nm_main_op import NMMainOp, NMMainOpAverage, op_from_name
 from pyneuromatic.analysis.nm_tool import NMTool
 from pyneuromatic.core.nm_folder import NMFolder
+import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_utilities as nmu
 
 
@@ -110,4 +111,16 @@ class NMToolMain(NMTool):
     def run_finish(self) -> bool:
         """Finalise the current op with the folder and prefix captured during run()."""
         self._op.run_finish(self._run_folder, self._run_prefix)
+        meta = self.run_meta
+        nmh.history(
+            "%s: folders=%s, dataseries=%s, channels=%s, epochs=%s"
+            % (
+                self._op.__class__.__name__,
+                meta.get("folders", []),
+                meta.get("dataseries", []),
+                meta.get("channels", []),
+                meta.get("epochs", []),
+            ),
+            path="NMToolMain.run_finish",
+        )
         return True

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -25,6 +25,7 @@ from pyneuromatic.analysis.nm_main_op import (
     op_from_name,
 )
 from pyneuromatic.analysis.nm_tool_main import NMToolMain
+import pyneuromatic.core.nm_history as nmh
 
 NM = NMManager(quiet=True)
 
@@ -205,6 +206,27 @@ class TestNMMainOpAverage(unittest.TestCase):
         self.op.run_all([(d, None)], folder)
         self.assertEqual(self.op.results, {})
 
+    # --- notes ---
+
+    def test_note_on_output_wave(self):
+        # consecutive epochs → range notation
+        folder = self._run({"RecordA0": [1.0, 2.0], "RecordA1": [3.0, 4.0], "RecordA2": [5.0, 6.0]})
+        out = folder.data.get("Avg_RecordA")
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out.notes), 1)
+        note = out.notes[0]["note"]
+        self.assertIn("folder=folder0", note)
+        self.assertIn("channel=A", note)
+        self.assertIn("epochs=0-2", note)
+        self.assertIn("n_epochs=3", note)
+
+    def test_note_non_consecutive_epochs(self):
+        # non-consecutive epochs → list notation
+        folder = self._run({"RecordA0": [1.0], "RecordA2": [2.0], "RecordA5": [3.0]})
+        out = folder.data.get("Avg_RecordA")
+        note = out.notes[0]["note"]
+        self.assertIn("epochs=[0,2,5]", note)
+
 
 # ===========================================================================
 # TestNMMainOpScale
@@ -281,6 +303,14 @@ class TestNMMainOpScale(unittest.TestCase):
         self.op.factor = 2.0
         self.op.run(d)   # should not raise
 
+    # --- notes ---
+
+    def test_note_written(self):
+        self.op.factor = 2.0
+        self.op.run(self.data)
+        self.assertEqual(len(self.data.notes), 1)
+        self.assertIn("NMScale(factor=2)", self.data.notes[0]["note"])
+
 
 # ===========================================================================
 # TestNMMainOpRedimension
@@ -356,6 +386,23 @@ class TestNMMainOpRedimension(unittest.TestCase):
         self.assertEqual(self.op.fill, 2.0)
         self.assertIsInstance(self.op.fill, float)
 
+    # --- notes ---
+
+    def test_note_truncate(self):
+        self.op.n_points = 3
+        self.op.run(self.data)
+        self.assertEqual(len(self.data.notes), 1)
+        note = self.data.notes[0]["note"]
+        self.assertIn("NMRedimension(n_points=3)", note)
+
+    def test_note_pad(self):
+        self.op.n_points = 7
+        self.op.fill = 9.0
+        self.op.run(self.data)
+        self.assertEqual(len(self.data.notes), 1)
+        note = self.data.notes[0]["note"]
+        self.assertIn("NMRedimension(n_points=7,fill=9)", note)
+
 
 # ===========================================================================
 # TestNMMainOpInsertPoints
@@ -424,6 +471,17 @@ class TestNMMainOpInsertPoints(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.op.fill = False
 
+    # --- notes ---
+
+    def test_note_written(self):
+        self.op.index = 1
+        self.op.n_points = 2
+        self.op.fill = 0.0
+        self.op.run(self.data)
+        self.assertEqual(len(self.data.notes), 1)
+        note = self.data.notes[0]["note"]
+        self.assertIn("NMInsertPoints(index=1,n_points=2,fill=0)", note)
+
 
 # ===========================================================================
 # TestNMMainOpDeletePoints
@@ -490,6 +548,16 @@ class TestNMMainOpDeletePoints(unittest.TestCase):
     def test_n_points_rejects_bool(self):
         with self.assertRaises(TypeError):
             self.op.n_points = True
+
+    # --- notes ---
+
+    def test_note_written(self):
+        self.op.index = 2
+        self.op.n_points = 3
+        self.op.run(self.data)
+        self.assertEqual(len(self.data.notes), 1)
+        note = self.data.notes[0]["note"]
+        self.assertIn("NMDeletePoints(index=2,n_points=3)", note)
 
 
 # ===========================================================================
@@ -680,6 +748,31 @@ class TestNMMainOpBaseline(unittest.TestCase):
         op.run_init()
         op.run(d)  # should not raise
 
+    # --- notes ---
+
+    def test_per_wave_note_written(self):
+        op = NMMainOpBaseline(t_begin=0.0, t_end=0.0, mode="per_wave")
+        d = _make_data("RecordA0", [3.0, 5.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        self.assertEqual(len(d.notes), 1)
+        note = d.notes[0]["note"]
+        self.assertIn("NMBaseline(t_begin=0,t_end=0,mode=per_wave,baseline=3)", note)
+
+    def test_average_note_written(self):
+        op = NMMainOpBaseline(t_begin=0.0, t_end=0.0, mode="average")
+        d1 = _make_data("RecordA0", [2.0, 8.0], xstart=0.0, xdelta=1.0)
+        d2 = _make_data("RecordA1", [4.0, 6.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d1, "A")
+        op.run(d2, "A")
+        op.run_finish()
+        # avg baseline = (2+4)/2 = 3
+        for d in (d1, d2):
+            self.assertEqual(len(d.notes), 1)
+            note = d.notes[0]["note"]
+            self.assertIn("NMBaseline(t_begin=0,t_end=0,mode=average,channel=A,baseline=3)", note)
+
 
 # ===========================================================================
 # TestNMToolMain
@@ -750,6 +843,23 @@ class TestNMToolMain(unittest.TestCase):
         meta = self.tool.run_meta
         self.assertIn("date", meta)
         self.assertIn("folders", meta)
+
+    # --- NMHistory ---
+
+    def test_history_logged_after_run(self):
+        # Create a fresh NMHistory and register it so we own the buffer handler
+        # on the shared logger (other test modules may have replaced it).
+        fresh_history = nmh.NMHistory(quiet=True)
+        nmh.set_history(fresh_history)
+        before = len(fresh_history.buffer)
+        _, targets = _make_folder_with_data({"RecordA0": [1.0, 2.0]})
+        self.tool.op = NMMainOpScale(factor=2.0)
+        self.tool.run_all(targets)
+        after = len(fresh_history.buffer)
+        self.assertGreater(after, before)
+        # Most recent entry should contain the op class name
+        last_msg = fresh_history.buffer[-1]["message"]
+        self.assertIn("NMMainOpScale", last_msg)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Each `NMMainOp` subclass writes a timestamped note to `NMData.notes`
  after modifying data, following Igor NeuroMatic's function-call format
  (e.g. `NMBaseline(t_begin=0,t_end=5,mode=per_wave,baseline=-0.068)`)
- `NMMainOpAverage` output wave note includes `folder`, `dataseries`,
  `channel`, and epoch range — compact `0-99` notation for consecutive
  epochs, `[0,2,5]` list otherwise
- `NMMainOp` base class gains `_add_note(data, text)` helper used by
  all subclasses
- `NMToolMain.run_finish()` logs a one-line summary to `NMHistory`
  after every run (op class name, folders, dataseries, channels, epochs)
- Adds 10 note/history tests across all op test classes

## Test plan

- [x] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py -v` — 101 passed
- [x] `python3 -m pytest tests/ -x -q` — 1604 passed

