### PR TITLE
feat(analysis): add NMMainOpIntegrate and NMMainOpDifferentiate ops

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -801,6 +801,108 @@ class NMMainOpRotate(NMMainOp):
 
 
 # =========================================================================
+# Integrate
+# =========================================================================
+
+
+class NMMainOpIntegrate(NMMainOp):
+    """Cumulative integration of each selected wave (in-place).
+
+    Two methods are supported:
+
+    - **rectangular**: ``np.cumsum(arr) * delta`` — equivalent to summing
+      rectangular strips of width ``delta``.
+    - **trapezoid**: cumulative trapezoidal rule — each step area is
+      ``0.5 * (y[i] + y[i+1]) * delta``; the first output point is 0.0
+      so the output length equals the input length.
+
+    Parameters:
+        method: ``"rectangular"`` (default) or ``"trapezoid"``.
+    """
+
+    name = "integrate"
+
+    _VALID_METHODS = {"rectangular", "trapezoid"}
+
+    def __init__(self, method: str = "rectangular") -> None:
+        self.method = method  # setter for validation
+
+    @property
+    def method(self) -> str:
+        """Integration method: ``'rectangular'`` or ``'trapezoid'``."""
+        return self._method
+
+    @method.setter
+    def method(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "method", "string"))
+        if value not in self._VALID_METHODS:
+            raise ValueError(
+                "method must be one of %s, got %r" % (sorted(self._VALID_METHODS), value)
+            )
+        self._method = value
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Integrate data.nparray in-place.
+
+        Args:
+            data: The NMData object to integrate.
+            channel_name: Unused; present for API consistency.
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        delta = data.xscale.delta
+        arr = data.nparray.astype(float)
+        if self._method == "rectangular":
+            data.nparray = np.cumsum(arr) * delta
+        else:  # "trapezoid"
+            steps = 0.5 * (arr[:-1] + arr[1:]) * delta
+            data.nparray = np.concatenate([[0.0], np.cumsum(steps)])
+        self._add_note(data, "NMIntegrate(method=%s)" % self._method)
+
+
+# =========================================================================
+# Differentiate
+# =========================================================================
+
+
+class NMMainOpDifferentiate(NMMainOp):
+    """First derivative of each selected wave using ``np.gradient`` (in-place).
+
+    Uses central differences for interior points and one-sided differences at
+    the boundaries.  Preserves array length.  Scales by ``xscale.delta`` so
+    the result has correct dy/dx units.  No parameters.
+    """
+
+    name = "differentiate"
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Differentiate data.nparray in-place.
+
+        Args:
+            data: The NMData object to differentiate.
+            channel_name: Unused; present for API consistency.
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        delta = data.xscale.delta
+        arr = data.nparray.astype(float)
+        if delta != 0:
+            data.nparray = np.gradient(arr, delta)
+        else:
+            data.nparray = np.gradient(arr)
+        self._add_note(data, "NMDifferentiate()")
+
+
+# =========================================================================
 # Registry and lookup
 # =========================================================================
 
@@ -809,7 +911,9 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "average": NMMainOpAverage,
     "baseline": NMMainOpBaseline,
     "delete_points": NMMainOpDeletePoints,
+    "differentiate": NMMainOpDifferentiate,
     "insert_points": NMMainOpInsertPoints,
+    "integrate": NMMainOpIntegrate,
     "redimension": NMMainOpRedimension,
     "reverse": NMMainOpReverse,
     "rotate": NMMainOpRotate,

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -19,7 +19,9 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpAverage,
     NMMainOpBaseline,
     NMMainOpDeletePoints,
+    NMMainOpDifferentiate,
     NMMainOpInsertPoints,
+    NMMainOpIntegrate,
     NMMainOpRedimension,
     NMMainOpReverse,
     NMMainOpRotate,
@@ -600,6 +602,14 @@ class TestOpFromName(unittest.TestCase):
         op = op_from_name("rotate")
         self.assertIsInstance(op, NMMainOpRotate)
 
+    def test_integrate_by_name(self):
+        op = op_from_name("integrate")
+        self.assertIsInstance(op, NMMainOpIntegrate)
+
+    def test_differentiate_by_name(self):
+        op = op_from_name("differentiate")
+        self.assertIsInstance(op, NMMainOpDifferentiate)
+
     def test_case_insensitive(self):
         op = op_from_name("AVERAGE")
         self.assertIsInstance(op, NMMainOpAverage)
@@ -888,6 +898,140 @@ class TestNMMainOpRotate(unittest.TestCase):
         self.op.n_points = -2
         self.op.run(self.data)
         self.assertIn("n_points=-2", self.data.notes[0]["note"])
+
+
+# ===========================================================================
+# TestNMMainOpIntegrate
+# ===========================================================================
+
+
+class TestNMMainOpIntegrate(unittest.TestCase):
+    """Test NMMainOpIntegrate directly."""
+
+    # --- rectangular ---
+
+    def test_rectangular_correct_values(self):
+        # [1,1,1,1] with delta=1 → cumsum=[1,2,3,4] * 1 = [1,2,3,4]
+        d = _make_data("RecordA0", [1.0, 1.0, 1.0, 1.0], xdelta=1.0)
+        NMMainOpIntegrate(method="rectangular").run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [1.0, 2.0, 3.0, 4.0])
+
+    def test_rectangular_uses_delta(self):
+        # [1,1,1,1] with delta=0.5 → cumsum=[1,2,3,4] * 0.5 = [0.5,1.0,1.5,2.0]
+        d = _make_data("RecordA0", [1.0, 1.0, 1.0, 1.0], xdelta=0.5)
+        NMMainOpIntegrate(method="rectangular").run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [0.5, 1.0, 1.5, 2.0])
+
+    # --- trapezoid ---
+
+    def test_trapezoid_correct_values(self):
+        # [0,2,4] with delta=1:
+        #   step0 = 0.5*(0+2)*1 = 1
+        #   step1 = 0.5*(2+4)*1 = 3
+        # result = [0, 1, 4]
+        d = _make_data("RecordA0", [0.0, 2.0, 4.0], xdelta=1.0)
+        NMMainOpIntegrate(method="trapezoid").run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [0.0, 1.0, 4.0])
+
+    def test_trapezoid_uses_delta(self):
+        # [0,2,4] with delta=2:
+        #   step0 = 0.5*(0+2)*2 = 2
+        #   step1 = 0.5*(2+4)*2 = 6
+        # result = [0, 2, 8]
+        d = _make_data("RecordA0", [0.0, 2.0, 4.0], xdelta=2.0)
+        NMMainOpIntegrate(method="trapezoid").run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [0.0, 2.0, 8.0])
+
+    def test_trapezoid_preserves_length(self):
+        arr = [1.0, 2.0, 3.0, 4.0, 5.0]
+        d = _make_data("RecordA0", arr, xdelta=1.0)
+        NMMainOpIntegrate(method="trapezoid").run(d)
+        self.assertEqual(len(d.nparray), len(arr))
+
+    # --- defaults and validation ---
+
+    def test_method_default_is_rectangular(self):
+        op = NMMainOpIntegrate()
+        self.assertEqual(op.method, "rectangular")
+
+    def test_method_rejects_unknown(self):
+        with self.assertRaises(ValueError):
+            NMMainOpIntegrate(method="simpson")
+
+    def test_method_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            NMMainOpIntegrate(method=1)
+
+    # --- edge cases ---
+
+    def test_skips_non_ndarray(self):
+        d = NMData(NM, name="RecordA0")
+        NMMainOpIntegrate().run(d)  # should not raise
+
+    # --- notes ---
+
+    def test_note_rectangular(self):
+        d = _make_data("RecordA0", [1.0, 2.0])
+        NMMainOpIntegrate(method="rectangular").run(d)
+        self.assertEqual(len(d.notes), 1)
+        self.assertIn("NMIntegrate(method=rectangular)", d.notes[0]["note"])
+
+    def test_note_trapezoid(self):
+        d = _make_data("RecordA0", [1.0, 2.0])
+        NMMainOpIntegrate(method="trapezoid").run(d)
+        self.assertEqual(len(d.notes), 1)
+        self.assertIn("NMIntegrate(method=trapezoid)", d.notes[0]["note"])
+
+
+# ===========================================================================
+# TestNMMainOpDifferentiate
+# ===========================================================================
+
+
+class TestNMMainOpDifferentiate(unittest.TestCase):
+    """Test NMMainOpDifferentiate directly."""
+
+    # --- correct values ---
+
+    def test_correct_values(self):
+        # [0,1,4,9] with delta=1 → np.gradient([0,1,4,9], 1) = [1,2,4,5]
+        d = _make_data("RecordA0", [0.0, 1.0, 4.0, 9.0], xdelta=1.0)
+        NMMainOpDifferentiate().run(d)
+        expected = np.gradient([0.0, 1.0, 4.0, 9.0], 1.0)
+        np.testing.assert_array_almost_equal(d.nparray, expected)
+
+    def test_uses_delta(self):
+        # same wave with delta=0.5 → result scaled by 1/0.5
+        arr = [0.0, 1.0, 4.0, 9.0]
+        d = _make_data("RecordA0", arr, xdelta=0.5)
+        NMMainOpDifferentiate().run(d)
+        expected = np.gradient(np.array(arr), 0.5)
+        np.testing.assert_array_almost_equal(d.nparray, expected)
+
+    def test_constant_wave_is_zero(self):
+        d = _make_data("RecordA0", [5.0, 5.0, 5.0, 5.0], xdelta=1.0)
+        NMMainOpDifferentiate().run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [0.0, 0.0, 0.0, 0.0])
+
+    def test_preserves_length(self):
+        arr = [1.0, 3.0, 6.0, 10.0, 15.0]
+        d = _make_data("RecordA0", arr, xdelta=1.0)
+        NMMainOpDifferentiate().run(d)
+        self.assertEqual(len(d.nparray), len(arr))
+
+    # --- edge cases ---
+
+    def test_skips_non_ndarray(self):
+        d = NMData(NM, name="RecordA0")
+        NMMainOpDifferentiate().run(d)  # should not raise
+
+    # --- notes ---
+
+    def test_note_written(self):
+        d = _make_data("RecordA0", [0.0, 1.0, 4.0])
+        NMMainOpDifferentiate().run(d)
+        self.assertEqual(len(d.notes), 1)
+        self.assertEqual(d.notes[0]["note"], "NMDifferentiate()")
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Adds `NMMainOpIntegrate(method="rectangular"|"trapezoid")` for permanent
  cumulative integration, mirroring `NMTransformIntegrate`
- Adds `NMMainOpDifferentiate()` for permanent first-derivative via
  `np.gradient()`, mirroring `NMTransformDifferentiate`
- Registers both under keys `"integrate"` and `"differentiate"` in `_OP_REGISTRY`

## Test plan
- [ ] `TestNMMainOpIntegrate`: rectangular/trapezoid values, delta scaling,
  length preservation, validation (unknown method, non-string), skip non-ndarray, notes
- [ ] `TestNMMainOpDifferentiate`: correct values, delta scaling, constant→zero,
  length preservation, skip non-ndarray, note
- [ ] Registry: `test_integrate_by_name`, `test_differentiate_by_name`
- [ ] Full suite: `python3 -m pytest tests/ -x -q` → 1640 passed

Closes #183

