### PR TITLE
feat(analysis): add NMMainOpReplaceValues and NMMainOpDeleteNaNs ops

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -903,6 +903,159 @@ class NMMainOpDifferentiate(NMMainOp):
 
 
 # =========================================================================
+# Replace values
+# =========================================================================
+
+
+class NMMainOpReplaceValues(NMMainOp):
+    """Replace all points equal to ``old_value`` with ``new_value`` (in-place).
+
+    NaN-aware: if ``old_value`` is NaN, ``np.isnan()`` is used to build the
+    mask (since ``nan != nan``).  The note reports how many points were
+    replaced; it is written even when no replacements occurred (n=0).
+
+    Parameters:
+        old_value: Value to search for (default 0.0).  ``float("nan")`` and
+            ``float("inf")`` are accepted.
+        new_value: Replacement value (default 0.0).
+    """
+
+    name = "replace_values"
+
+    def __init__(self, old_value: float = 0.0, new_value: float = 0.0) -> None:
+        self.old_value = old_value  # setters for validation
+        self.new_value = new_value
+
+    @property
+    def old_value(self) -> float:
+        """Value to search for."""
+        return self._old_value
+
+    @old_value.setter
+    def old_value(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "old_value", "float"))
+        self._old_value = float(value)
+
+    @property
+    def new_value(self) -> float:
+        """Replacement value."""
+        return self._new_value
+
+    @new_value.setter
+    def new_value(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "new_value", "float"))
+        self._new_value = float(value)
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Replace matching values in data.nparray in-place.
+
+        Args:
+            data: The NMData object to modify.
+            channel_name: Unused; present for API consistency.
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        import math
+        arr = data.nparray.astype(float)
+        if math.isnan(self._old_value):
+            mask = np.isnan(arr)
+        else:
+            mask = arr == self._old_value
+        n = int(np.count_nonzero(mask))
+        arr[mask] = self._new_value
+        data.nparray = arr
+        self._add_note(
+            data,
+            "NMReplaceValues(old=%.6g,new=%.6g,n=%d)"
+            % (self._old_value, self._new_value, n),
+        )
+
+
+# =========================================================================
+# Delete NaNs
+# =========================================================================
+
+
+class NMMainOpDeleteNaNs(NMMainOp):
+    """Remove NaN and/or ±Inf points from each selected wave (in-place).
+
+    Shortens the array.  The note reports how many points were removed;
+    it is written even when n=0.
+
+    Parameters:
+        delete_nans: If True (default), remove NaN points.
+        delete_infs: If True, remove ±Inf points (default False).
+
+    At least one of ``delete_nans`` or ``delete_infs`` must be True.
+    """
+
+    name = "delete_nans"
+
+    def __init__(self, delete_nans: bool = True, delete_infs: bool = False) -> None:
+        self.delete_nans = delete_nans  # setters for validation
+        self.delete_infs = delete_infs
+        if not self._delete_nans and not self._delete_infs:
+            raise ValueError(
+                "at least one of delete_nans or delete_infs must be True"
+            )
+
+    @property
+    def delete_nans(self) -> bool:
+        """If True, NaN points are removed."""
+        return self._delete_nans
+
+    @delete_nans.setter
+    def delete_nans(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "delete_nans", "boolean"))
+        self._delete_nans = value
+
+    @property
+    def delete_infs(self) -> bool:
+        """If True, ±Inf points are removed (default False)."""
+        return self._delete_infs
+
+    @delete_infs.setter
+    def delete_infs(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "delete_infs", "boolean"))
+        self._delete_infs = value
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Remove NaN/Inf points from data.nparray in-place.
+
+        Args:
+            data: The NMData object to modify.
+            channel_name: Unused; present for API consistency.
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        arr = data.nparray.astype(float)
+        mask = np.zeros(len(arr), dtype=bool)
+        if self._delete_nans:
+            mask |= np.isnan(arr)
+        if self._delete_infs:
+            mask |= np.isinf(arr)
+        n = int(np.count_nonzero(mask))
+        data.nparray = arr[~mask]
+        self._add_note(
+            data,
+            "NMDeleteNaNs(delete_nans=%s,delete_infs=%s,n=%d)"
+            % (self._delete_nans, self._delete_infs, n),
+        )
+
+
+# =========================================================================
 # Registry and lookup
 # =========================================================================
 
@@ -910,11 +1063,13 @@ class NMMainOpDifferentiate(NMMainOp):
 _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "average": NMMainOpAverage,
     "baseline": NMMainOpBaseline,
+    "delete_nans": NMMainOpDeleteNaNs,
     "delete_points": NMMainOpDeletePoints,
     "differentiate": NMMainOpDifferentiate,
     "insert_points": NMMainOpInsertPoints,
     "integrate": NMMainOpIntegrate,
     "redimension": NMMainOpRedimension,
+    "replace_values": NMMainOpReplaceValues,
     "reverse": NMMainOpReverse,
     "rotate": NMMainOpRotate,
     "scale": NMMainOpScale,

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -18,11 +18,13 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOp,
     NMMainOpAverage,
     NMMainOpBaseline,
+    NMMainOpDeleteNaNs,
     NMMainOpDeletePoints,
     NMMainOpDifferentiate,
     NMMainOpInsertPoints,
     NMMainOpIntegrate,
     NMMainOpRedimension,
+    NMMainOpReplaceValues,
     NMMainOpReverse,
     NMMainOpRotate,
     NMMainOpScale,
@@ -610,6 +612,14 @@ class TestOpFromName(unittest.TestCase):
         op = op_from_name("differentiate")
         self.assertIsInstance(op, NMMainOpDifferentiate)
 
+    def test_replace_values_by_name(self):
+        op = op_from_name("replace_values")
+        self.assertIsInstance(op, NMMainOpReplaceValues)
+
+    def test_delete_nans_by_name(self):
+        op = op_from_name("delete_nans")
+        self.assertIsInstance(op, NMMainOpDeleteNaNs)
+
     def test_case_insensitive(self):
         op = op_from_name("AVERAGE")
         self.assertIsInstance(op, NMMainOpAverage)
@@ -995,9 +1005,10 @@ class TestNMMainOpDifferentiate(unittest.TestCase):
 
     def test_correct_values(self):
         # [0,1,4,9] with delta=1 → np.gradient([0,1,4,9], 1) = [1,2,4,5]
-        d = _make_data("RecordA0", [0.0, 1.0, 4.0, 9.0], xdelta=1.0)
+        arr = [0.0, 1.0, 4.0, 9.0]
+        d = _make_data("RecordA0", arr, xdelta=1.0)
         NMMainOpDifferentiate().run(d)
-        expected = np.gradient([0.0, 1.0, 4.0, 9.0], 1.0)
+        expected = np.gradient(arr, 1.0)
         np.testing.assert_array_almost_equal(d.nparray, expected)
 
     def test_uses_delta(self):
@@ -1032,6 +1043,156 @@ class TestNMMainOpDifferentiate(unittest.TestCase):
         NMMainOpDifferentiate().run(d)
         self.assertEqual(len(d.notes), 1)
         self.assertEqual(d.notes[0]["note"], "NMDifferentiate()")
+
+
+# ===========================================================================
+# TestNMMainOpReplaceValues
+# ===========================================================================
+
+
+class TestNMMainOpReplaceValues(unittest.TestCase):
+    """Test NMMainOpReplaceValues directly."""
+
+    # --- correct values ---
+
+    def test_replaces_exact_value(self):
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0, 2.0, 1.0])
+        NMMainOpReplaceValues(old_value=2.0, new_value=99.0).run(d)
+        np.testing.assert_array_equal(d.nparray, [1.0, 99.0, 3.0, 99.0, 1.0])
+
+    def test_replaces_nan(self):
+        d = _make_data("RecordA0", [1.0, float("nan"), 3.0])
+        NMMainOpReplaceValues(old_value=float("nan"), new_value=0.0).run(d)
+        np.testing.assert_array_equal(d.nparray, [1.0, 0.0, 3.0])
+
+    def test_no_match_unchanged(self):
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0])
+        NMMainOpReplaceValues(old_value=9.0, new_value=0.0).run(d)
+        np.testing.assert_array_equal(d.nparray, [1.0, 2.0, 3.0])
+
+    # --- defaults ---
+
+    def test_old_value_default_is_zero(self):
+        self.assertEqual(NMMainOpReplaceValues().old_value, 0.0)
+
+    def test_new_value_default_is_zero(self):
+        self.assertEqual(NMMainOpReplaceValues().new_value, 0.0)
+
+    # --- validation ---
+
+    def test_old_value_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpReplaceValues(old_value=True)
+
+    def test_new_value_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpReplaceValues(new_value=True)
+
+    # --- edge cases ---
+
+    def test_skips_non_ndarray(self):
+        d = NMData(NM, name="RecordA0")
+        NMMainOpReplaceValues().run(d)  # should not raise
+
+    # --- notes ---
+
+    def test_note_written(self):
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0, 2.0, 1.0])
+        NMMainOpReplaceValues(old_value=2.0, new_value=99.0).run(d)
+        self.assertEqual(len(d.notes), 1)
+        self.assertIn("NMReplaceValues(old=2,new=99,n=2)", d.notes[0]["note"])
+
+    def test_note_nan_old(self):
+        d = _make_data("RecordA0", [1.0, float("nan"), 3.0])
+        NMMainOpReplaceValues(old_value=float("nan"), new_value=0.0).run(d)
+        self.assertIn("NMReplaceValues(old=nan,new=0,n=1)", d.notes[0]["note"])
+
+    def test_note_written_when_no_match(self):
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0])
+        NMMainOpReplaceValues(old_value=9.0, new_value=0.0).run(d)
+        self.assertEqual(len(d.notes), 1)
+        self.assertIn("n=0", d.notes[0]["note"])
+
+
+# ===========================================================================
+# TestNMMainOpDeleteNaNs
+# ===========================================================================
+
+
+class TestNMMainOpDeleteNaNs(unittest.TestCase):
+    """Test NMMainOpDeleteNaNs directly."""
+
+    # --- correct values ---
+
+    def test_deletes_nan_only(self):
+        # default: delete_nans=True, delete_infs=False → Inf is kept
+        d = _make_data("RecordA0", [1.0, float("nan"), float("inf"), 3.0])
+        NMMainOpDeleteNaNs().run(d)
+        self.assertEqual(len(d.nparray), 3)
+        self.assertTrue(math.isinf(d.nparray[1]))
+
+    def test_deletes_inf_only(self):
+        d = _make_data("RecordA0", [1.0, float("nan"), float("inf"), 3.0])
+        NMMainOpDeleteNaNs(delete_nans=False, delete_infs=True).run(d)
+        self.assertEqual(len(d.nparray), 3)
+        self.assertTrue(math.isnan(d.nparray[1]))
+
+    def test_deletes_both(self):
+        d = _make_data("RecordA0", [float("nan"), 1.0, float("inf"), 2.0, float("-inf")])
+        NMMainOpDeleteNaNs(delete_nans=True, delete_infs=True).run(d)
+        np.testing.assert_array_equal(d.nparray, [1.0, 2.0])
+
+    def test_no_nans_unchanged(self):
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0])
+        NMMainOpDeleteNaNs().run(d)
+        np.testing.assert_array_equal(d.nparray, [1.0, 2.0, 3.0])
+
+    def test_all_nans_empty_array(self):
+        d = _make_data("RecordA0", [float("nan"), float("nan")])
+        NMMainOpDeleteNaNs().run(d)
+        self.assertEqual(len(d.nparray), 0)
+
+    # --- defaults ---
+
+    def test_default_delete_nans_true(self):
+        self.assertTrue(NMMainOpDeleteNaNs().delete_nans)
+
+    def test_default_delete_infs_false(self):
+        self.assertFalse(NMMainOpDeleteNaNs().delete_infs)
+
+    # --- validation ---
+
+    def test_both_false_raises(self):
+        with self.assertRaises(ValueError):
+            NMMainOpDeleteNaNs(delete_nans=False, delete_infs=False)
+
+    def test_delete_nans_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpDeleteNaNs(delete_nans=1)
+
+    def test_delete_infs_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpDeleteNaNs(delete_infs=1)
+
+    # --- edge cases ---
+
+    def test_skips_non_ndarray(self):
+        d = NMData(NM, name="RecordA0")
+        NMMainOpDeleteNaNs().run(d)  # should not raise
+
+    # --- notes ---
+
+    def test_note_written(self):
+        d = _make_data("RecordA0", [1.0, float("nan"), 3.0])
+        NMMainOpDeleteNaNs().run(d)
+        self.assertEqual(len(d.notes), 1)
+        self.assertIn("NMDeleteNaNs(delete_nans=True,delete_infs=False,n=1)", d.notes[0]["note"])
+
+    def test_note_no_deletions(self):
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0])
+        NMMainOpDeleteNaNs().run(d)
+        self.assertEqual(len(d.notes), 1)
+        self.assertIn("n=0", d.notes[0]["note"])
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Adds `NMMainOpReplaceValues(old_value, new_value)` for in-place exact-value
  replacement; NaN-aware via `np.isnan()` when `old_value` is NaN
- Adds `NMMainOpDeleteNaNs(delete_nans=True, delete_infs=False)` for removing
  non-finite points
- Registers both under keys `"replace_values"` and `"delete_nans"` in `_OP_REGISTRY`

## Test plan
- [ ] `TestNMMainOpReplaceValues`: exact replacement, NaN replacement, no-match,
  defaults, bool rejection, skip non-ndarray, notes (match/nan/no-match)
- [ ] `TestNMMainOpDeleteNaNs`: NaN-only, Inf-only, both, no deletions, all-NaN→empty,
  defaults, both-False raises, bool rejection, skip non-ndarray, notes
- [ ] Registry: `test_replace_values_by_name`, `test_delete_nans_by_name`
- [ ] Full suite: `python3 -m pytest tests/ -x -q` → 1666 passed

Closes #185 
