### PR TITLE
feat(analysis): add NMMainOpNormalize op

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -543,6 +543,38 @@ def _time_to_slice(arr: np.ndarray, xscale_dict: dict, t_begin: float, t_end: fl
     return slice(i0, i1)
 
 
+def _compute_ref(arr: np.ndarray, fxn: str, n_mean: int) -> float:
+    """Compute a scalar reference value from arr using the given function.
+
+    Args:
+        arr: Array slice to compute the reference from.
+        fxn: One of ``"mean"``, ``"min"``, ``"max"``, ``"mean@min"``,
+            ``"mean@max"``.
+        n_mean: Number of points to compute mean around the extremum (used
+            only for ``"mean@min"`` and ``"mean@max"``).
+
+    Returns:
+        Scalar reference value, or ``float("nan")`` if arr is empty.
+    """
+    if len(arr) == 0:
+        return float("nan")
+    if fxn == "mean":
+        return float(np.nanmean(arr))
+    elif fxn == "min":
+        return float(np.nanmin(arr))
+    elif fxn == "max":
+        return float(np.nanmax(arr))
+    elif fxn == "mean@min":
+        i = int(np.nanargmin(arr))
+        half = n_mean // 2
+        return float(np.nanmean(arr[max(0, i - half):i + half + 1]))
+    elif fxn == "mean@max":
+        i = int(np.nanargmax(arr))
+        half = n_mean // 2
+        return float(np.nanmean(arr[max(0, i - half):i + half + 1]))
+    return float("nan")
+
+
 # =========================================================================
 # Baseline
 # =========================================================================
@@ -702,7 +734,7 @@ class NMMainOpBaseline(NMMainOp):
         """Apply averaged baseline (average mode only).
 
         In ``per_wave`` mode this is a no-op (subtraction was done in ``run()``).
-        In ``average`` mode the mean of all per-wave baselines for each channel
+        In ``average`` mode the average of all per-wave baselines for each channel
         is computed and subtracted from every wave in that channel.
         """
         if self._mode == "per_wave":
@@ -1056,6 +1088,319 @@ class NMMainOpDeleteNaNs(NMMainOp):
 
 
 # =========================================================================
+# Normalize
+# =========================================================================
+
+
+class NMMainOpNormalize(NMMainOp):
+    """Rescale each wave so a low reference maps to norm_min and a high reference maps to norm_max.
+
+    Two independent time windows are used:
+
+    - Window 1 (``t_begin1``/``t_end1``) computes the "low" reference via
+      ``fxn1`` (``"mean"``, ``"min"``, or ``"mean@min"``).
+    - Window 2 (``t_begin2``/``t_end2``) computes the "high" reference via
+      ``fxn2`` (``"mean"``, ``"max"``, or ``"mean@max"``).
+
+    Two modes (matching NMMainOpBaseline):
+
+    - **per_wave**: Each wave is normalized to its own references.
+    - **average**: Per-channel mean references are computed across all waves,
+      then applied to every wave in that channel.
+
+    Parameters:
+        t_begin1: Window 1 start in time units (default 0.0).
+        t_end1: Window 1 end in time units (default 0.0).
+        fxn1: Function for the low reference: ``"mean"``, ``"min"``, or
+            ``"mean@min"`` (default ``"mean"``).
+        n_mean1: Points around min for ``mean@min`` (default 1).
+        t_begin2: Window 2 start in time units (default 0.0).
+        t_end2: Window 2 end in time units (default 0.0).
+        fxn2: Function for the high reference: ``"mean"``, ``"max"``, or
+            ``"mean@max"`` (default ``"mean"``).
+        n_mean2: Points around max for ``mean@max`` (default 1).
+        norm_min: Target normalized minimum (default 0.0).
+        norm_max: Target normalized maximum (default 1.0).
+        mode: ``"per_wave"`` (default) or ``"average"``.
+    """
+
+    name = "normalize"
+
+    _VALID_FXN1 = {"mean", "min", "mean@min"}
+    _VALID_FXN2 = {"mean", "max", "mean@max"}
+    _VALID_MODES = {"per_wave", "average"}
+
+    def __init__(
+        self,
+        t_begin1: float = 0.0,
+        t_end1: float = 0.0,
+        fxn1: str = "mean",
+        n_mean1: int = 1,
+        t_begin2: float = 0.0,
+        t_end2: float = 0.0,
+        fxn2: str = "mean",
+        n_mean2: int = 1,
+        norm_min: float = 0.0,
+        norm_max: float = 1.0,
+        mode: str = "per_wave",
+    ) -> None:
+        self.t_begin1 = t_begin1
+        self.t_end1 = t_end1
+        self.fxn1 = fxn1
+        self.n_mean1 = n_mean1
+        self.t_begin2 = t_begin2
+        self.t_end2 = t_end2
+        self.fxn2 = fxn2
+        self.n_mean2 = n_mean2
+        self.norm_min = norm_min
+        self.norm_max = norm_max
+        self.mode = mode
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def t_begin1(self) -> float:
+        """Window 1 start (time units)."""
+        return self._t_begin1
+
+    @t_begin1.setter
+    def t_begin1(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "t_begin1", "float"))
+        self._t_begin1 = float(value)
+
+    @property
+    def t_end1(self) -> float:
+        """Window 1 end (time units)."""
+        return self._t_end1
+
+    @t_end1.setter
+    def t_end1(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "t_end1", "float"))
+        self._t_end1 = float(value)
+
+    @property
+    def fxn1(self) -> str:
+        """Low-reference function: ``'mean'``, ``'min'``, or ``'mean@min'``."""
+        return self._fxn1
+
+    @fxn1.setter
+    def fxn1(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "fxn1", "string"))
+        if value not in self._VALID_FXN1:
+            raise ValueError(
+                "fxn1 must be one of %s, got %r" % (sorted(self._VALID_FXN1), value)
+            )
+        self._fxn1 = value
+
+    @property
+    def n_mean1(self) -> int:
+        """Points around min for ``mean@min`` (default 1)."""
+        return self._n_mean1
+
+    @n_mean1.setter
+    def n_mean1(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "n_mean1", "int"))
+        if value < 1:
+            raise ValueError("n_mean1 must be >= 1, got %d" % value)
+        self._n_mean1 = value
+
+    @property
+    def t_begin2(self) -> float:
+        """Window 2 start (time units)."""
+        return self._t_begin2
+
+    @t_begin2.setter
+    def t_begin2(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "t_begin2", "float"))
+        self._t_begin2 = float(value)
+
+    @property
+    def t_end2(self) -> float:
+        """Window 2 end (time units)."""
+        return self._t_end2
+
+    @t_end2.setter
+    def t_end2(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "t_end2", "float"))
+        self._t_end2 = float(value)
+
+    @property
+    def fxn2(self) -> str:
+        """High-reference function: ``'mean'``, ``'max'``, or ``'mean@max'``."""
+        return self._fxn2
+
+    @fxn2.setter
+    def fxn2(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "fxn2", "string"))
+        if value not in self._VALID_FXN2:
+            raise ValueError(
+                "fxn2 must be one of %s, got %r" % (sorted(self._VALID_FXN2), value)
+            )
+        self._fxn2 = value
+
+    @property
+    def n_mean2(self) -> int:
+        """Points around max for ``mean@max`` (default 1)."""
+        return self._n_mean2
+
+    @n_mean2.setter
+    def n_mean2(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "n_mean2", "int"))
+        if value < 1:
+            raise ValueError("n_mean2 must be >= 1, got %d" % value)
+        self._n_mean2 = value
+
+    @property
+    def norm_min(self) -> float:
+        """Target normalized minimum."""
+        return self._norm_min
+
+    @norm_min.setter
+    def norm_min(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "norm_min", "float"))
+        self._norm_min = float(value)
+
+    @property
+    def norm_max(self) -> float:
+        """Target normalized maximum."""
+        return self._norm_max
+
+    @norm_max.setter
+    def norm_max(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "norm_max", "float"))
+        self._norm_max = float(value)
+
+    @property
+    def mode(self) -> str:
+        """Normalization mode: ``'per_wave'`` or ``'average'``."""
+        return self._mode
+
+    @mode.setter
+    def mode(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "mode", "string"))
+        if value not in self._VALID_MODES:
+            raise ValueError(
+                "mode must be one of %s, got %r" % (sorted(self._VALID_MODES), value)
+            )
+        self._mode = value
+
+    # ------------------------------------------------------------------
+    # Validation helper
+
+    def _validate_windows(self) -> None:
+        if self._t_end1 < self._t_begin1:
+            raise ValueError(
+                "t_end1 (%g) must be >= t_begin1 (%g)" % (self._t_end1, self._t_begin1)
+            )
+        if self._t_end2 < self._t_begin2:
+            raise ValueError(
+                "t_end2 (%g) must be >= t_begin2 (%g)" % (self._t_end2, self._t_begin2)
+            )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _apply(self, arr: np.ndarray, ref_min: float, ref_max: float) -> np.ndarray:
+        """Apply normalization formula to arr."""
+        range = ref_max - ref_min
+        if range == 0:
+            return np.full_like(arr, self._norm_min)
+        return (arr - ref_min) / range * (self._norm_max - self._norm_min) + self._norm_min
+
+    def _note_str(self, ref_min: float, ref_max: float, channel_name: str | None = None) -> str:
+        note = (
+            "NMNormalize(t_begin1=%.6g,t_end1=%.6g,fxn1=%s,"
+            "t_begin2=%.6g,t_end2=%.6g,fxn2=%s,"
+            "norm_min=%.6g,norm_max=%.6g,mode=%s"
+        ) % (
+            self._t_begin1, self._t_end1, self._fxn1,
+            self._t_begin2, self._t_end2, self._fxn2,
+            self._norm_min, self._norm_max, self._mode,
+        )
+        if channel_name is not None:
+            note += ",channel=%s" % channel_name
+        note += ",ref_min=%.6g,ref_max=%.6g)" % (ref_min, ref_max)
+        return note
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run_init(self) -> None:
+        """Reset per-run accumulators."""
+        self._validate_windows()
+        self._ref_min_accum: dict[str, list[float]] = {}
+        self._ref_max_accum: dict[str, list[float]] = {}
+        self._data_refs: dict[str, list[NMData]] = {}
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Compute references and (optionally) normalize one wave.
+
+        Args:
+            data: The NMData object to process.
+            channel_name: Channel name from the selection context, or None
+                (parsed from data.name as a fallback).
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+
+        if channel_name is None:
+            parsed = nmu.parse_data_name(data.name)
+            channel_name = parsed[1] if parsed is not None else "A"
+
+        arr = data.nparray.astype(float)
+        xd = data.xscale.to_dict()
+        sl1 = _time_to_slice(arr, xd, self._t_begin1, self._t_end1)
+        sl2 = _time_to_slice(arr, xd, self._t_begin2, self._t_end2)
+        ref_min = _compute_ref(arr[sl1], self._fxn1, self._n_mean1)
+        ref_max = _compute_ref(arr[sl2], self._fxn2, self._n_mean2)
+
+        if self._mode == "per_wave":
+            data.nparray = self._apply(arr, ref_min, ref_max)
+            self._add_note(data, self._note_str(ref_min, ref_max))
+        else:  # "average"
+            self._ref_min_accum.setdefault(channel_name, []).append(ref_min)
+            self._ref_max_accum.setdefault(channel_name, []).append(ref_max)
+            self._data_refs.setdefault(channel_name, []).append(data)
+
+    def run_finish(
+        self,
+        folder: NMFolder | None = None,
+        prefix: str | None = None,
+    ) -> None:
+        """Apply averaged references (average mode only).
+
+        In ``per_wave`` mode this is a no-op (normalization was done in
+        ``run()``).  In ``average`` mode the mean of all per-wave references
+        for each channel is computed and applied to every wave in that channel.
+        """
+        if self._mode == "per_wave":
+            return
+        for channel_name, ref_mins in self._ref_min_accum.items():
+            avg_ref_min = float(np.nanmean(ref_mins))
+            avg_ref_max = float(np.nanmean(self._ref_max_accum[channel_name]))
+            for d in self._data_refs[channel_name]:
+                arr = d.nparray.astype(float)
+                d.nparray = self._apply(arr, avg_ref_min, avg_ref_max)
+                self._add_note(d, self._note_str(avg_ref_min, avg_ref_max, channel_name))
+
+
+# =========================================================================
 # Registry and lookup
 # =========================================================================
 
@@ -1068,6 +1413,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "differentiate": NMMainOpDifferentiate,
     "insert_points": NMMainOpInsertPoints,
     "integrate": NMMainOpIntegrate,
+    "normalize": NMMainOpNormalize,
     "redimension": NMMainOpRedimension,
     "replace_values": NMMainOpReplaceValues,
     "reverse": NMMainOpReverse,

--- a/pyneuromatic/analysis/nm_stat_func.py
+++ b/pyneuromatic/analysis/nm_stat_func.py
@@ -217,56 +217,56 @@ class NMStatFuncMaxMin(NMStatFunc):
 
     Accepted names: max, min, mean@max, mean@min.
 
-    When ``n_avg`` is provided for a ``"max"`` or ``"min"`` name, the name is
+    When ``n_mean`` is provided for a ``"max"`` or ``"min"`` name, the name is
     upgraded to ``"mean@max"`` or ``"mean@min"`` automatically.
 
     Args:
         name: One of the names in ``FUNC_NAMES_MAXMIN``.
-        n_avg: Number of points to average around the peak location. Required
+        n_mean: Number of points to compute mean around peak location. Required
             for ``mean@max`` / ``mean@min``; upgrades ``max`` / ``min`` when
             provided.
     """
 
-    _VALID_KEYS = {"n_avg"}
+    _VALID_KEYS = {"n_mean"}
 
     def __init__(
-        self, name: str, n_avg: int | None = None,
+        self, name: str, n_mean: int | None = None,
     ) -> None:
         if name.lower() not in FUNC_NAMES_MAXMIN:
             raise ValueError("func name: '%s'" % name)
         f = name.lower()
         if f in ("mean@max", "mean@min"):
-            if n_avg is None:
-                raise KeyError("missing func key 'n_avg'")
-        if n_avg is not None:
-            if isinstance(n_avg, bool):
-                raise TypeError("n_avg: '%s'" % n_avg)
-            n_avg = int(n_avg)  # raises TypeError/ValueError/OverflowError
-            if n_avg < 0:
-                raise ValueError("n_avg: '%s'" % n_avg)
-            # Upgrade max→mean@max, min→mean@min when n_avg is provided
+            if n_mean is None:
+                raise KeyError("missing func key 'n_mean'")
+        if n_mean is not None:
+            if isinstance(n_mean, bool):
+                raise TypeError("n_mean: '%s'" % n_mean)
+            n_mean = int(n_mean)  # raises TypeError/ValueError/OverflowError
+            if n_mean < 0:
+                raise ValueError("n_mean: '%s'" % n_mean)
+            # Upgrade max→mean@max, min→mean@min when n_mean is provided
             if f == "max":
                 f = "mean@max"
             elif f == "min":
                 f = "mean@min"
         super().__init__(f)
-        self._n_avg = n_avg
+        self._n_mean = n_mean
 
     def to_dict(self) -> dict:
         d = {"name": self._name}
-        if self._n_avg is not None:
-            d["n_avg"] = self._n_avg
+        if self._n_mean is not None:
+            d["n_mean"] = self._n_mean
         return d
 
     def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
                 bsln_result):
-        """Run the max/min stat; warn if n_avg <= 1 for mean@ variants."""
+        """Run the max/min stat; warn if n_mean <= 1 for mean@ variants."""
         func: dict[str, Any] = {"name": self._name}
-        if self._n_avg is not None:
-            func["n_avg"] = self._n_avg
+        if self._n_mean is not None:
+            func["n_mean"] = self._n_mean
         if self._name in ("mean@max", "mean@min"):
-            n_avg = self._n_avg if self._n_avg is not None else 0
-            if n_avg <= 1:
+            n_mean = self._n_mean if self._n_mean is not None else 0
+            if n_mean <= 1:
                 func["warning"] = "not enough data points to compute a mean"
         r = run_stat(data, func, "main", x0, x1, xclip, ignore_nans)
         self._add_ds(r, bsln_result)
@@ -851,7 +851,7 @@ def _stat_func_from_dict(
 
     Args:
         d: Dict with at least a ``"name"`` key, a bare string func name,
-            or None. Additional keys (``"p0"``, ``"n_avg"``, etc.) are
+            or None. Additional keys (``"p0"``, ``"n_mean"``, etc.) are
             forwarded to the subclass constructor.
 
     Returns:

--- a/pyneuromatic/analysis/nm_stat_utilities.py
+++ b/pyneuromatic/analysis/nm_stat_utilities.py
@@ -37,8 +37,8 @@ def _stat_maxmin(f, func, yarray, data, i0, ysize, ignore_nans, results,
                  yunits, **_):
     """Compute max or min value and its location.
 
-    For mean@max and mean@min, also compute the mean of n_avg points centred
-    on the peak index (func["n_avg"] key, optional).
+    For mean@max and mean@min, also compute the mean of n_mean points centred
+    on the peak index (func["n_mean"] key, optional).
     """
     if "max" in f:
         index = np.nanargmax(yarray) if ignore_nans else np.argmax(yarray)
@@ -51,19 +51,19 @@ def _stat_maxmin(f, func, yarray, data, i0, ysize, ignore_nans, results,
     results["x"] = data.get_xvalue(i)
     results["xunits"] = data.xscale.units
 
-    n_avg = 0
-    if "n_avg" in func and 0 <= i < ysize:
-        n_avg = int(func["n_avg"])
-        if n_avg <= 1:
-            n_avg = 0
+    n_mean = 0
+    if "n_mean" in func and 0 <= i < ysize:
+        n_mean = int(func["n_mean"])
+        if n_mean <= 1:
+            n_mean = 0
 
-    if n_avg > 1:
-        if n_avg % 2 == 0:  # even
-            i0_m = int(i - 0.5 * n_avg)
-            i1_m = int(i0_m + n_avg - 1)
+    if n_mean > 1:
+        if n_mean % 2 == 0:  # even
+            i0_m = int(i - 0.5 * n_mean)
+            i1_m = int(i0_m + n_mean - 1)
         else:  # odd
-            i0_m = int(i - 0.5 * (n_avg - 1))
-            i1_m = int(i + 0.5 * (n_avg - 1))
+            i0_m = int(i - 0.5 * (n_mean - 1))
+            i1_m = int(i + 0.5 * (n_mean - 1))
         i0_m = max(i0_m, 0)
         i0_m = min(i0_m, ysize - 1)
         i1_m = max(i1_m, 0)
@@ -328,9 +328,9 @@ def stat(
             - mean+var / mean+std / mean+sem:
               no extra keys required; extra stat appended to results.
             - max / min:
-              optional "n_avg" (int) to average that many points around peak.
+              optional "n_mean" (int) # points to compute mean around peak.
             - mean@max / mean@min:
-              "n_avg" (int) required; mean of n_avg points around peak.
+              "n_mean" (int) required; mean of n_mean points around peak.
             - level / level+ / level-:
               "ylevel" (float) required; the y-axis threshold to search for.
             - slope:

--- a/tests/test_analysis/test_nm_stat_func.py
+++ b/tests/test_analysis/test_nm_stat_func.py
@@ -138,43 +138,43 @@ class TestNMStatFuncMaxMin(unittest.TestCase):
         with self.assertRaises(ValueError):
             nmsf.NMStatFuncMaxMin("badfuncname")
 
-    def test_mean_at_max_requires_n_avg(self):
+    def test_mean_at_max_requires_n_mean(self):
         with self.assertRaises(KeyError):
             nmsf.NMStatFuncMaxMin("mean@max")
 
-    def test_n_avg_type_errors(self):
+    def test_n_mean_type_errors(self):
         for b in [[], (), {}, set(), NM, True, False]:
             with self.assertRaises(TypeError):
-                nmsf.NMStatFuncMaxMin("mean@max", n_avg=b)
+                nmsf.NMStatFuncMaxMin("mean@max", n_mean=b)
 
-    def test_n_avg_value_errors(self):
+    def test_n_mean_value_errors(self):
         for b in [-10, math.nan, "badvalue"]:
             with self.assertRaises(ValueError):
-                nmsf.NMStatFuncMaxMin("mean@max", n_avg=b)
+                nmsf.NMStatFuncMaxMin("mean@max", n_mean=b)
 
-    def test_n_avg_overflow(self):
+    def test_n_mean_overflow(self):
         with self.assertRaises(OverflowError):
-            nmsf.NMStatFuncMaxMin("mean@max", n_avg=math.inf)
+            nmsf.NMStatFuncMaxMin("mean@max", n_mean=math.inf)
 
-    def test_max_min_without_n_avg(self):
+    def test_max_min_without_n_mean(self):
         for f in ("max", "min"):
             t = nmsf.NMStatFuncMaxMin(f)
             self.assertEqual(t.name, f)
             self.assertEqual(t.to_dict(), {"name": f})
 
-    def test_n_avg_upgrades_to_mean_at(self):
+    def test_n_mean_upgrades_to_mean_at(self):
         for f in ["max", "min", "mean@max", "mean@min"]:
-            t = nmsf.NMStatFuncMaxMin(f, n_avg=10)
+            t = nmsf.NMStatFuncMaxMin(f, n_mean=10)
             expected = ("mean@" + f) if f in ("max", "min") else f
             self.assertEqual(t.name, expected)
-            self.assertEqual(t.to_dict()["n_avg"], 10)
+            self.assertEqual(t.to_dict()["n_mean"], 10)
 
     def test_from_dict(self):
         for f in ["max", "min", "mean@max", "mean@min"]:
-            t = nmsf._stat_func_from_dict({"name": f, "n_avg": 10})
+            t = nmsf._stat_func_from_dict({"name": f, "n_mean": 10})
             expected = ("mean@" + f) if f in ("max", "min") else f
             self.assertEqual(t.name, expected)
-            self.assertEqual(t["n_avg"], 10)
+            self.assertEqual(t["n_mean"], 10)
 
     def test_from_dict_unknown_key_raises(self):
         with self.assertRaises(KeyError):
@@ -603,14 +603,14 @@ class TestStatFuncFromDict(unittest.TestCase):
             self.assertIsInstance(t, nmsf.NMStatFuncBasic)
             self.assertEqual(t.name, f)
 
-    def test_maxmin_without_n_avg(self):
+    def test_maxmin_without_n_mean(self):
         for f in ("max", "min"):
             t = nmsf._stat_func_from_dict({"name": f})
             self.assertEqual(t.name, f)
 
-    def test_maxmin_with_n_avg(self):
+    def test_maxmin_with_n_mean(self):
         for f in ("mean@max", "mean@min"):
-            t = nmsf._stat_func_from_dict({"name": f, "n_avg": 5})
+            t = nmsf._stat_func_from_dict({"name": f, "n_mean": 5})
             self.assertEqual(t.name, f)
 
     def test_level_ylevel(self):

--- a/tests/test_analysis/test_nm_stat_igor.py
+++ b/tests/test_analysis/test_nm_stat_igor.py
@@ -51,7 +51,7 @@ _IGOR_R0 = {
 }
 
 _X0, _X1 = 500.0, 1000.0  # ms
-_N_AVG = 500  # n_avg for mean@max and mean@min (10 ms window at 0.02 ms sampling)
+_N_MEAN = 500  # n_mean for mean@max and mean@min (10 ms window at 0.02 ms sampling)
 
 # ---------------------------------------------------------------------------
 # Sine wave test parameters
@@ -215,23 +215,23 @@ class TestIgorWaveStats(unittest.TestCase):
         self.assertAlmostEqual(r["s"], _IGOR_R0["value@xend"], places=4)
 
     def test_mean_at_max(self):
-        # n_avg=500 determined by matching Igor minAvg/maxAvg to 3 decimal places
-        r = nsmm.stat(_DATA, {"name": "mean@max", "n_avg": _N_AVG},
+        # n_mean=500 determined by matching Igor minAvg/maxAvg to 3 decimal places
+        r = nsmm.stat(_DATA, {"name": "mean@max", "n_mean": _N_MEAN},
                       x0=_X0, x1=_X1, xclip=True)
         self.assertAlmostEqual(r["s"], _IGOR_R0["maxAvg"], places=3)
 
     def test_mean_at_max_location(self):
-        r = nsmm.stat(_DATA, {"name": "mean@max", "n_avg": _N_AVG},
+        r = nsmm.stat(_DATA, {"name": "mean@max", "n_mean": _N_MEAN},
                       x0=_X0, x1=_X1, xclip=True)
         self.assertAlmostEqual(r["x"], _IGOR_R0["maxAvgLoc"], places=1)
 
     def test_mean_at_min(self):
-        r = nsmm.stat(_DATA, {"name": "mean@min", "n_avg": _N_AVG},
+        r = nsmm.stat(_DATA, {"name": "mean@min", "n_mean": _N_MEAN},
                       x0=_X0, x1=_X1, xclip=True)
         self.assertAlmostEqual(r["s"], _IGOR_R0["minAvg"], places=3)
 
     def test_mean_at_min_location(self):
-        r = nsmm.stat(_DATA, {"name": "mean@min", "n_avg": _N_AVG},
+        r = nsmm.stat(_DATA, {"name": "mean@min", "n_mean": _N_MEAN},
                       x0=_X0, x1=_X1, xclip=True)
         self.assertAlmostEqual(r["x"], _IGOR_R0["minAvgLoc"], places=1)
 

--- a/tests/test_analysis/test_nm_stat_win.py
+++ b/tests/test_analysis/test_nm_stat_win.py
@@ -151,16 +151,16 @@ class TestNMStatWin(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.w1.func = {"name": "badname"}
 
-    def test_func_set_maxmin_n_avg(self):
-        self.w1._func_set({"name": "mean@max", "n_avg": 7})
-        self.w1._func_set({"n_avg": "3"})
+    def test_func_set_maxmin_n_mean(self):
+        self.w1._func_set({"name": "mean@max", "n_mean": 7})
+        self.w1._func_set({"n_mean": "3"})
         self.assertEqual(self.w1.func["name"], "mean@max")
-        self.assertEqual(self.w1.func["n_avg"], 3)
+        self.assertEqual(self.w1.func["n_mean"], 3)
 
-    def test_func_set_maxmin_n_avg_bool_raises(self):
-        self.w1._func_set({"name": "mean@max", "n_avg": 7})
+    def test_func_set_maxmin_n_mean_bool_raises(self):
+        self.w1._func_set({"name": "mean@max", "n_mean": 7})
         with self.assertRaises(TypeError):
-            self.w1._func_set({"n_avg": True})
+            self.w1._func_set({"n_mean": True})
 
     def test_func_set_level(self):
         self.w1._func_set({"name": "level+", "ylevel": -10})
@@ -305,7 +305,7 @@ class TestNMStatWin(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.w1.bsln_func = {"name": "badname"}
         with self.assertRaises(ValueError):
-            self.w1._bsln_func_set({"name": "mean@max", "n_avg": 7})
+            self.w1._bsln_func_set({"name": "mean@max", "n_mean": 7})
 
     def test_results_list(self):
         self.assertIsInstance(self.w1.results, list)
@@ -349,18 +349,18 @@ class TestNMStatWin(unittest.TestCase):
         self.assertTrue(np.isnan(r[1]["Δs"]))
 
     def test_compute_mean_at_max_warning(self):
-        self.w1.func = {"name": "mean@max", "n_avg": 0}
+        self.w1.func = {"name": "mean@max", "n_mean": 0}
         r = self.w1.compute(self.datanan, xclip=True, ignore_nans=True)
         self.assertIn("warning", r[1]["func"])
 
-    def test_compute_mean_at_max_with_n_avg(self):
-        self.w1.func = {"name": "mean@max", "n_avg": 5}
+    def test_compute_mean_at_max_with_n_mean(self):
+        self.w1.func = {"name": "mean@max", "n_mean": 5}
         r = self.w1.compute(self.datanan, xclip=True, ignore_nans=True)
         self.assertEqual(r[1]["func"]["name"], "mean@max")
-        self.assertEqual(r[1]["func"]["n_avg"], 5)
+        self.assertEqual(r[1]["func"]["n_mean"], 5)
 
     def test_compute_mean_at_min(self):
-        self.w1.func = {"name": "mean@min", "n_avg": 5}
+        self.w1.func = {"name": "mean@min", "n_mean": 5}
         r = self.w1.compute(self.datanan, xclip=True, ignore_nans=True)
         self.assertEqual(r[1]["func"]["name"], "mean@min")
 

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -23,6 +23,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpDifferentiate,
     NMMainOpInsertPoints,
     NMMainOpIntegrate,
+    NMMainOpNormalize,
     NMMainOpRedimension,
     NMMainOpReplaceValues,
     NMMainOpReverse,
@@ -620,6 +621,10 @@ class TestOpFromName(unittest.TestCase):
         op = op_from_name("delete_nans")
         self.assertIsInstance(op, NMMainOpDeleteNaNs)
 
+    def test_normalize_by_name(self):
+        op = op_from_name("normalize")
+        self.assertIsInstance(op, NMMainOpNormalize)
+
     def test_case_insensitive(self):
         op = op_from_name("AVERAGE")
         self.assertIsInstance(op, NMMainOpAverage)
@@ -1196,8 +1201,217 @@ class TestNMMainOpDeleteNaNs(unittest.TestCase):
 
 
 # ===========================================================================
+# TestNMMainOpNormalize
+# ===========================================================================
+
+
+class TestNMMainOpNormalize(unittest.TestCase):
+    """Tests for NMMainOpNormalize (per_wave and average modes)."""
+
+    # ------------------------------------------------------------------
+    # per_wave mode — correct values
+
+    def test_per_wave_min_max(self):
+        # [0,5,10], fxn1=min→0, fxn2=max→10, range=10 → [0.0, 0.5, 1.0]
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=2.0, fxn1="min",
+            t_begin2=0.0, t_end2=2.0, fxn2="max",
+        )
+        data = _make_data("RecordA0", [0.0, 5.0, 10.0])
+        op.run_init()
+        op.run(data, "A")
+        np.testing.assert_array_almost_equal(data.nparray, [0.0, 0.5, 1.0])
+
+    def test_per_wave_mean_zero_range(self):
+        # fxn1=mean and fxn2=mean over same window → ref_min==ref_max → norm_min everywhere
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=4.0, fxn1="mean",
+            t_begin2=0.0, t_end2=4.0, fxn2="mean",
+            norm_min=-99.0,
+        )
+        data = _make_data("RecordA0", [0.0, 2.0, 4.0, 6.0, 8.0])
+        op.run_init()
+        op.run(data, "A")
+        np.testing.assert_array_equal(data.nparray, [-99.0] * 5)
+
+    def test_per_wave_uses_windows(self):
+        # [0,1,2,3,4] xdelta=1; window1=[0,0]→first point(0), window2=[4,4]→last point(4)
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=0.0, fxn1="mean",
+            t_begin2=4.0, t_end2=4.0, fxn2="mean",
+        )
+        data = _make_data("RecordA0", [0.0, 1.0, 2.0, 3.0, 4.0])
+        op.run_init()
+        op.run(data, "A")
+        np.testing.assert_array_almost_equal(data.nparray, [0.0, 0.25, 0.5, 0.75, 1.0])
+
+    def test_per_wave_custom_norm_range(self):
+        # norm_min=-1, norm_max=1; [0,5,10]→ref_min=0,ref_max=10 → [-1,0,1]
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=2.0, fxn1="min",
+            t_begin2=0.0, t_end2=2.0, fxn2="max",
+            norm_min=-1.0, norm_max=1.0,
+        )
+        data = _make_data("RecordA0", [0.0, 5.0, 10.0])
+        op.run_init()
+        op.run(data, "A")
+        np.testing.assert_array_almost_equal(data.nparray, [-1.0, 0.0, 1.0])
+
+    def test_per_wave_mean_at_min(self):
+        # [3,1,2], fxn1=mean@min, n_mean1=3; min at i=1, mean of [3,1,2]=2.0 → ref_min=2.0
+        # fxn2=max → ref_max=3.0; range=1; normalized: arr-2.0 → [1,-1,0]
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=2.0, fxn1="mean@min", n_mean1=3,
+            t_begin2=0.0, t_end2=2.0, fxn2="max",
+        )
+        data = _make_data("RecordA0", [3.0, 1.0, 2.0])
+        op.run_init()
+        op.run(data, "A")
+        np.testing.assert_array_almost_equal(data.nparray, [1.0, -1.0, 0.0])
+
+    def test_per_wave_mean_at_max(self):
+        # [1,5,3], fxn2=mean@max, n_mean2=3; max at i=1, mean of [1,5,3]=3.0 → ref_max=3.0
+        # fxn1=min → ref_min=1.0; range=2; normalized: (arr-1)/2 → [0,2,1]
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=2.0, fxn1="min",
+            t_begin2=0.0, t_end2=2.0, fxn2="mean@max", n_mean2=3,
+        )
+        data = _make_data("RecordA0", [1.0, 5.0, 3.0])
+        op.run_init()
+        op.run(data, "A")
+        np.testing.assert_array_almost_equal(data.nparray, [0.0, 2.0, 1.0])
+
+    def test_per_wave_preserves_length(self):
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=99.0, fxn1="min",
+            t_begin2=0.0, t_end2=99.0, fxn2="max",
+        )
+        data = _make_data("RecordA0", list(range(100)))
+        op.run_init()
+        op.run(data, "A")
+        self.assertEqual(len(data.nparray), 100)
+
+    # ------------------------------------------------------------------
+    # average mode
+
+    def test_average_mode_shared_refs(self):
+        # 2 waves same channel; ref_mins=[0,2]→avg=1, ref_maxes=[4,6]→avg=5, range=4
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=1.0, fxn1="min",
+            t_begin2=0.0, t_end2=1.0, fxn2="max",
+            mode="average",
+        )
+        d0 = _make_data("RecordA0", [0.0, 4.0])
+        d1 = _make_data("RecordA1", [2.0, 6.0])
+        op.run_all([(d0, "A"), (d1, "A")], folder=None)
+        np.testing.assert_array_almost_equal(d0.nparray, [-0.25, 0.75])
+        np.testing.assert_array_almost_equal(d1.nparray, [0.25, 1.25])
+
+    def test_average_mode_per_channel(self):
+        # Channel A ref_max=10, channel B ref_max=5 — independent
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=1.0, fxn1="min",
+            t_begin2=0.0, t_end2=1.0, fxn2="max",
+            mode="average",
+        )
+        dA = _make_data("RecordA0", [0.0, 10.0])
+        dB = _make_data("RecordB0", [0.0, 5.0])
+        op.run_all([(dA, "A"), (dB, "B")], folder=None)
+        np.testing.assert_array_almost_equal(dA.nparray, [0.0, 1.0])
+        np.testing.assert_array_almost_equal(dB.nparray, [0.0, 1.0])
+        # Verify each channel's note has its own ref_max
+        note_A = dA.notes[0]["note"]
+        note_B = dB.notes[0]["note"]
+        self.assertIn("ref_max=10", note_A)
+        self.assertIn("ref_max=5", note_B)
+
+    # ------------------------------------------------------------------
+    # validation
+
+    def test_fxn1_rejects_unknown(self):
+        with self.assertRaises(ValueError):
+            NMMainOpNormalize(fxn1="bad")
+
+    def test_fxn1_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            NMMainOpNormalize(fxn1=42)
+
+    def test_fxn2_rejects_unknown(self):
+        with self.assertRaises(ValueError):
+            NMMainOpNormalize(fxn2="bad")
+
+    def test_n_mean1_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpNormalize(n_mean1=True)
+
+    def test_n_mean1_rejects_zero(self):
+        with self.assertRaises(ValueError):
+            NMMainOpNormalize(n_mean1=0)
+
+    def test_norm_min_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpNormalize(norm_min=True)
+
+    def test_norm_max_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpNormalize(norm_max=False)
+
+    def test_mode_rejects_unknown(self):
+        with self.assertRaises(ValueError):
+            NMMainOpNormalize(mode="bad")
+
+    def test_t_end1_before_t_begin1_raises(self):
+        op = NMMainOpNormalize(t_begin1=5.0, t_end1=0.0)
+        with self.assertRaises(ValueError):
+            op.run_init()
+
+    # ------------------------------------------------------------------
+    # edge cases / notes
+
+    def test_skips_non_ndarray(self):
+        op = NMMainOpNormalize()
+        d = NMData(NM, name="RecordA0")  # no nparray
+        op.run_init()
+        op.run(d, "A")  # should not raise
+        self.assertEqual(len(d.notes), 0)
+
+    def test_note_per_wave(self):
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=2.0, fxn1="min",
+            t_begin2=0.0, t_end2=2.0, fxn2="max",
+            mode="per_wave",
+        )
+        data = _make_data("RecordA0", [0.0, 5.0, 10.0])
+        op.run_init()
+        op.run(data, "A")
+        self.assertEqual(len(data.notes), 1)
+        note = data.notes[0]["note"]
+        self.assertIn("NMNormalize", note)
+        self.assertIn("mode=per_wave", note)
+        self.assertIn("ref_min=", note)
+        self.assertIn("ref_max=", note)
+
+    def test_note_average(self):
+        op = NMMainOpNormalize(
+            t_begin1=0.0, t_end1=1.0, fxn1="min",
+            t_begin2=0.0, t_end2=1.0, fxn2="max",
+            mode="average",
+        )
+        data = _make_data("RecordA0", [0.0, 10.0])
+        op.run_all([(data, "A")], folder=None)
+        self.assertEqual(len(data.notes), 1)
+        note = data.notes[0]["note"]
+        self.assertIn("NMNormalize", note)
+        self.assertIn("mode=average", note)
+        self.assertIn("channel=A", note)
+        self.assertIn("ref_min=", note)
+        self.assertIn("ref_max=", note)
+
+
+# ===========================================================================
 # TestNMToolMain
 # ===========================================================================
+
 
 class TestNMToolMain(unittest.TestCase):
     """Test NMToolMain.op property and end-to-end run_all()."""
@@ -1226,7 +1440,7 @@ class TestNMToolMain(unittest.TestCase):
 
     def test_op_setter_rejects_unknown_string(self):
         with self.assertRaises(ValueError):
-            self.tool.op = "normalize"
+            self.tool.op = "badopname"
 
     def test_op_setter_rejects_bad_type(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
## Summary
- Add `NMMainOpNormalize` for permanent amplitude normalization (closes #187)
- Add `_compute_ref()` module-level helper (supports `"mean"`, `"min"`, `"max"`, `"mean@min"`, `"mean@max"`)
- Register under key `"normalize"` in `_OP_REGISTRY`

## Test plan
- [x] `TestNMMainOpNormalize` — 22 tests covering per_wave values, window selection, custom norm range, `mean@min`/`mean@max`, average mode sharing and per-channel independence, validation errors, skip non-ndarray, note format
- [x] `test_normalize_by_name` — registry lookup
- [x] Full suite passes (1688 tests)

Closes #187