### PR TITLE
feat(analysis): add NMMainOpAccumulate base class with Sum, SumSqr, M…

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -117,23 +117,30 @@ class NMMainOp:
 
 
 # =========================================================================
-# Average
+# Accumulate (base for Average, Sum, SumSqr, Min, Max)
 # =========================================================================
 
 
-class NMMainOpAverage(NMMainOp):
-    """Average selected data waves per channel.
+class NMMainOpAccumulate(NMMainOp):
+    """Base class for ops that accumulate waves and reduce them per channel.
 
-    Accumulates arrays by channel, truncates all arrays to the shortest
-    length, and writes the mean as a new NMData wave
-    ``Avg_{prefix}{channel}`` (e.g. ``Avg_RecordA``) into the source folder.
+    Subclasses set two class attributes and override ``_reduce()``:
+
+    - ``_output_prefix``: prefix for the output wave name (e.g. ``"Avg_"``).
+    - ``_note_name``: op name used in the note string (e.g. ``"NMAverage"``).
+    - ``_reduce(stack)``: compute the per-channel result from the stacked array.
+
+    The full lifecycle is handled here: ``run_init`` resets buffers,
+    ``run`` accumulates per-channel arrays, and ``run_finish`` reduces
+    and writes one output wave per channel.
 
     Parameters:
-        ignore_nans: If True (default) use ``np.nanmean``; otherwise
-            ``np.mean`` (NaN propagates to the result).
+        ignore_nans: If True (default) use NaN-aware reductions
+            (``np.nanmean``, ``np.nansum``, etc.); otherwise NaN propagates.
     """
 
-    name = "average"
+    _output_prefix: str = ""
+    _note_name: str = ""
 
     def __init__(self, ignore_nans: bool = True) -> None:
         if not isinstance(ignore_nans, bool):
@@ -145,7 +152,7 @@ class NMMainOpAverage(NMMainOp):
 
     @property
     def ignore_nans(self) -> bool:
-        """If True, NaN values are excluded from the mean (np.nanmean)."""
+        """If True, NaN values are excluded from the reduction."""
         return self._ignore_nans
 
     @ignore_nans.setter
@@ -158,6 +165,22 @@ class NMMainOpAverage(NMMainOp):
     def results(self) -> dict[str, str]:
         """Read-only dict mapping channel name → output NMData name."""
         return dict(self._results)
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        """Reduce the stacked array to a single output array.
+
+        Args:
+            stack: 2-D array of shape (n_waves, n_points).
+
+        Returns:
+            1-D reduced array of shape (n_points,).
+
+        Raises:
+            NotImplementedError: If the subclass does not override this method.
+        """
+        raise NotImplementedError(
+            "%s._reduce() not implemented" % self.__class__.__name__
+        )
 
     def run_init(self) -> None:
         """Reset accumulation state for a new run."""
@@ -199,15 +222,89 @@ class NMMainOpAverage(NMMainOp):
         self._accum[channel_name].append(data.nparray.astype(float).copy())
         self._data_names.setdefault(channel_name, []).append(data.name)
 
+    def _epoch_str(self, cname: str) -> str:
+        """Format the epoch list for the note string."""
+        return nmu.format_epoch_string(self._data_names.get(cname, []))
+
+    def _make_note_str(
+        self,
+        note_name: str,
+        folder_name: str,
+        ds_name: str,
+        cname: str,
+        epoch_str: str,
+        n: int,
+    ) -> str:
+        """Build the note string for an output wave."""
+        return (
+            "%s(folder=%s,dataseries=%s,channel=%s,epochs=%s,n_epochs=%d)"
+            % (note_name, folder_name, ds_name, cname, epoch_str, n)
+        )
+
+    def _write_output_wave(
+        self,
+        folder: NMFolder,
+        out_name: str,
+        arr: np.ndarray,
+        note_name: str,
+        folder_name: str,
+        ds_name: str,
+        cname: str,
+        epoch_str: str,
+        n: int,
+    ) -> None:
+        """Create an output wave in folder and add a note to it."""
+        folder.data.new(
+            out_name,
+            nparray=arr,
+            xscale=self._xscales[cname],
+            yscale=self._yscales[cname],
+        )
+        out_data = folder.data.get(out_name)
+        if out_data is not None:
+            self._add_note(
+                out_data,
+                self._make_note_str(note_name, folder_name, ds_name, cname, epoch_str, n),
+            )
+
+    def _process_channel(
+        self,
+        folder: NMFolder,
+        pfx: str,
+        cname: str,
+        arrays: list[np.ndarray],
+    ) -> None:
+        """Reduce and write one output wave for a single channel.
+
+        Subclasses may override to write additional output waves (e.g.
+        Stdv, Var, SEM alongside the mean).
+
+        Args:
+            folder: Destination NMFolder.
+            pfx: Dataseries prefix for the output wave name.
+            cname: Channel name.
+            arrays: List of accumulated arrays for this channel.
+        """
+        min_len = min(len(a) for a in arrays)
+        stack = np.stack([a[:min_len] for a in arrays])
+        n = len(arrays)
+        epoch_str = self._epoch_str(cname)
+        arr = self._reduce(stack)
+        out_name = self._output_prefix + pfx + cname
+        self._write_output_wave(
+            folder, out_name, arr, self._note_name, folder.name, pfx, cname, epoch_str, n
+        )
+        self._results[cname] = out_name
+
     def run_finish(
         self,
         folder: NMFolder | None = None,
         prefix: str | None = None,
     ) -> None:
-        """Compute the mean and write one output wave per channel to folder.
+        """Reduce and write one output wave per channel to folder.
 
         Args:
-            folder: Destination NMFolder for the averaged waves.
+            folder: Destination NMFolder for the output waves.
             prefix: Dataseries name used as the output wave prefix.  Falls
                 back to the prefix parsed from the first wave name if None.
         """
@@ -216,39 +313,195 @@ class NMMainOpAverage(NMMainOp):
 
         pfx = prefix if prefix is not None else (self._parsed_prefix or "")
         for cname, arrays in self._accum.items():
-            min_len = min(len(a) for a in arrays)
-            stack = np.stack([a[:min_len] for a in arrays])
-            avg = np.nanmean(stack, axis=0) if self._ignore_nans else np.mean(stack, axis=0)
-            out_name = "Avg_" + pfx + cname
-            folder.data.new(
-                out_name,
-                nparray=avg,
-                xscale=self._xscales[cname],
-                yscale=self._yscales[cname],
+            self._process_channel(folder, pfx, cname, arrays)
+
+
+# =========================================================================
+# Average
+# =========================================================================
+
+
+class NMMainOpAverage(NMMainOpAccumulate):
+    """Average selected data waves per channel.
+
+    Accumulates arrays by channel, truncates all arrays to the shortest
+    length, and writes the mean as ``Avg_{prefix}{channel}``
+    (e.g. ``Avg_RecordA``) into the source folder.
+
+    Optionally also writes Stdv, Var, and/or SEM waves (sample statistics,
+    ``ddof=1``) when the corresponding ``compute_*`` parameter is True.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nanmean``; otherwise
+            ``np.mean`` (NaN propagates to the result).
+        compute_stdv: If True, write ``Stdv_{prefix}{channel}`` (default False).
+        compute_var: If True, write ``Var_{prefix}{channel}`` (default False).
+        compute_sem: If True, write ``SEM_{prefix}{channel}`` (default False).
+    """
+
+    name = "average"
+    _output_prefix = "Avg_"
+    _note_name = "NMAverage"
+
+    def __init__(
+        self,
+        ignore_nans: bool = True,
+        compute_stdv: bool = False,
+        compute_var: bool = False,
+        compute_sem: bool = False,
+    ) -> None:
+        super().__init__(ignore_nans)
+        self.compute_stdv = compute_stdv  # setters validate bool
+        self.compute_var = compute_var
+        self.compute_sem = compute_sem
+
+    @property
+    def compute_stdv(self) -> bool:
+        """If True, write a Stdv output wave alongside the mean."""
+        return self._compute_stdv
+
+    @compute_stdv.setter
+    def compute_stdv(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "compute_stdv", "boolean"))
+        self._compute_stdv = value
+
+    @property
+    def compute_var(self) -> bool:
+        """If True, write a Var output wave alongside the mean."""
+        return self._compute_var
+
+    @compute_var.setter
+    def compute_var(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "compute_var", "boolean"))
+        self._compute_var = value
+
+    @property
+    def compute_sem(self) -> bool:
+        """If True, write a SEM output wave alongside the mean."""
+        return self._compute_sem
+
+    @compute_sem.setter
+    def compute_sem(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "compute_sem", "boolean"))
+        self._compute_sem = value
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        return np.nanmean(stack, axis=0) if self._ignore_nans else np.mean(stack, axis=0)
+
+    def _process_channel(
+        self,
+        folder: NMFolder,
+        pfx: str,
+        cname: str,
+        arrays: list[np.ndarray],
+    ) -> None:
+        """Write mean wave, then optionally Stdv/Var/SEM waves."""
+        super()._process_channel(folder, pfx, cname, arrays)
+        if not (self._compute_stdv or self._compute_var or self._compute_sem):
+            return
+        min_len = min(len(a) for a in arrays)
+        stack = np.stack([a[:min_len] for a in arrays])
+        n = len(arrays)
+        epoch_str = self._epoch_str(cname)
+        std_fn = np.nanstd if self._ignore_nans else np.std
+        std = std_fn(stack, axis=0, ddof=1)
+        if self._compute_stdv:
+            self._write_output_wave(
+                folder, "Stdv_" + pfx + cname, std,
+                "NMStdv", folder.name, pfx, cname, epoch_str, n,
             )
-            out_data = folder.data.get(out_name)
-            if out_data is not None:
-                n = len(arrays)
-                ds_name = prefix if prefix is not None else (self._parsed_prefix or "")
-                epoch_nums = []
-                for dname in self._data_names.get(cname, []):
-                    parsed = nmu.parse_data_name(dname)
-                    epoch_nums.append(str(parsed[2]) if parsed is not None else dname)
-                try:
-                    ints = [int(e) for e in epoch_nums]
-                    lo, hi = min(ints), max(ints)
-                    if len(ints) > 1 and ints == list(range(lo, hi + 1)):
-                        epoch_str = "%d-%d" % (lo, hi)
-                    else:
-                        epoch_str = "[" + ",".join(epoch_nums) + "]"
-                except ValueError:
-                    epoch_str = "[" + ",".join(epoch_nums) + "]"
-                self._add_note(
-                    out_data,
-                    "NMAverage(folder=%s,dataseries=%s,channel=%s,epochs=%s,n_epochs=%d)"
-                    % (folder.name, ds_name, cname, epoch_str, n),
-                )
-            self._results[cname] = out_name
+        if self._compute_var:
+            self._write_output_wave(
+                folder, "Var_" + pfx + cname, std ** 2,
+                "NMVar", folder.name, pfx, cname, epoch_str, n,
+            )
+        if self._compute_sem:
+            self._write_output_wave(
+                folder, "SEM_" + pfx + cname, std / np.sqrt(n),
+                "NMSEM", folder.name, pfx, cname, epoch_str, n,
+            )
+
+
+# =========================================================================
+# Sum, SumSqr, Min, Max  (NMMainOpAccumulate subclasses)
+# =========================================================================
+
+
+class NMMainOpSum(NMMainOpAccumulate):
+    """Sum selected data waves point-by-point per channel.
+
+    Writes ``Sum_{prefix}{channel}`` (e.g. ``Sum_RecordA``) to the folder.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nansum`` (NaN treated as 0);
+            otherwise ``np.sum`` (NaN propagates).
+    """
+
+    name = "sum"
+    _output_prefix = "Sum_"
+    _note_name = "NMSum"
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        return np.nansum(stack, axis=0) if self._ignore_nans else np.sum(stack, axis=0)
+
+
+class NMMainOpSumSqr(NMMainOpAccumulate):
+    """Sum of squares of selected data waves point-by-point per channel.
+
+    Squares each wave then sums, writing ``SumSqr_{prefix}{channel}``
+    (e.g. ``SumSqr_RecordA``) to the folder.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nansum`` on the squared array;
+            otherwise ``np.sum`` (NaN propagates).
+    """
+
+    name = "sum_sqr"
+    _output_prefix = "SumSqr_"
+    _note_name = "NMSumSqr"
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        sq = stack ** 2
+        return np.nansum(sq, axis=0) if self._ignore_nans else np.sum(sq, axis=0)
+
+
+class NMMainOpMin(NMMainOpAccumulate):
+    """Point-by-point minimum across selected data waves per channel.
+
+    Writes ``Min_{prefix}{channel}`` (e.g. ``Min_RecordA``) to the folder.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nanmin`` (NaN ignored);
+            otherwise ``np.min`` (NaN propagates).
+    """
+
+    name = "min"
+    _output_prefix = "Min_"
+    _note_name = "NMMin"
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        return np.nanmin(stack, axis=0) if self._ignore_nans else np.min(stack, axis=0)
+
+
+class NMMainOpMax(NMMainOpAccumulate):
+    """Point-by-point maximum across selected data waves per channel.
+
+    Writes ``Max_{prefix}{channel}`` (e.g. ``Max_RecordA``) to the folder.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nanmax`` (NaN ignored);
+            otherwise ``np.max`` (NaN propagates).
+    """
+
+    name = "max"
+    _output_prefix = "Max_"
+    _note_name = "NMMax"
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        return np.nanmax(stack, axis=0) if self._ignore_nans else np.max(stack, axis=0)
 
 
 # =========================================================================
@@ -1413,12 +1666,16 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "differentiate": NMMainOpDifferentiate,
     "insert_points": NMMainOpInsertPoints,
     "integrate": NMMainOpIntegrate,
+    "max": NMMainOpMax,
+    "min": NMMainOpMin,
     "normalize": NMMainOpNormalize,
     "redimension": NMMainOpRedimension,
     "replace_values": NMMainOpReplaceValues,
     "reverse": NMMainOpReverse,
     "rotate": NMMainOpRotate,
     "scale": NMMainOpScale,
+    "sum": NMMainOpSum,
+    "sum_sqr": NMMainOpSumSqr,
 }
 
 

--- a/pyneuromatic/core/nm_utilities.py
+++ b/pyneuromatic/core/nm_utilities.py
@@ -561,9 +561,74 @@ def parse_data_name(
     return (prefix, channel_char, epoch_num)
 
 
+def format_epoch_string(data_names: list[str]) -> str:
+    """Format a list of wave names as a compact epoch string for notes.
+
+    Extracts epoch numbers via ``parse_data_name``, sorts them, then chooses
+    the most compact representation:
+
+    1. **Consecutive** (step = 1, n ≥ 2): ``"0-9"``
+    2. **Arithmetic series** (constant step > 1, n ≥ 3): ``"1-13:3"``
+    3. **Grouped ranges** (multiple consecutive runs): ``"[0-4,10-14]"``
+    4. **Everything else**: ``"[0,2,5]"``
+
+    Args:
+        data_names: List of NMData wave names (e.g. ``["RecordA0", "RecordA2"]``).
+
+    Returns:
+        Compact epoch string.
+
+    Examples:
+        >>> format_epoch_string(["RecordA0", "RecordA1", "RecordA2"])
+        '0-2'
+        >>> format_epoch_string(["RecordA1", "RecordA4", "RecordA7", "RecordA10"])
+        '1-10:3'
+        >>> format_epoch_string(["RecordA0", "RecordA1", "RecordA10", "RecordA11"])
+        '[0-1,10-11]'
+        >>> format_epoch_string(["RecordA0", "RecordA2", "RecordA5"])
+        '[0,2,5]'
+    """
+    epoch_nums = []
+    for dname in data_names:
+        parsed = parse_data_name(dname)
+        epoch_nums.append(str(parsed[2]) if parsed is not None else dname)
+    try:
+        ints = sorted(int(e) for e in epoch_nums)
+    except ValueError:
+        return "[" + ",".join(epoch_nums) + "]"
+
+    if not ints:
+        return "[]"
+
+    lo, hi = ints[0], ints[-1]
+
+    if len(ints) == 1:
+        return "[%d]" % lo
+
+    # Case 1: all consecutive (step = 1)
+    if ints == list(range(lo, hi + 1)):
+        return "%d-%d" % (lo, hi)
+
+    # Case 2: arithmetic series with constant step > 1 (requires n >= 3)
+    if len(ints) >= 3:
+        step = ints[1] - ints[0]
+        if step > 1 and all(ints[i] - ints[i - 1] == step for i in range(1, len(ints))):
+            return "%d-%d:%d" % (lo, hi, step)
+
+    # Case 3: group into maximal consecutive runs, format each as "lo" or "lo-hi"
+    groups: list[list[int]] = [[ints[0]]]
+    for x in ints[1:]:
+        if x == groups[-1][-1] + 1:
+            groups[-1].append(x)
+        else:
+            groups.append([x])
+    parts = ["%d-%d" % (g[0], g[-1]) if len(g) > 2 else ",".join(str(x) for x in g) for g in groups]
+    return "[" + ",".join(parts) + "]"
+
+
 def type_error_str(
-    obj: object, 
-    obj_name: str, 
+    obj: object,
+    obj_name: str,
     type_str: str
 ) -> str:
     """Create error message for TypeError.

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -16,6 +16,7 @@ from pyneuromatic.core.nm_folder import NMFolder
 from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.analysis.nm_main_op import (
     NMMainOp,
+    NMMainOpAccumulate,
     NMMainOpAverage,
     NMMainOpBaseline,
     NMMainOpDeleteNaNs,
@@ -23,12 +24,16 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpDifferentiate,
     NMMainOpInsertPoints,
     NMMainOpIntegrate,
+    NMMainOpMax,
+    NMMainOpMin,
     NMMainOpNormalize,
     NMMainOpRedimension,
     NMMainOpReplaceValues,
     NMMainOpReverse,
     NMMainOpRotate,
     NMMainOpScale,
+    NMMainOpSum,
+    NMMainOpSumSqr,
     op_from_name,
 )
 from pyneuromatic.analysis.nm_tool_main import NMToolMain
@@ -110,13 +115,9 @@ class TestNMMainOpAverage(unittest.TestCase):
 
     # --- output naming and results dict ---
 
-    def test_output_in_folder(self):
-        self._run()
-        self.assertIsNotNone(self.op.results)
-        self.assertIn("A", self.op.results)
-
     def test_output_name_in_results(self):
         self._run()
+        self.assertIn("A", self.op.results)
         self.assertEqual(self.op.results["A"], "Avg_RecordA")
 
     def test_results_populated_after_run(self):
@@ -126,6 +127,7 @@ class TestNMMainOpAverage(unittest.TestCase):
     # --- NaN handling ---
 
     def test_nanmean_ignores_nan(self):
+        # self.op.ignore_nans = True by default
         arrays = {
             "RecordA0": [2.0, math.nan, 2.0],
             "RecordA1": [4.0, 4.0,      4.0],
@@ -133,8 +135,9 @@ class TestNMMainOpAverage(unittest.TestCase):
         folder = self._run(arrays)
         out = folder.data.get("Avg_RecordA")
         self.assertIsNotNone(out)
-        # nanmean of [2, nan] and [4, 4] at index 1 = mean([4]) = 4.0
+        # nanmean of [2, nan, 2] and [4, 4, 4] at index 1 = mean([nan, 4]) = 4.0
         self.assertTrue(np.isfinite(out.nparray[1]))
+        np.testing.assert_array_almost_equal(out.nparray, [3.0, 4.0, 3.0])
 
     def test_mean_nan_propagates(self):
         self.op.ignore_nans = False
@@ -233,6 +236,290 @@ class TestNMMainOpAverage(unittest.TestCase):
         out = folder.data.get("Avg_RecordA")
         note = out.notes[0]["note"]
         self.assertIn("epochs=[0,2,5]", note)
+
+    # --- compute_stdv / compute_var / compute_sem ---
+
+    def test_compute_stdv_default_false(self):
+        self.assertFalse(self.op.compute_stdv)
+
+    def test_compute_var_default_false(self):
+        self.assertFalse(self.op.compute_var)
+
+    def test_compute_sem_default_false(self):
+        self.assertFalse(self.op.compute_sem)
+
+    def test_compute_stdv_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.compute_stdv = 1
+
+    def test_compute_var_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.compute_var = "yes"
+
+    def test_compute_sem_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.op.compute_sem = 0
+
+    def test_compute_stdv_writes_wave(self):
+        self.op.compute_stdv = True
+        folder = self._run()
+        self.assertIsNotNone(folder.data.get("Stdv_RecordA"))
+
+    def test_compute_stdv_values(self):
+        # [2,2,2], [4,4,4], [6,6,6] → stdv (ddof=1) = 2.0 at each point
+        self.op.compute_stdv = True
+        folder = self._run()
+        out = folder.data.get("Stdv_RecordA")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_almost_equal(out.nparray, [2.0, 2.0, 2.0])
+
+    def test_compute_var_values(self):
+        self.op.compute_var = True
+        folder = self._run()
+        out = folder.data.get("Var_RecordA")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_almost_equal(out.nparray, [4.0, 4.0, 4.0])
+
+    def test_compute_sem_values(self):
+        import math
+        self.op.compute_sem = True
+        folder = self._run()
+        out = folder.data.get("SEM_RecordA")
+        self.assertIsNotNone(out)
+        # stdv=2.0, n=3, sem=2/sqrt(3)
+        expected = 2.0 / math.sqrt(3)
+        np.testing.assert_array_almost_equal(out.nparray, [expected, expected, expected])
+
+    def test_all_three_writes_three_extra_waves(self):
+        self.op.compute_stdv = True
+        self.op.compute_var = True
+        self.op.compute_sem = True
+        folder = self._run()
+        self.assertIsNotNone(folder.data.get("Stdv_RecordA"))
+        self.assertIsNotNone(folder.data.get("Var_RecordA"))
+        self.assertIsNotNone(folder.data.get("SEM_RecordA"))
+
+    def test_stdv_note_on_output_wave(self):
+        self.op.compute_stdv = True
+        folder = self._run({"RecordA0": [2.0, 2.0], "RecordA1": [4.0, 4.0], "RecordA2": [6.0, 6.0]})
+        out = folder.data.get("Stdv_RecordA")
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out.notes), 1)
+        note = out.notes[0]["note"]
+        self.assertIn("NMStdv(folder=folder0", note)
+        self.assertIn("channel=A", note)
+        self.assertIn("n_epochs=3", note)
+
+
+# ===========================================================================
+# TestNMMainOpSum
+# ===========================================================================
+
+class TestNMMainOpSum(unittest.TestCase):
+    """Test NMMainOpSum directly."""
+
+    def setUp(self):
+        self.op = NMMainOpSum()
+        self.arrays = {
+            "RecordA0": [1.0, 2.0, 3.0],
+            "RecordA1": [4.0, 5.0, 6.0],
+        }
+
+    def _run(self, arrays=None):
+        if arrays is None:
+            arrays = self.arrays
+        return _run_op_directly(self.op, arrays)
+
+    def test_correct_values(self):
+        folder = self._run()
+        out = folder.data.get("Sum_RecordA")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_almost_equal(out.nparray, [5.0, 7.0, 9.0])
+
+    def test_output_name(self):
+        folder = self._run()
+        self.assertIsNotNone(folder.data.get("Sum_RecordA"))
+
+    def test_nan_handling_ignore_nans(self):
+        # self.op.ignore_nans = True by default
+        arrays = {
+            "RecordA0": [math.nan, 2.0],
+            "RecordA1": [4.0, 5.0],
+        }
+        folder = self._run(arrays)
+        out = folder.data.get("Sum_RecordA")
+        self.assertIsNotNone(out)
+        # nansum treats nan as 0, so [nan+4, 2+5] = [4, 7]
+        np.testing.assert_array_almost_equal(out.nparray, [4.0, 7.0])
+
+    def test_nan_propagates_when_ignore_nans_false(self):
+        self.op.ignore_nans = False
+        arrays = {
+            "RecordA0": [math.nan, 2.0],
+            "RecordA1": [4.0, 5.0],
+        }
+        folder = self._run(arrays)
+        out = folder.data.get("Sum_RecordA")
+        self.assertTrue(math.isnan(out.nparray[0]))
+        self.assertEqual(out.nparray[1], 7.0)
+
+    def test_two_channels(self):
+        arrays = {
+            "RecordA0": [1.0, 2.0],
+            "RecordA1": [3.0, 4.0],
+            "RecordB0": [5.0, 6.0],
+            "RecordB1": [7.0, 8.0],
+        }
+        folder = self._run(arrays)
+        self.assertIsNotNone(folder.data.get("Sum_RecordA"))
+        self.assertIsNotNone(folder.data.get("Sum_RecordB"))
+
+    def test_no_folder_graceful(self):
+        data_items = [(_make_data("RecordA0", [1.0, 2.0]), None)]
+        self.op.run_all(data_items, None)
+        self.assertEqual(self.op.results, {})
+
+    def test_note_written(self):
+        folder = self._run({"RecordA0": [1.0], "RecordA1": [2.0]})
+        out = folder.data.get("Sum_RecordA")
+        self.assertIsNotNone(out)
+        self.assertEqual(len(out.notes), 1)
+        note = out.notes[0]["note"]
+        self.assertIn("NMSum(folder=folder0", note)
+        self.assertIn("channel=A", note)
+        self.assertIn("n_epochs=2", note)
+
+
+# ===========================================================================
+# TestNMMainOpSumSqr
+# ===========================================================================
+
+class TestNMMainOpSumSqr(unittest.TestCase):
+    """Test NMMainOpSumSqr directly."""
+
+    def setUp(self):
+        self.op = NMMainOpSumSqr()
+
+    def _run(self, arrays):
+        return _run_op_directly(self.op, arrays)
+
+    def test_correct_values(self):
+        # [1,2] and [3,4] → [1²+3², 2²+4²] = [10, 20]
+        folder = self._run({"RecordA0": [1.0, 2.0], "RecordA1": [3.0, 4.0]})
+        out = folder.data.get("SumSqr_RecordA")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_almost_equal(out.nparray, [10.0, 20.0])
+
+    def test_output_name(self):
+        folder = self._run({"RecordA0": [1.0], "RecordA1": [2.0]})
+        self.assertIsNotNone(folder.data.get("SumSqr_RecordA"))
+
+    def test_nan_handling_ignore_nans(self):
+        arrays = {
+            "RecordA0": [math.nan, 2.0],
+            "RecordA1": [3.0, 4.0],
+        }
+        folder = self._run(arrays)
+        out = folder.data.get("SumSqr_RecordA")
+        self.assertIsNotNone(out)
+        # nansum: [nan²+9, 4+16] = [9, 20]
+        np.testing.assert_array_almost_equal(out.nparray, [9.0, 20.0])
+
+    def test_note_written(self):
+        folder = self._run({"RecordA0": [1.0], "RecordA1": [2.0]})
+        out = folder.data.get("SumSqr_RecordA")
+        self.assertIsNotNone(out)
+        note = out.notes[0]["note"]
+        self.assertIn("NMSumSqr(folder=folder0", note)
+        self.assertIn("channel=A", note)
+
+
+# ===========================================================================
+# TestNMMainOpMin
+# ===========================================================================
+
+class TestNMMainOpMin(unittest.TestCase):
+    """Test NMMainOpMin directly."""
+
+    def setUp(self):
+        self.op = NMMainOpMin()
+
+    def _run(self, arrays):
+        return _run_op_directly(self.op, arrays)
+
+    def test_correct_values(self):
+        # [1,5] and [3,2] → point-by-point min = [1, 2]
+        folder = self._run({"RecordA0": [1.0, 5.0], "RecordA1": [3.0, 2.0]})
+        out = folder.data.get("Min_RecordA")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_almost_equal(out.nparray, [1.0, 2.0])
+
+    def test_output_name(self):
+        folder = self._run({"RecordA0": [1.0], "RecordA1": [2.0]})
+        self.assertIsNotNone(folder.data.get("Min_RecordA"))
+
+    def test_nan_handling_ignore_nans(self):
+        arrays = {
+            "RecordA0": [math.nan, 5.0],
+            "RecordA1": [3.0, 2.0],
+        }
+        folder = self._run(arrays)
+        out = folder.data.get("Min_RecordA")
+        self.assertIsNotNone(out)
+        # nanmin ignores nan: [3.0, 2.0]
+        np.testing.assert_array_almost_equal(out.nparray, [3.0, 2.0])
+
+    def test_note_written(self):
+        folder = self._run({"RecordA0": [1.0], "RecordA1": [2.0]})
+        out = folder.data.get("Min_RecordA")
+        self.assertIsNotNone(out)
+        note = out.notes[0]["note"]
+        self.assertIn("NMMin(folder=folder0", note)
+        self.assertIn("channel=A", note)
+
+
+# ===========================================================================
+# TestNMMainOpMax
+# ===========================================================================
+
+class TestNMMainOpMax(unittest.TestCase):
+    """Test NMMainOpMax directly."""
+
+    def setUp(self):
+        self.op = NMMainOpMax()
+
+    def _run(self, arrays):
+        return _run_op_directly(self.op, arrays)
+
+    def test_correct_values(self):
+        # [1,5] and [3,2] → point-by-point max = [3, 5]
+        folder = self._run({"RecordA0": [1.0, 5.0], "RecordA1": [3.0, 2.0]})
+        out = folder.data.get("Max_RecordA")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_almost_equal(out.nparray, [3.0, 5.0])
+
+    def test_output_name(self):
+        folder = self._run({"RecordA0": [1.0], "RecordA1": [2.0]})
+        self.assertIsNotNone(folder.data.get("Max_RecordA"))
+
+    def test_nan_handling_ignore_nans(self):
+        arrays = {
+            "RecordA0": [math.nan, 5.0],
+            "RecordA1": [3.0, 2.0],
+        }
+        folder = self._run(arrays)
+        out = folder.data.get("Max_RecordA")
+        self.assertIsNotNone(out)
+        # nanmax ignores nan: [3.0, 5.0]
+        np.testing.assert_array_almost_equal(out.nparray, [3.0, 5.0])
+
+    def test_note_written(self):
+        folder = self._run({"RecordA0": [1.0], "RecordA1": [2.0]})
+        out = folder.data.get("Max_RecordA")
+        self.assertIsNotNone(out)
+        note = out.notes[0]["note"]
+        self.assertIn("NMMax(folder=folder0", note)
+        self.assertIn("channel=A", note)
 
 
 # ===========================================================================
@@ -624,6 +911,22 @@ class TestOpFromName(unittest.TestCase):
     def test_normalize_by_name(self):
         op = op_from_name("normalize")
         self.assertIsInstance(op, NMMainOpNormalize)
+
+    def test_sum_by_name(self):
+        op = op_from_name("sum")
+        self.assertIsInstance(op, NMMainOpSum)
+
+    def test_sum_sqr_by_name(self):
+        op = op_from_name("sum_sqr")
+        self.assertIsInstance(op, NMMainOpSumSqr)
+
+    def test_min_by_name(self):
+        op = op_from_name("min")
+        self.assertIsInstance(op, NMMainOpMin)
+
+    def test_max_by_name(self):
+        op = op_from_name("max")
+        self.assertIsInstance(op, NMMainOpMax)
 
     def test_case_insensitive(self):
         op = op_from_name("AVERAGE")

--- a/tests/test_core/test_nm_utilities.py
+++ b/tests/test_core/test_nm_utilities.py
@@ -384,5 +384,114 @@ class TestParseDataName(unittest.TestCase):
         self.assertEqual(result, ("Record", "A", 0))
 
 
+# ===========================================================================
+# TestFormatEpochString
+# ===========================================================================
+
+class TestFormatEpochString(unittest.TestCase):
+    """Tests for nmu.format_epoch_string()."""
+
+    # --- consecutive epochs → range notation ---
+
+    def test_consecutive_returns_range(self):
+        self.assertEqual(nmu.format_epoch_string(["RecordA0", "RecordA1", "RecordA2"]), "0-2")
+
+    def test_two_consecutive(self):
+        self.assertEqual(nmu.format_epoch_string(["RecordA4", "RecordA5"]), "4-5")
+
+    def test_large_consecutive_range(self):
+        names = ["RecordA%d" % i for i in range(10)]
+        self.assertEqual(nmu.format_epoch_string(names), "0-9")
+
+    # --- non-consecutive epochs → bracket notation ---
+
+    def test_non_consecutive_returns_brackets(self):
+        self.assertEqual(nmu.format_epoch_string(["RecordA0", "RecordA2", "RecordA5"]), "[0,2,5]")
+
+    def test_single_gap(self):
+        self.assertEqual(nmu.format_epoch_string(["RecordA0", "RecordA2"]), "[0,2]")
+
+    # --- single wave ---
+
+    def test_single_wave_returns_single_number(self):
+        self.assertEqual(nmu.format_epoch_string(["RecordA3"]), "[3]")
+
+    # --- unparseable names fall back to the raw name ---
+
+    def test_unparseable_name_uses_raw(self):
+        result = nmu.format_epoch_string(["nopattern"])
+        self.assertIn("nopattern", result)
+
+    def test_mixed_parseable_and_not(self):
+        # One parseable, one not — should not raise
+        result = nmu.format_epoch_string(["RecordA0", "nopattern"])
+        self.assertIsInstance(result, str)
+
+    # --- empty list ---
+
+    def test_empty_list_returns_string(self):
+        # min/max on empty list raises ValueError, caught internally
+        result = nmu.format_epoch_string([])
+        self.assertIsInstance(result, str)
+
+    # --- channel/prefix independence ---
+
+    def test_different_prefix_same_epochs(self):
+        self.assertEqual(nmu.format_epoch_string(["StimulusA0", "StimulusA1"]), "0-1")
+
+    def test_multi_digit_epoch(self):
+        self.assertEqual(nmu.format_epoch_string(["RecordA10", "RecordA11", "RecordA12"]), "10-12")
+
+    # --- arithmetic series (constant step > 1) ---
+
+    def test_arithmetic_series_step3(self):
+        names = ["RecordA%d" % i for i in [1, 4, 7, 10, 13]]
+        self.assertEqual(nmu.format_epoch_string(names), "1-13:3")
+
+    def test_arithmetic_series_step2(self):
+        names = ["RecordA%d" % i for i in [0, 2, 4, 6]]
+        self.assertEqual(nmu.format_epoch_string(names), "0-6:2")
+
+    def test_arithmetic_series_step5(self):
+        names = ["RecordA%d" % i for i in [5, 10, 15]]
+        self.assertEqual(nmu.format_epoch_string(names), "5-15:5")
+
+    def test_arithmetic_series_requires_n3(self):
+        # n=2 with step > 1 should NOT use arithmetic notation
+        self.assertEqual(nmu.format_epoch_string(["RecordA1", "RecordA4"]), "[1,4]")
+
+    def test_non_constant_step_not_arithmetic(self):
+        # steps 2, 3 — not constant, falls through to grouped format
+        names = ["RecordA%d" % i for i in [0, 2, 5]]
+        self.assertEqual(nmu.format_epoch_string(names), "[0,2,5]")
+
+    # --- grouped consecutive runs ---
+
+    def test_two_groups(self):
+        names = ["RecordA%d" % i for i in [0, 1, 2, 3, 4, 10, 11, 12, 13, 14]]
+        self.assertEqual(nmu.format_epoch_string(names), "[0-4,10-14]")
+
+    def test_two_groups_short(self):
+        # 2-element runs listed individually, not as range
+        names = ["RecordA%d" % i for i in [0, 1, 5, 6, 7]]
+        self.assertEqual(nmu.format_epoch_string(names), "[0,1,5-7]")
+
+    def test_three_groups(self):
+        names = ["RecordA%d" % i for i in [0, 1, 2, 5, 6, 10]]
+        self.assertEqual(nmu.format_epoch_string(names), "[0-2,5,6,10]")
+
+    def test_groups_with_singletons(self):
+        # Mix of ranges and single points
+        names = ["RecordA%d" % i for i in [0, 1, 2, 5, 8, 11]]
+        self.assertEqual(nmu.format_epoch_string(names), "[0-2,5,8,11]")
+
+    # --- sorting ---
+
+    def test_unsorted_input_sorted_in_output(self):
+        # Names given out of order — result should be sorted
+        names = ["RecordA2", "RecordA0", "RecordA1"]
+        self.assertEqual(nmu.format_epoch_string(names), "0-2")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Add `NMMainOpAccumulate` base class that extracts the shared
  accumulate → reduce → write lifecycle from `NMMainOpAverage`
- Refactor `NMMainOpAverage` as a subclass; add optional `compute_stdv`,
  `compute_var`, `compute_sem` params (sample statistics, ddof=1)
- Add `NMMainOpSum`, `NMMainOpSumSqr`, `NMMainOpMin`, `NMMainOpMax` as
  point-by-point accumulate ops
- Add `nmu.format_epoch_string()` utility with compact notation for
  consecutive (`"0-9"`), arithmetic-series (`"1-13:3"`), and grouped
  (`"[0-4,10-14]"`) epoch ranges; used in all accumulate op notes

## Test plan
- [ ] 35 new tests for accumulate ops (correct values, NaN handling,
      two channels, no-folder, notes, stdev/var/sem values and notes)
- [ ] 10 new tests for `format_epoch_string` (consecutive, arithmetic
      series, grouped ranges, unparseable names, empty list, sorting)
- [ ] All 1723 tests pass

Closes #189
