### PR TITLE
feat(analysis): add NMMainOpArithmetic and NMMainOpArithmeticByArray ops

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -75,7 +75,18 @@ class NMMainOp:
             prefix: Dataseries name to use as the output wave prefix.  If
                 ``None``, ops fall back to parsing the prefix from the data
                 name.
+
+        Note:
+            Before calling ``run_init()``, stores ``folder``, ``prefix``,
+            item count, and the full item list as ``self._folder``,
+            ``self._prefix``, ``self._n_items``, and ``self._data_items`` so
+            that subclasses can access them in ``run_init()`` without
+            overriding ``run_all()``.
         """
+        self._folder = folder
+        self._prefix = prefix
+        self._n_items = len(data_items)
+        self._data_items = data_items
         self.run_init()
         for data, channel_name in data_items:
             self.run(data, channel_name)
@@ -551,6 +562,227 @@ class NMMainOpScale(NMMainOp):
 
 
 # =========================================================================
+# Arithmetic (array-wise arithmetic operation)
+# =========================================================================
+
+
+class NMMainOpArithmetic(NMMainOp):
+    """Apply an arithmetic operation to each selected data array.
+
+    The ``factor`` parameter controls the operand:
+
+    - **scalar** (``float``): the same factor is applied to every data item.
+    - **list** (``list[float]``): factors consumed in order, one per data
+      item.  List length must exactly match the number of data items.
+    - **dict** (``dict[str, float]``): factor looked up by data name;
+      missing keys are silently skipped.
+
+    Parameters:
+        factor: Operand — ``float``, ``list[float]``, or
+            ``dict[str, float]``.  Default is ``1.0``.
+        op: Operation string — one of ``"x"`` (multiply), ``"/"`` (divide),
+            ``"+"`` (add), ``"-"`` (subtract), ``"="`` (assign),
+            ``"**"`` (exponentiate).  Default is ``"x"``.
+    """
+
+    name = "arithmetic"
+
+    def __init__(
+        self,
+        factor: float | list[float] | dict[str, float] = 1.0,
+        op: str = "x",
+    ) -> None:
+        self.factor = factor
+        self.op = op
+        self._index: int = 0
+
+    @property
+    def factor(self) -> float | list[float] | dict[str, float]:
+        """Operand — scalar, list, or dict."""
+        return self._factor
+
+    @factor.setter
+    def factor(self, value: float | list[float] | dict[str, float]) -> None:
+        if isinstance(value, bool):
+            raise TypeError(
+                nmu.type_error_str(value, "factor", "float, list, or dict")
+            )
+        if isinstance(value, (int, float)):
+            self._factor = float(value)
+        elif isinstance(value, list):
+            for i, v in enumerate(value):
+                if isinstance(v, bool) or not isinstance(v, (int, float)):
+                    raise TypeError(
+                        "factor[%d]: expected float, got %s" % (i, type(v).__name__)
+                    )
+            self._factor = value
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                if not isinstance(k, str):
+                    raise TypeError(
+                        "factor key %r: expected str, got %s" % (k, type(k).__name__)
+                    )
+                if isinstance(v, bool) or not isinstance(v, (int, float)):
+                    raise TypeError(
+                        "factor[%r]: expected float, got %s" % (k, type(v).__name__)
+                    )
+            self._factor = value
+        else:
+            raise TypeError(
+                "factor must be float, list, or dict, got %s" % type(value).__name__
+            )
+
+    @property
+    def op(self) -> str:
+        """Operation string."""
+        return self._op
+
+    @op.setter
+    def op(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "op", "str"))
+        if value not in _VALID_ARITH_OPS:
+            raise ValueError(
+                "op must be one of %s, got %r" % (sorted(_VALID_ARITH_OPS), value)
+            )
+        self._op = value
+
+    def run_init(self) -> None:
+        """Reset index and pre-validate list length before any run() calls."""
+        self._index = 0
+        if isinstance(self._factor, list) and len(self._factor) != self._n_items:
+            raise IndexError(
+                "NMMainOpArithmetic: factor list length must match number of "
+                "data items (need %d, got %d)" % (self._n_items, len(self._factor))
+            )
+
+    def _get_factor(self, name: str) -> float | None:
+        if isinstance(self._factor, (int, float)):
+            return self._factor
+        if isinstance(self._factor, list):
+            f = float(self._factor[self._index])
+            self._index += 1
+            return f
+        return self._factor.get(name)  # dict: None if name not found
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Apply factor and op to data.nparray in-place."""
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        factor = self._get_factor(data.name)
+        if factor is None:
+            return  # dict mode: name not in dict of factors — skip
+        data.nparray = _apply_op(data.nparray.astype(float), factor, self._op)
+        self._add_note(
+            data, "NMArithmetic(factor=%.6g,op=%s)" % (factor, self._op)
+        )
+
+
+# =========================================================================
+# Arithmetic (element-wise arithmetic operation)
+# =========================================================================
+
+
+class NMMainOpArithmeticByArray(NMMainOp):
+    """Apply an element-wise arithmetic operation using a reference array.
+
+    The operation is applied as ``data = data op ref`` element-by-element.
+    When ``data`` and ``ref`` differ in length the operation is applied to
+    the overlap (``min(len(data), len(ref))``); elements beyond the overlap
+    are left unchanged.
+
+    Parameters:
+        ref: Reference operand — either an ``np.ndarray`` or a ``str`` data
+            name that will be looked up in the source folder at run time.
+        op: Operation string — same choices as :class:`NMMainOpArithmetic`.
+            Default is ``"x"``.
+    """
+
+    name = "arithmetic_by_array"
+
+    def __init__(self, ref: np.ndarray | str | None = None, op: str = "x") -> None:
+        self.ref = np.zeros(0) if ref is None else ref
+        self.op = op
+        self._resolved_ref: np.ndarray | None = None
+
+    @property
+    def ref(self) -> np.ndarray | str:
+        """Reference operand (array or data name string)."""
+        return self._ref
+
+    @ref.setter
+    def ref(self, value: np.ndarray | str) -> None:
+        if isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "ref", "np.ndarray or str"))
+        if not isinstance(value, (np.ndarray, str)):
+            raise TypeError(nmu.type_error_str(value, "ref", "np.ndarray or str"))
+        self._ref = value
+
+    @property
+    def op(self) -> str:
+        """Operation string."""
+        return self._op
+
+    @op.setter
+    def op(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "op", "str"))
+        if value not in _VALID_ARITH_OPS:
+            raise ValueError(
+                "op must be one of %s, got %r" % (sorted(_VALID_ARITH_OPS), value)
+            )
+        self._op = value
+
+    def run_init(self) -> None:
+        """Resolve the reference array before the per-item loop.
+
+        Reads ``self._folder`` (set by :meth:`NMMainOp.run_all`) to look up a
+        string ref name.  Stores the resolved array in ``self._resolved_ref``.
+        """
+        folder = self._folder
+        if isinstance(self._ref, str):
+            if folder is None:
+                raise ValueError(
+                    "folder required to resolve ref %r" % self._ref
+                )
+            ref_data = folder.data.get(self._ref)
+            if ref_data is None or not isinstance(ref_data.nparray, np.ndarray):
+                raise ValueError(
+                    "ref %r not found in folder %r" % (self._ref, folder.name)
+                )
+            self._resolved_ref = ref_data.nparray.astype(float)
+        else:
+            self._resolved_ref = self._ref.astype(float)
+        ref_len = len(self._resolved_ref)
+        for data, _ in self._data_items:
+            if isinstance(data.nparray, np.ndarray) and len(data.nparray) != ref_len:
+                raise ValueError(
+                    "NMMainOpArithmeticByArray: length mismatch for %r "
+                    "(data has %d points, ref has %d)"
+                    % (data.name, len(data.nparray), ref_len)
+                )
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Apply ref and op to data.nparray element-wise in-place."""
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        arr = data.nparray.astype(float)
+        data.nparray = _apply_op(arr, self._resolved_ref, self._op)
+        ref_label = self._ref if isinstance(self._ref, str) else "array"
+        self._add_note(
+            data, "NMArithmeticByArray(ref=%s,op=%s)" % (ref_label, self._op)
+        )
+
+
+# =========================================================================
 # Redimension
 # =========================================================================
 
@@ -826,6 +1058,38 @@ def _compute_ref(arr: np.ndarray, fxn: str, n_mean: int) -> float:
         half = n_mean // 2
         return float(np.nanmean(arr[max(0, i - half):i + half + 1]))
     return float("nan")
+
+
+_VALID_ARITH_OPS: frozenset[str] = frozenset({"x", "/", "+", "-", "=", "**"})
+
+
+def _apply_op(arr: np.ndarray, value, op: str) -> np.ndarray:
+    """Apply a binary operation between arr and value.
+
+    Args:
+        arr: Input array.
+        value: Scalar float or ndarray of the same length as arr.
+        op: One of ``"x"`` (multiply), ``"/"`` (divide), ``"+"`` (add),
+            ``"-"`` (subtract), ``"="`` (assign constant/array),
+            ``"**"`` (exponentiate).
+
+    Returns:
+        Result array (same dtype promotion as numpy default, except ``"="``
+        which returns float64).
+    """
+    if op == "x":
+        return arr * value
+    if op == "/":
+        return arr / value
+    if op == "+":
+        return arr + value
+    if op == "-":
+        return arr - value
+    if op == "=":
+        return np.full_like(arr, value, dtype=float)
+    if op == "**":
+        return arr ** value
+    raise ValueError("unknown op: %r" % op)
 
 
 # =========================================================================
@@ -1659,6 +1923,8 @@ class NMMainOpNormalize(NMMainOp):
 
 
 _OP_REGISTRY: dict[str, type[NMMainOp]] = {
+    "arithmetic": NMMainOpArithmetic,
+    "arithmetic_by_array": NMMainOpArithmeticByArray,
     "average": NMMainOpAverage,
     "baseline": NMMainOpBaseline,
     "delete_nans": NMMainOpDeleteNaNs,

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -17,6 +17,8 @@ from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.analysis.nm_main_op import (
     NMMainOp,
     NMMainOpAccumulate,
+    NMMainOpArithmetic,
+    NMMainOpArithmeticByArray,
     NMMainOpAverage,
     NMMainOpBaseline,
     NMMainOpDeleteNaNs,
@@ -928,6 +930,14 @@ class TestOpFromName(unittest.TestCase):
         op = op_from_name("max")
         self.assertIsInstance(op, NMMainOpMax)
 
+    def test_arithmetic_by_name(self):
+        op = op_from_name("arithmetic")
+        self.assertIsInstance(op, NMMainOpArithmetic)
+
+    def test_arithmetic_by_array_by_name(self):
+        op = op_from_name("arithmetic_by_array")
+        self.assertIsInstance(op, NMMainOpArithmeticByArray)
+
     def test_case_insensitive(self):
         op = op_from_name("AVERAGE")
         self.assertIsInstance(op, NMMainOpAverage)
@@ -1798,6 +1808,251 @@ class TestNMToolMain(unittest.TestCase):
         # Most recent entry should contain the op class name
         last_msg = fresh_history.buffer[-1]["message"]
         self.assertIn("NMMainOpScale", last_msg)
+
+
+# ===========================================================================
+# TestNMMainOpArithmetic
+# ===========================================================================
+
+
+class TestNMMainOpArithmetic(unittest.TestCase):
+    """Tests for NMMainOpArithmetic (scalar, list, and dict factor modes)."""
+
+    def _make_items(self, names, arrays):
+        return [(_make_data(n, a), None) for n, a in zip(names, arrays)]
+
+    # ------------------------------------------------------------------
+    # scalar mode
+
+    def _run_scalar(self, arr, factor, op):
+        op_obj = NMMainOpArithmetic(factor=factor, op=op)
+        d = _make_data("RecordA0", arr)
+        op_obj.run_all([(d, None)], folder=None)
+        return d.nparray
+
+    def test_scalar_multiply(self):
+        result = self._run_scalar([1.0, 2.0, 3.0], factor=2.0, op="x")
+        np.testing.assert_array_almost_equal(result, [2.0, 4.0, 6.0])
+
+    def test_scalar_add(self):
+        result = self._run_scalar([1.0, 2.0, 3.0], factor=10.0, op="+")
+        np.testing.assert_array_almost_equal(result, [11.0, 12.0, 13.0])
+
+    def test_scalar_subtract(self):
+        result = self._run_scalar([5.0, 6.0, 7.0], factor=2.0, op="-")
+        np.testing.assert_array_almost_equal(result, [3.0, 4.0, 5.0])
+
+    def test_scalar_divide(self):
+        result = self._run_scalar([4.0, 6.0, 8.0], factor=2.0, op="/")
+        np.testing.assert_array_almost_equal(result, [2.0, 3.0, 4.0])
+
+    def test_scalar_assign(self):
+        result = self._run_scalar([1.0, 2.0, 3.0], factor=99.0, op="=")
+        np.testing.assert_array_almost_equal(result, [99.0, 99.0, 99.0])
+
+    def test_scalar_exponentiate(self):
+        result = self._run_scalar([2.0, 3.0, 4.0], factor=2.0, op="**")
+        np.testing.assert_array_almost_equal(result, [4.0, 9.0, 16.0])
+
+    # ------------------------------------------------------------------
+    # list mode
+
+    def test_list_multiply(self):
+        items = self._make_items(
+            ["RecordA0", "RecordA1", "RecordA2"],
+            [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]],
+        )
+        op = NMMainOpArithmetic(factor=[2.0, 3.0, 4.0], op="x")
+        op.run_all(items, folder=None)
+        np.testing.assert_array_almost_equal(items[0][0].nparray, [2.0, 4.0])
+        np.testing.assert_array_almost_equal(items[1][0].nparray, [9.0, 12.0])
+        np.testing.assert_array_almost_equal(items[2][0].nparray, [20.0, 24.0])
+
+    def test_list_add(self):
+        items = self._make_items(["RecordA0", "RecordA1"], [[1.0], [2.0]])
+        op = NMMainOpArithmetic(factor=[10.0, 20.0], op="+")
+        op.run_all(items, folder=None)
+        np.testing.assert_array_almost_equal(items[0][0].nparray, [11.0])
+        np.testing.assert_array_almost_equal(items[1][0].nparray, [22.0])
+
+    def test_list_length_mismatch_raises_before_any_run(self):
+        items = self._make_items(["RecordA0", "RecordA1"], [[1.0], [2.0]])
+        op = NMMainOpArithmetic(factor=[2.0])  # 1 factor for 2 items
+        with self.assertRaises(IndexError):
+            op.run_all(items, folder=None)
+        # error raised in run_init — no items should have been modified
+        np.testing.assert_array_almost_equal(items[0][0].nparray, [1.0])
+        np.testing.assert_array_almost_equal(items[1][0].nparray, [2.0])
+
+    def test_list_too_long_raises(self):
+        items = self._make_items(["RecordA0"], [[1.0]])
+        op = NMMainOpArithmetic(factor=[2.0, 3.0])  # 2 factors for 1 item
+        with self.assertRaises(IndexError):
+            op.run_all(items, folder=None)
+
+    def test_list_state_reset_between_runs(self):
+        items = self._make_items(["RecordA0"], [[1.0]])
+        op = NMMainOpArithmetic(factor=[5.0], op="x")
+        op.run_all(items, folder=None)
+        np.testing.assert_array_almost_equal(items[0][0].nparray, [5.0])
+        items2 = self._make_items(["RecordA0"], [[2.0]])
+        op.run_all(items2, folder=None)
+        np.testing.assert_array_almost_equal(items2[0][0].nparray, [10.0])
+
+    def test_list_element_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpArithmetic(factor=[1.0, True])
+
+    # ------------------------------------------------------------------
+    # dict mode
+
+    def test_dict_multiply(self):
+        items = self._make_items(
+            ["RecordA0", "RecordA1"], [[2.0, 3.0], [4.0, 5.0]]
+        )
+        op = NMMainOpArithmetic(factor={"RecordA0": 10.0, "RecordA1": 0.5}, op="x")
+        op.run_all(items, folder=None)
+        np.testing.assert_array_almost_equal(items[0][0].nparray, [20.0, 30.0])
+        np.testing.assert_array_almost_equal(items[1][0].nparray, [2.0, 2.5])
+
+    def test_dict_missing_key_skips(self):
+        d = _make_data("RecordA0", [3.0, 4.0])
+        op = NMMainOpArithmetic(factor={"RecordA1": 2.0}, op="x")
+        op.run_all([(d, None)], folder=None)
+        np.testing.assert_array_almost_equal(d.nparray, [3.0, 4.0])
+
+    def test_factor_rejects_tuple(self):
+        with self.assertRaises(TypeError):
+            NMMainOpArithmetic(factor=(1.0, 2.0))
+
+    # ------------------------------------------------------------------
+    # validation
+
+    def test_op_default_is_multiply(self):
+        op = NMMainOpArithmetic(factor=3.0)
+        self.assertEqual(op.op, "x")
+
+    def test_op_rejects_unknown(self):
+        with self.assertRaises(ValueError):
+            NMMainOpArithmetic(factor=1.0, op="^")
+
+    def test_op_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            NMMainOpArithmetic(factor=1.0, op=2)
+
+    def test_factor_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpArithmetic(factor=True)
+
+    def test_factor_rejects_str(self):
+        with self.assertRaises(TypeError):
+            NMMainOpArithmetic(factor="2")
+
+    def test_skips_non_ndarray(self):
+        op = NMMainOpArithmetic(factor=2.0)
+        d = NMData("RecordA0")
+        op.run(d)
+
+    def test_note_written(self):
+        op = NMMainOpArithmetic(factor=2.0, op="x")
+        d = _make_data("RecordA0", [1.0, 2.0])
+        op.run(d)
+        notes = [e["note"] for e in d.notes._entries]
+        self.assertTrue(any("NMArithmetic(factor=2,op=x)" in n for n in notes))
+
+
+# ===========================================================================
+# TestNMMainOpArithmeticByArray
+# ===========================================================================
+
+
+def _make_folder_with_ref(folder_name, data_name, arr):
+    """Return (folder, NMData) with a data item pre-loaded."""
+    folder = NMFolder(name=folder_name)
+    folder.data.new(data_name, nparray=np.array(arr, dtype=float))
+    return folder, folder.data.get(data_name)
+
+
+class TestNMMainOpArithmeticByArray(unittest.TestCase):
+    """Tests for NMMainOpArithmeticByArray (element-wise reference arithmetic)."""
+
+    def _run(self, data_arr, ref_arr, op):
+        d = _make_data("RecordA0", data_arr)
+        ref = np.array(ref_arr, dtype=float)
+        op_obj = NMMainOpArithmeticByArray(ref=ref, op=op)
+        op_obj.run_all([(d, None)], folder=None)
+        return d.nparray
+
+    def test_multiply_by_array(self):
+        result = self._run([1.0, 2.0, 3.0], [2.0, 3.0, 4.0], "x")
+        np.testing.assert_array_almost_equal(result, [2.0, 6.0, 12.0])
+
+    def test_subtract_array(self):
+        result = self._run([5.0, 6.0, 7.0], [1.0, 2.0, 3.0], "-")
+        np.testing.assert_array_almost_equal(result, [4.0, 4.0, 4.0])
+
+    def test_assign_array(self):
+        result = self._run([1.0, 2.0, 3.0], [9.0, 8.0, 7.0], "=")
+        np.testing.assert_array_almost_equal(result, [9.0, 8.0, 7.0])
+
+    def test_ref_by_name(self):
+        folder, _ = _make_folder_with_ref("Folder1", "RefWave", [2.0, 4.0, 6.0])
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0])
+        items = [(d, None)]
+        op = NMMainOpArithmeticByArray(ref="RefWave", op="x")
+        op.run_all(items, folder=folder)
+        np.testing.assert_array_almost_equal(d.nparray, [2.0, 8.0, 18.0])
+
+    def test_ref_wave_not_found_raises(self):
+        folder = NMFolder(name="Folder1")
+        d = _make_data("RecordA0", [1.0, 2.0])
+        op = NMMainOpArithmeticByArray(ref="NoSuchWave", op="x")
+        with self.assertRaises(ValueError):
+            op.run_all([(d, None)], folder=folder)
+
+    def test_no_folder_with_string_ref_raises(self):
+        d = _make_data("RecordA0", [1.0, 2.0])
+        op = NMMainOpArithmeticByArray(ref="RefWave", op="x")
+        with self.assertRaises(ValueError):
+            op.run_all([(d, None)], folder=None)
+
+    def test_length_mismatch_short_ref_raises_before_any_run(self):
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0, 4.0])
+        ref = np.array([10.0, 10.0], dtype=float)
+        op = NMMainOpArithmeticByArray(ref=ref, op="x")
+        with self.assertRaises(ValueError):
+            op.run_all([(d, None)], folder=None)
+        # error raised in run_init — data should be unchanged
+        np.testing.assert_array_almost_equal(d.nparray, [1.0, 2.0, 3.0, 4.0])
+
+    def test_length_mismatch_long_ref_raises_before_any_run(self):
+        d = _make_data("RecordA0", [1.0, 2.0])
+        ref = np.array([3.0, 4.0, 5.0, 6.0], dtype=float)
+        op = NMMainOpArithmeticByArray(ref=ref, op="x")
+        with self.assertRaises(ValueError):
+            op.run_all([(d, None)], folder=None)
+        # error raised in run_init — data should be unchanged
+        np.testing.assert_array_almost_equal(d.nparray, [1.0, 2.0])
+
+    def test_ref_rejects_non_array_non_string(self):
+        with self.assertRaises(TypeError):
+            NMMainOpArithmeticByArray(ref=42)
+
+    def test_note_with_name_ref(self):
+        folder, _ = _make_folder_with_ref("Folder1", "RefWave", [1.0, 1.0])
+        d = _make_data("RecordA0", [2.0, 3.0])
+        op = NMMainOpArithmeticByArray(ref="RefWave", op="x")
+        op.run_all([(d, None)], folder=folder)
+        notes = [e["note"] for e in d.notes._entries]
+        self.assertTrue(any("NMArithmeticByArray(ref=RefWave,op=x)" in n for n in notes))
+
+    def test_note_with_array_ref(self):
+        d = _make_data("RecordA0", [2.0, 3.0])
+        ref = np.array([1.0, 1.0])
+        op = NMMainOpArithmeticByArray(ref=ref, op="+")
+        op.run_all([(d, None)], folder=None)
+        notes = [e["note"] for e in d.notes._entries]
+        self.assertTrue(any("NMArithmeticByArray(ref=array,op=+)" in n for n in notes))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `NMMainOpArithmetic`: applies a scalar, list, or dict of factors to
  each data array in-place, supporting ops `x`, `/`, `+`, `-`, `=`, `**`
- Add `NMMainOpArithmeticByArray`: applies a reference array element-wise
  (reference is `np.ndarray` or a data name resolved from the folder at
  run time); arrays must match in length
- Improve `NMMainOp.run_all()` to store `_folder`, `_prefix`, `_n_items`,
  and `_data_items` on `self` before `run_init()`, so subclasses can access
  them without overriding `run_all()`
- Pre-flight validation in `run_init()` for both new ops — no data is
  modified if inputs are invalid

## Test plan
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py -v`
- [ ] `python3 -m pytest tests/ -x -q`
- [ ] All 1778 existing tests pass; ~35 new tests added

Closes #191