### PR TITLE
feat(analysis): remove NMMainOpScale (superseded by NMMainOpArithmetic)

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -2,8 +2,8 @@
 """
 NMMainOp — operation classes for NMToolMain.
 
-Provides a base class NMMainOp and concrete subclasses (NMMainOpAverage,
-NMMainOpScale) following the same pattern as nm_transform.py:
+Provides a base class NMMainOp and concrete subclasses following the same
+pattern as nm_transform.py:
 one class per operation, a module-level registry, and a lookup helper.
 
 Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
@@ -513,52 +513,6 @@ class NMMainOpMax(NMMainOpAccumulate):
 
     def _reduce(self, stack: np.ndarray) -> np.ndarray:
         return np.nanmax(stack, axis=0) if self._ignore_nans else np.max(stack, axis=0)
-
-
-# =========================================================================
-# Scale
-# =========================================================================
-
-
-class NMMainOpScale(NMMainOp):
-    """Multiply each selected wave by a scalar factor (in-place).
-
-    Parameters:
-        factor: Multiplication factor (default 1.0).  Must be int or float
-            (not bool).
-    """
-
-    name = "scale"
-
-    def __init__(self, factor: float = 1.0) -> None:
-        self.factor = factor  # use setter for validation
-
-    @property
-    def factor(self) -> float:
-        """Multiplication factor applied to each wave."""
-        return self._factor
-
-    @factor.setter
-    def factor(self, value: float) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "factor", "float"))
-        self._factor = float(value)
-
-    def run(
-        self,
-        data: NMData,
-        channel_name: str | None = None,
-    ) -> None:
-        """Multiply data.nparray by self.factor in-place.
-
-        Args:
-            data: The NMData object to scale.
-            channel_name: Unused; present for API consistency.
-        """
-        if not isinstance(data.nparray, np.ndarray):
-            return
-        data.nparray = data.nparray * self._factor
-        self._add_note(data, "NMScale(factor=%.6g)" % self._factor)
 
 
 # =========================================================================
@@ -1939,7 +1893,6 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "replace_values": NMMainOpReplaceValues,
     "reverse": NMMainOpReverse,
     "rotate": NMMainOpRotate,
-    "scale": NMMainOpScale,
     "sum": NMMainOpSum,
     "sum_sqr": NMMainOpSumSqr,
 }

--- a/pyneuromatic/analysis/nm_tool_main.py
+++ b/pyneuromatic/analysis/nm_tool_main.py
@@ -37,7 +37,7 @@ class NMToolMain(NMTool):
     full parameter control::
 
         tool = NMToolMain()
-        tool.op = NMMainOpScale(factor=2.0)
+        tool.op = NMMainOpArithmetic(factor=2.0)
         nm.run_tool(tool)
 
     Delegates to the current ``op`` via the standard ``run_init / run /

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -33,7 +33,6 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpReplaceValues,
     NMMainOpReverse,
     NMMainOpRotate,
-    NMMainOpScale,
     NMMainOpSum,
     NMMainOpSumSqr,
     op_from_name,
@@ -525,90 +524,6 @@ class TestNMMainOpMax(unittest.TestCase):
 
 
 # ===========================================================================
-# TestNMMainOpScale
-# ===========================================================================
-
-class TestNMMainOpScale(unittest.TestCase):
-    """Test NMMainOpScale directly."""
-
-    def setUp(self):
-        self.op = NMMainOpScale()
-        self.data = _make_data("RecordA0", [1.0, 2.0, 3.0])
-
-    def _run_single(self, data=None):
-        if data is None:
-            data = self.data
-        self.op.run(data)
-
-    # --- factor property ---
-
-    def test_factor_default(self):
-        self.assertEqual(self.op.factor, 1.0)
-
-    def test_factor_setter(self):
-        self.op.factor = 2.5
-        self.assertEqual(self.op.factor, 2.5)
-
-    def test_factor_accepts_int(self):
-        self.op.factor = 3
-        self.assertEqual(self.op.factor, 3.0)
-        self.assertIsInstance(self.op.factor, float)
-
-    def test_factor_rejects_bool(self):
-        with self.assertRaises(TypeError):
-            self.op.factor = True
-
-    def test_factor_rejects_str(self):
-        with self.assertRaises(TypeError):
-            self.op.factor = "2.0"
-
-    # --- scaling values ---
-
-    def test_scale_by_2(self):
-        self.op.factor = 2.0
-        self._run_single()
-        np.testing.assert_array_almost_equal(self.data.nparray, [2.0, 4.0, 6.0])
-
-    def test_scale_by_1_no_change(self):
-        self.op.factor = 1.0
-        self._run_single()
-        np.testing.assert_array_almost_equal(self.data.nparray, [1.0, 2.0, 3.0])
-
-    def test_scale_by_0(self):
-        self.op.factor = 0.0
-        self._run_single()
-        np.testing.assert_array_almost_equal(self.data.nparray, [0.0, 0.0, 0.0])
-
-    def test_scale_by_negative(self):
-        self.op.factor = -1.0
-        self._run_single()
-        np.testing.assert_array_almost_equal(self.data.nparray, [-1.0, -2.0, -3.0])
-
-    def test_scale_modifies_nparray_in_place(self):
-        original_obj = self.data
-        self.op.factor = 2.0
-        self._run_single()
-        # Same NMData object, modified array
-        self.assertIs(self.data, original_obj)
-        self.assertEqual(self.data.nparray[0], 2.0)
-
-    # --- skip if no nparray ---
-
-    def test_data_without_nparray_is_skipped(self):
-        d = NMData(NM, name="RecordA0")   # nparray=None
-        self.op.factor = 2.0
-        self.op.run(d)   # should not raise
-
-    # --- notes ---
-
-    def test_note_written(self):
-        self.op.factor = 2.0
-        self.op.run(self.data)
-        self.assertEqual(len(self.data.notes), 1)
-        self.assertIn("NMScale(factor=2)", self.data.notes[0]["note"])
-
-
-# ===========================================================================
 # TestNMMainOpRedimension
 # ===========================================================================
 
@@ -866,9 +781,9 @@ class TestOpFromName(unittest.TestCase):
         op = op_from_name("average")
         self.assertIsInstance(op, NMMainOpAverage)
 
-    def test_scale_by_name(self):
-        op = op_from_name("scale")
-        self.assertIsInstance(op, NMMainOpScale)
+    def test_scale_name_raises(self):
+        with self.assertRaises(ValueError):
+            op_from_name("scale")
 
     def test_redimension_by_name(self):
         op = op_from_name("redimension")
@@ -1740,16 +1655,16 @@ class TestNMToolMain(unittest.TestCase):
     # --- op setter ---
 
     def test_op_setter_accepts_instance(self):
-        self.tool.op = NMMainOpScale()
-        self.assertIsInstance(self.tool.op, NMMainOpScale)
+        self.tool.op = NMMainOpArithmetic()
+        self.assertIsInstance(self.tool.op, NMMainOpArithmetic)
 
     def test_op_setter_accepts_string_average(self):
         self.tool.op = "average"
         self.assertIsInstance(self.tool.op, NMMainOpAverage)
 
-    def test_op_setter_accepts_string_scale(self):
-        self.tool.op = "scale"
-        self.assertIsInstance(self.tool.op, NMMainOpScale)
+    def test_op_setter_accepts_string_arithmetic(self):
+        self.tool.op = "arithmetic"
+        self.assertIsInstance(self.tool.op, NMMainOpArithmetic)
 
     def test_op_setter_rejects_unknown_string(self):
         with self.assertRaises(ValueError):
@@ -1772,13 +1687,13 @@ class TestNMToolMain(unittest.TestCase):
         self.assertIsNotNone(out)
         np.testing.assert_array_almost_equal(out.nparray, [3.0, 6.0])
 
-    # --- end-to-end: scale ---
+    # --- end-to-end: arithmetic ---
 
-    def test_run_all_scale_end_to_end(self):
+    def test_run_all_arithmetic_end_to_end(self):
         folder, targets = _make_folder_with_data({
             "RecordA0": [1.0, 2.0, 3.0],
         })
-        self.tool.op = NMMainOpScale(factor=3.0)
+        self.tool.op = NMMainOpArithmetic(factor=3.0)
         self.tool.run_all(targets)
         d = folder.data.get("RecordA0")
         np.testing.assert_array_almost_equal(d.nparray, [3.0, 6.0, 9.0])
@@ -1801,13 +1716,13 @@ class TestNMToolMain(unittest.TestCase):
         nmh.set_history(fresh_history)
         before = len(fresh_history.buffer)
         _, targets = _make_folder_with_data({"RecordA0": [1.0, 2.0]})
-        self.tool.op = NMMainOpScale(factor=2.0)
+        self.tool.op = NMMainOpArithmetic(factor=2.0)
         self.tool.run_all(targets)
         after = len(fresh_history.buffer)
         self.assertGreater(after, before)
         # Most recent entry should contain the op class name
         last_msg = fresh_history.buffer[-1]["message"]
-        self.assertIn("NMMainOpScale", last_msg)
+        self.assertIn("NMMainOpArithmetic", last_msg)
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary
- Remove `NMMainOpScale` — fully superseded by `NMMainOpArithmetic(op="x")`
- Remove `"scale"` registry key; `op_from_name("scale")` now raises `ValueError`
- Update `nm_tool_main.py` docstring example to use `NMMainOpArithmetic`
- Replace all test references with `NMMainOpArithmetic` equivalents

## Test plan
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py -v`
- [ ] `python3 -m pytest tests/ -x -q`
- [ ] 1766 tests pass

Closes #193 