### PR TITLE
feat(analysis): add NMMainOpInequality op (#195)

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -28,6 +28,7 @@ import numpy as np
 
 from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_folder import NMFolder
+import pyneuromatic.core.nm_math as nm_math
 import pyneuromatic.core.nm_utilities as nmu
 
 
@@ -1872,6 +1873,145 @@ class NMMainOpNormalize(NMMainOp):
 
 
 # =========================================================================
+# NMMainOpInequality
+# =========================================================================
+
+
+class NMMainOpInequality(NMMainOp):
+    """Apply an inequality test point-by-point to each data array.
+
+    Output is written as a new array ``IQ_{data.name}`` in the source
+    folder (non-destructive).  Original data is unchanged.
+
+    Args:
+        op:            Operator string (see
+                       :data:`~pyneuromatic.core.nm_math.VALID_INEQUALITY_OPS`).
+        a:             Threshold / lower bound.
+        b:             Upper bound; required for range ops, else None.
+        binary_output: If True (default), output values are 1.0 (pass) or
+                       0.0 (fail).  If False, output is the original value
+                       where the condition is met and NaN elsewhere.
+    """
+
+    name = "inequality"
+
+    def __init__(
+        self,
+        op: str = ">",
+        a: float = 0.0,
+        b: float | None = None,
+        binary_output: bool = True,
+    ) -> None:
+        self.op = op
+        self.a = a
+        self.b = b
+        self.binary_output = binary_output
+        self._results: dict = {}
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def op(self) -> str:
+        return self._op
+
+    @op.setter
+    def op(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "op", "string"))
+        if value not in nm_math.VALID_INEQUALITY_OPS:
+            raise ValueError(
+                "unknown operator %r. Valid ops: %s"
+                % (value, sorted(nm_math.VALID_INEQUALITY_OPS))
+            )
+        self._op = value
+
+    @property
+    def a(self) -> float:
+        return self._a
+
+    @a.setter
+    def a(self, value: float) -> None:
+        if isinstance(value, bool):
+            raise TypeError("a must be a number, not bool")
+        if not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "a", "number"))
+        self._a = float(value)
+
+    @property
+    def b(self) -> float | None:
+        return self._b
+
+    @b.setter
+    def b(self, value: float | None) -> None:
+        if value is None:
+            self._b = None
+            return
+        if isinstance(value, bool):
+            raise TypeError("b must be a number or None, not bool")
+        if not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "b", "number"))
+        self._b = float(value)
+
+    @property
+    def binary_output(self) -> bool:
+        return self._binary_output
+
+    @binary_output.setter
+    def binary_output(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "binary_output", "bool"))
+        self._binary_output = value
+
+    @property
+    def results(self) -> dict:
+        """Per-output-wave dict; populated after :meth:`run_all`."""
+        return self._results
+
+    # ------------------------------------------------------------------
+    # NMMainOp interface
+    # ------------------------------------------------------------------
+
+    def run_init(self) -> None:
+        self._results = {}
+        if self._op in nm_math._RANGE_INEQUALITY_OPS and self._b is None:
+            raise ValueError("range op %r requires b" % self._op)
+
+    def run(self, data: NMData, channel_name: str | None = None) -> None:
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        arr = data.nparray.astype(float)
+        mask = nm_math.inequality_mask(arr, self._op, self._a, self._b)
+        result = (
+            mask.astype(float)
+            if self._binary_output
+            else np.where(mask, arr, np.nan)
+        )
+        successes = int(np.sum(mask))
+        condition = nm_math.inequality_condition_str(self._op, self._a, self._b)
+        out_name = "IQ_" + data.name
+        if self._folder is not None:
+            xscale = {
+                "start": data.xscale.start,
+                "delta": data.xscale.delta,
+                "label": data.xscale.label,
+                "units": data.xscale.units,
+            }
+            yscale = {"label": data.yscale.label, "units": data.yscale.units}
+            self._folder.data.new(out_name, nparray=result,
+                                  xscale=xscale, yscale=yscale)
+            out_data = self._folder.data.get(out_name)
+            if out_data is not None:
+                self._add_note(out_data, "NMInequality(%s)" % condition)
+        self._results[out_name] = {
+            "successes": successes,
+            "failures": len(arr) - successes,
+            "condition": condition,
+        }
+
+
+# =========================================================================
 # Registry and lookup
 # =========================================================================
 
@@ -1884,6 +2024,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "delete_nans": NMMainOpDeleteNaNs,
     "delete_points": NMMainOpDeletePoints,
     "differentiate": NMMainOpDifferentiate,
+    "inequality": NMMainOpInequality,
     "insert_points": NMMainOpInsertPoints,
     "integrate": NMMainOpIntegrate,
     "max": NMMainOpMax,

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -35,6 +35,7 @@ from pyneuromatic.core.nm_epoch import NMEpoch
 from pyneuromatic.core.nm_folder import NMFolder
 import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_configurations as nmc
+import pyneuromatic.core.nm_math as nm_math
 import pyneuromatic.core.nm_utilities as nmu
 
 
@@ -837,21 +838,18 @@ class NMToolStats2:
             ValueError: If the named array has no data, op is unrecognised,
                 or a range op is given without b.
         """
-        _SINGLE_OPS = frozenset({">", ">=", "<", "<=", "==", "!="})
-        _RANGE_OPS = frozenset({"<<", "<=<=", "<=<", "<<="})
-
         if not isinstance(toolfolder, NMToolFolder):
             raise TypeError(
                 nmu.type_error_str(toolfolder, "toolfolder", "NMToolFolder")
             )
         if not isinstance(name, str):
             raise TypeError(nmu.type_error_str(name, "name", "string"))
-        if op not in _SINGLE_OPS | _RANGE_OPS:
+        if op not in nm_math.VALID_INEQUALITY_OPS:
             raise ValueError(
                 "unknown operator %r. Single: %s; range: %s"
-                % (op, sorted(_SINGLE_OPS), sorted(_RANGE_OPS))
+                % (op, sorted(nm_math._SINGLE_INEQUALITY_OPS), sorted(nm_math._RANGE_INEQUALITY_OPS))
             )
-        if op in _RANGE_OPS and b is None:
+        if op in nm_math._RANGE_INEQUALITY_OPS and b is None:
             raise ValueError(
                 "range operator %r requires b to be specified" % op
             )
@@ -864,27 +862,7 @@ class NMToolStats2:
 
         arr = d.nparray.astype(float)
 
-        # Build boolean mask — NaN propagates as False in comparisons
-        if op == ">":
-            mask = arr > a
-        elif op == ">=":
-            mask = arr >= a
-        elif op == "<":
-            mask = arr < a
-        elif op == "<=":
-            mask = arr <= a
-        elif op == "==":
-            mask = arr == a
-        elif op == "!=":
-            mask = arr != a
-        elif op == "<<":     # a < y < b
-            mask = (arr > a) & (arr < b)
-        elif op == "<=<=":   # a <= y <= b
-            mask = (arr >= a) & (arr <= b)
-        elif op == "<=<":    # a <= y < b
-            mask = (arr >= a) & (arr < b)
-        else:                # op == "<<="  a < y <= b
-            mask = (arr > a) & (arr <= b)
+        mask = nm_math.inequality_mask(arr, op, a, b)
 
         if binary_output:
             result = mask.astype(float)
@@ -894,7 +872,7 @@ class NMToolStats2:
         successes = int(np.sum(mask))
         failures = len(mask) - successes
 
-        condition = NMToolStats2._inequality_condition_str(op, a, b)
+        condition = nm_math.inequality_condition_str(op, a, b)
 
         if save_to_numpy and toolfolder.data is not None:
             toolfolder.data.new("IQ_%s" % name, nparray=result)
@@ -916,24 +894,6 @@ class NMToolStats2:
             "failures": failures,
             "condition": condition,
         }
-
-    @staticmethod
-    def _inequality_condition_str(op: str, a: float, b: float | None) -> str:
-        """Build a human-readable condition string for inequality().
-
-        Examples: ``"y > 50"``, ``"2 < y < 5"``, ``"y == 0"``.
-        """
-        if op == ">":   return "y > %g" % a
-        if op == ">=":  return "y >= %g" % a
-        if op == "<":   return "y < %g" % a
-        if op == "<=":  return "y <= %g" % a
-        if op == "==":  return "y == %g" % a
-        if op == "!=":  return "y != %g" % a
-        if op == "<<":   return "%g < y < %g" % (a, b)
-        if op == "<=<=": return "%g <= y <= %g" % (a, b)
-        if op == "<=<":  return "%g <= y < %g" % (a, b)
-        if op == "<<=":  return "%g < y <= %g" % (a, b)
-        return ""
 
     @staticmethod
     def _add_epoch_sets_from_mask(

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -1,0 +1,111 @@
+"""Pure math utility functions shared across pyNeuroMatic.
+
+No NM object dependencies — only numpy.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+_SINGLE_INEQUALITY_OPS: frozenset[str] = frozenset({">", ">=", "<", "<=", "==", "!="})
+_RANGE_INEQUALITY_OPS: frozenset[str] = frozenset({"<<", "<=<=", "<=<", "<<="})
+VALID_INEQUALITY_OPS: frozenset[str] = _SINGLE_INEQUALITY_OPS | _RANGE_INEQUALITY_OPS
+
+
+def inequality_mask(
+    arr: np.ndarray,
+    op: str,
+    a: float,
+    b: float | None = None,
+) -> np.ndarray:
+    """Return a boolean mask: True where *arr* satisfies the inequality.
+
+    NaN elements propagate as False (numpy comparison behaviour).
+
+    Args:
+        arr: 1-D (or N-D) numpy array of values to test.
+        op:  Comparison operator.  Single-threshold: ``">"``, ``">="``,
+             ``"<"``, ``"<="``, ``"=="``, ``"!="``.  Range (requires *b*):
+             ``"<<"`` (a < y < b), ``"<=<="`` (a <= y <= b),
+             ``"<=<"`` (a <= y < b), ``"<<="`` (a < y <= b).
+        a:   Threshold value (or lower bound for range operators).
+        b:   Upper bound; required for range operators.
+
+    Returns:
+        Boolean numpy array, same shape as *arr*.
+
+    Raises:
+        ValueError: If *op* is not in ``VALID_INEQUALITY_OPS``, or a range
+            op is used without providing *b*.
+    """
+    if op not in VALID_INEQUALITY_OPS:
+        raise ValueError(
+            "unknown operator %r. Valid ops: %s" % (op, sorted(VALID_INEQUALITY_OPS))
+        )
+    if op in _RANGE_INEQUALITY_OPS and b is None:
+        raise ValueError("range operator %r requires b to be specified" % op)
+
+    if op == ">":
+        return arr > a
+    if op == ">=":
+        return arr >= a
+    if op == "<":
+        return arr < a
+    if op == "<=":
+        return arr <= a
+    if op == "==":
+        return arr == a
+    if op == "!=":
+        return arr != a
+    if op == "<<":      # a < y < b
+        return (arr > a) & (arr < b)
+    if op == "<=<=":    # a <= y <= b
+        return (arr >= a) & (arr <= b)
+    if op == "<=<":     # a <= y < b
+        return (arr >= a) & (arr < b)
+    # op == "<<="       # a < y <= b
+    return (arr > a) & (arr <= b)
+
+
+def apply_inequality(
+    arr: np.ndarray,
+    op: str,
+    a: float,
+    b: float | None = None,
+    binary_output: bool = True,
+) -> np.ndarray:
+    """Apply an inequality test and return the result array.
+
+    Args:
+        arr:           Array to test.
+        op:            Comparison operator (see :func:`inequality_mask`).
+        a:             Threshold / lower bound.
+        b:             Upper bound; required for range ops.
+        binary_output: If True (default), returns 1.0 where mask is True,
+                       0.0 elsewhere.  If False, returns the original value
+                       where mask is True and NaN elsewhere.
+
+    Returns:
+        Float numpy array, same shape as *arr*.
+    """
+    mask = inequality_mask(arr, op, a, b)
+    if binary_output:
+        return mask.astype(float)
+    return np.where(mask, arr, np.nan)
+
+
+def inequality_condition_str(op: str, a: float, b: float | None) -> str:
+    """Build a human-readable condition string.
+
+    Examples: ``"y > 50"``, ``"2 < y < 5"``, ``"y == 0"``.
+    """
+    if op == ">":    return "y > %g" % a
+    if op == ">=":   return "y >= %g" % a
+    if op == "<":    return "y < %g" % a
+    if op == "<=":   return "y <= %g" % a
+    if op == "==":   return "y == %g" % a
+    if op == "!=":   return "y != %g" % a
+    if op == "<<":   return "%g < y < %g" % (a, b)
+    if op == "<=<=": return "%g <= y <= %g" % (a, b)
+    if op == "<=<":  return "%g <= y < %g" % (a, b)
+    if op == "<<=":  return "%g < y <= %g" % (a, b)
+    return ""

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -24,6 +24,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpDeleteNaNs,
     NMMainOpDeletePoints,
     NMMainOpDifferentiate,
+    NMMainOpInequality,
     NMMainOpInsertPoints,
     NMMainOpIntegrate,
     NMMainOpMax,
@@ -1968,6 +1969,141 @@ class TestNMMainOpArithmeticByArray(unittest.TestCase):
         op.run_all([(d, None)], folder=None)
         notes = [e["note"] for e in d.notes._entries]
         self.assertTrue(any("NMArithmeticByArray(ref=array,op=+)" in n for n in notes))
+
+
+# ===========================================================================
+# TestNMMainOpInequality
+# ===========================================================================
+
+
+class TestNMMainOpInequality(unittest.TestCase):
+
+    def _run(self, op, arrays_by_name):
+        """Run op and return the folder."""
+        return _run_op_directly(op, arrays_by_name)
+
+    # --- basic output ---
+
+    def test_gt_binary(self):
+        op = NMMainOpInequality(op=">", a=2.0, binary_output=True)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        out = folder.data.get("IQ_RecordA0")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_equal(out.nparray, [0.0, 0.0, 1.0, 1.0, 1.0])
+
+    def test_lt_non_binary(self):
+        op = NMMainOpInequality(op="<", a=4.0, binary_output=False)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        out = folder.data.get("IQ_RecordA0")
+        self.assertIsNotNone(out)
+        arr = out.nparray
+        np.testing.assert_array_equal(arr[:3], [1.0, 2.0, 3.0])
+        self.assertTrue(math.isnan(arr[3]))
+        self.assertTrue(math.isnan(arr[4]))
+
+    def test_range_op(self):
+        op = NMMainOpInequality(op="<=<=", a=2.0, b=4.0, binary_output=True)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        out = folder.data.get("IQ_RecordA0")
+        np.testing.assert_array_equal(out.nparray, [0.0, 1.0, 1.0, 1.0, 0.0])
+
+    # --- output wave in folder ---
+
+    def test_output_wave_created_in_folder(self):
+        op = NMMainOpInequality(op=">", a=0.0)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0]})
+        self.assertIsNotNone(folder.data.get("IQ_RecordA0"))
+
+    def test_output_wave_values(self):
+        op = NMMainOpInequality(op=">=", a=3.0, binary_output=True)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0]})
+        out = folder.data.get("IQ_RecordA0")
+        np.testing.assert_array_equal(out.nparray, [0.0, 0.0, 1.0, 1.0])
+
+    def test_xscale_copied(self):
+        folder = NMFolder(name="folder0")
+        folder.data.new(
+            "RecordA0",
+            nparray=np.array([1.0, 2.0, 3.0], dtype=float),
+            xscale={"start": 0.5, "delta": 0.1, "label": "Time", "units": "ms"},
+            yscale={"label": "Vm", "units": "mV"},
+        )
+        src = folder.data.get("RecordA0")
+        op = NMMainOpInequality(op=">", a=1.5)
+        op.run_all([(src, None)], folder=folder)
+        out = folder.data.get("IQ_RecordA0")
+        self.assertAlmostEqual(out.xscale.start, 0.5)
+        self.assertAlmostEqual(out.xscale.delta, 0.1)
+
+    # --- results dict ---
+
+    def test_results_populated(self):
+        op = NMMainOpInequality(op=">", a=2.0)
+        self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        r = op.results["IQ_RecordA0"]
+        self.assertEqual(r["successes"], 3)
+        self.assertEqual(r["failures"], 2)
+        self.assertEqual(r["condition"], "y > 2")
+
+    def test_multiple_waves(self):
+        op = NMMainOpInequality(op=">", a=0.0)
+        folder = self._run(op, {
+            "RecordA0": [1.0],
+            "RecordA1": [2.0],
+            "RecordA2": [3.0],
+        })
+        self.assertIsNotNone(folder.data.get("IQ_RecordA0"))
+        self.assertIsNotNone(folder.data.get("IQ_RecordA1"))
+        self.assertIsNotNone(folder.data.get("IQ_RecordA2"))
+        self.assertEqual(len(op.results), 3)
+
+    # --- validation ---
+
+    def test_range_op_without_b_raises_in_run_init(self):
+        op = NMMainOpInequality(op="<<", a=1.0)   # b=None
+        folder = NMFolder(name="folder0")
+        d = folder.data.new("RecordA0", nparray=np.array([1.0, 2.0]))
+        with self.assertRaises(ValueError):
+            op.run_all([(d, None)], folder=folder)
+
+    def test_unknown_op_raises_in_setter(self):
+        with self.assertRaises(ValueError):
+            NMMainOpInequality(op="^", a=1.0)
+
+    def test_a_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpInequality(op=">", a=True)
+
+    def test_b_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpInequality(op="<<", a=1.0, b=True)
+
+    def test_b_none_valid(self):
+        op = NMMainOpInequality(op=">", a=1.0, b=None)
+        self.assertIsNone(op.b)
+
+    def test_skips_non_ndarray(self):
+        op = NMMainOpInequality(op=">", a=0.0)
+        folder = NMFolder(name="folder0")
+        d = folder.data.new("RecordA0")   # no nparray
+        op.run_all([(d, None)], folder=folder)
+        # no output wave created, no error
+        self.assertIsNone(folder.data.get("IQ_RecordA0"))
+
+    # --- note ---
+
+    def test_note_written(self):
+        op = NMMainOpInequality(op=">", a=2.0)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0]})
+        out = folder.data.get("IQ_RecordA0")
+        notes = [e["note"] for e in out.notes._entries]
+        self.assertTrue(any("NMInequality(y > 2)" in n for n in notes))
+
+    # --- registry ---
+
+    def test_inequality_by_name(self):
+        op = op_from_name("inequality")
+        self.assertIsInstance(op, NMMainOpInequality)
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -1,0 +1,145 @@
+"""Tests for pyneuromatic.core.nm_math."""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+import pyneuromatic.core.nm_math as nm_math
+from pyneuromatic.core.nm_math import (
+    VALID_INEQUALITY_OPS,
+    apply_inequality,
+    inequality_condition_str,
+    inequality_mask,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ARR = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+
+
+# ---------------------------------------------------------------------------
+# TestInequalityMask
+# ---------------------------------------------------------------------------
+
+
+class TestInequalityMask:
+    def test_gt(self):
+        mask = inequality_mask(ARR, ">", 3.0)
+        np.testing.assert_array_equal(mask, [False, False, False, True, True])
+
+    def test_gte(self):
+        mask = inequality_mask(ARR, ">=", 3.0)
+        np.testing.assert_array_equal(mask, [False, False, True, True, True])
+
+    def test_lt(self):
+        mask = inequality_mask(ARR, "<", 3.0)
+        np.testing.assert_array_equal(mask, [True, True, False, False, False])
+
+    def test_lte(self):
+        mask = inequality_mask(ARR, "<=", 3.0)
+        np.testing.assert_array_equal(mask, [True, True, True, False, False])
+
+    def test_eq(self):
+        mask = inequality_mask(ARR, "==", 3.0)
+        np.testing.assert_array_equal(mask, [False, False, True, False, False])
+
+    def test_neq(self):
+        mask = inequality_mask(ARR, "!=", 3.0)
+        np.testing.assert_array_equal(mask, [True, True, False, True, True])
+
+    def test_range_open_open(self):
+        # a < y < b  →  "<<"
+        mask = inequality_mask(ARR, "<<", 1.0, 4.0)
+        np.testing.assert_array_equal(mask, [False, True, True, False, False])
+
+    def test_range_closed_closed(self):
+        # a <= y <= b  →  "<=<="
+        mask = inequality_mask(ARR, "<=<=", 2.0, 4.0)
+        np.testing.assert_array_equal(mask, [False, True, True, True, False])
+
+    def test_range_closed_open(self):
+        # a <= y < b  →  "<=<"
+        mask = inequality_mask(ARR, "<=<", 2.0, 4.0)
+        np.testing.assert_array_equal(mask, [False, True, True, False, False])
+
+    def test_range_open_closed(self):
+        # a < y <= b  →  "<<="
+        mask = inequality_mask(ARR, "<<=", 2.0, 4.0)
+        np.testing.assert_array_equal(mask, [False, False, True, True, False])
+
+    def test_nan_is_false(self):
+        arr = np.array([1.0, float("nan"), 3.0])
+        mask = inequality_mask(arr, ">", 0.0)
+        assert mask[0] is np.bool_(True)
+        assert not mask[1]  # NaN comparison → False
+        assert mask[2] is np.bool_(True)
+
+    def test_unknown_op_raises(self):
+        with pytest.raises(ValueError, match="unknown operator"):
+            inequality_mask(ARR, "^", 1.0)
+
+    def test_range_op_without_b_raises(self):
+        with pytest.raises(ValueError, match="requires b"):
+            inequality_mask(ARR, "<<", 1.0)  # b not provided
+
+
+# ---------------------------------------------------------------------------
+# TestApplyInequality
+# ---------------------------------------------------------------------------
+
+
+class TestApplyInequality:
+    def test_binary_output_true(self):
+        result = apply_inequality(ARR, ">", 3.0, binary_output=True)
+        np.testing.assert_array_equal(result, [0.0, 0.0, 0.0, 1.0, 1.0])
+        assert result.dtype == float
+
+    def test_binary_output_false(self):
+        result = apply_inequality(ARR, ">", 3.0, binary_output=False)
+        assert math.isnan(result[0])
+        assert math.isnan(result[1])
+        assert math.isnan(result[2])
+        assert result[3] == 4.0
+        assert result[4] == 5.0
+
+
+# ---------------------------------------------------------------------------
+# TestInequalityConditionStr
+# ---------------------------------------------------------------------------
+
+
+class TestInequalityConditionStr:
+    def test_gt(self):
+        assert inequality_condition_str(">", 5.0, None) == "y > 5"
+
+    def test_gte(self):
+        assert inequality_condition_str(">=", 5.0, None) == "y >= 5"
+
+    def test_lt(self):
+        assert inequality_condition_str("<", 5.0, None) == "y < 5"
+
+    def test_lte(self):
+        assert inequality_condition_str("<=", 5.0, None) == "y <= 5"
+
+    def test_eq(self):
+        assert inequality_condition_str("==", 0.0, None) == "y == 0"
+
+    def test_neq(self):
+        assert inequality_condition_str("!=", 0.0, None) == "y != 0"
+
+    def test_range_open_open(self):
+        assert inequality_condition_str("<<", 2.0, 5.0) == "2 < y < 5"
+
+    def test_range_closed_closed(self):
+        assert inequality_condition_str("<=<=", 2.0, 5.0) == "2 <= y <= 5"
+
+    def test_range_closed_open(self):
+        assert inequality_condition_str("<=<", 2.0, 5.0) == "2 <= y < 5"
+
+    def test_range_open_closed(self):
+        assert inequality_condition_str("<<=", 2.0, 5.0) == "2 < y <= 5"


### PR DESCRIPTION
## Summary
- Adds `NMMainOpInequality` — applies an inequality test point-by-point to
  each data waveform and writes `IQ_{name}` output arrays to the source
  folder (non-destructive); `binary_output=True` → 1.0/0.0, `False` → value/NaN
- Extracts shared inequality logic into a new `pyneuromatic/core/nm_math.py`
  pure-function module; `NMToolStats2.inequality` now delegates to it
- Removes the now-redundant `NMToolStats2._inequality_condition_str` static method

## Test plan
- [ ] `python3 -m pytest tests/test_core/test_nm_math.py -v` — 25 new tests
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py -v` — 15 new tests
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_stats.py -v` — all existing tests pass
- [ ] `python3 -m pytest tests/ -x -q` — full suite green (1807 tests)

Closes #195 