### PR TITLE
feat(analysis): NMMainOpHistogram — amplitude histogram per waveform

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -24,6 +24,7 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 
+import math
 import numpy as np
 
 from pyneuromatic.core.nm_data import NMData
@@ -981,9 +982,9 @@ class NMMainOpBaseline(NMMainOp):
       wave in that channel.
 
     Parameters:
-        t_begin: Baseline window start in time units (default 0.0).
-        t_end: Baseline window end in time units (default 0.0).  Must be >=
-            ``t_begin``.
+        x0: Baseline window start in time units (default 0.0).
+        x1: Baseline window end in time units (default 0.0).  Must be >=
+            ``x0``.
         mode: ``"per_wave"`` (default) or ``"average"``.
         ignore_nans: If True (default) use ``np.nanmean``; otherwise ``np.mean``
             (NaN propagates to the result).
@@ -995,13 +996,13 @@ class NMMainOpBaseline(NMMainOp):
 
     def __init__(
         self,
-        t_begin: float = 0.0,
-        t_end: float = 0.0,
+        x0: float = 0.0,
+        x1: float = 0.0,
         mode: str = "per_wave",
         ignore_nans: bool = True,
     ) -> None:
-        self.t_begin = t_begin
-        self.t_end = t_end
+        self.x0 = x0
+        self.x1 = x1
         self.mode = mode
         self.ignore_nans = ignore_nans
 
@@ -1009,26 +1010,26 @@ class NMMainOpBaseline(NMMainOp):
     # Properties
 
     @property
-    def t_begin(self) -> float:
+    def x0(self) -> float:
         """Baseline window start (time units)."""
-        return self._t_begin
+        return self._x0
 
-    @t_begin.setter
-    def t_begin(self, value: float) -> None:
+    @x0.setter
+    def x0(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "t_begin", "float"))
-        self._t_begin = float(value)
+            raise TypeError(nmu.type_error_str(value, "x0", "float"))
+        self._x0 = float(value)
 
     @property
-    def t_end(self) -> float:
+    def x1(self) -> float:
         """Baseline window end (time units)."""
-        return self._t_end
+        return self._x1
 
-    @t_end.setter
-    def t_end(self, value: float) -> None:
+    @x1.setter
+    def x1(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "t_end", "float"))
-        self._t_end = float(value)
+            raise TypeError(nmu.type_error_str(value, "x1", "float"))
+        self._x1 = float(value)
 
     @property
     def mode(self) -> str:
@@ -1060,9 +1061,9 @@ class NMMainOpBaseline(NMMainOp):
     # Validation helper
 
     def _validate_window(self) -> None:
-        if self._t_end < self._t_begin:
+        if self._x1 < self._x0:
             raise ValueError(
-                "t_end (%g) must be >= t_begin (%g)" % (self._t_end, self._t_begin)
+                "x1 (%g) must be >= x0 (%g)" % (self._x1, self._x0)
             )
 
     # ------------------------------------------------------------------
@@ -1094,7 +1095,7 @@ class NMMainOpBaseline(NMMainOp):
             channel_name = parsed[1] if parsed is not None else "A"
 
         sl = nm_math.time_window_to_slice(
-            data.nparray, data.xscale.to_dict(), self._t_begin, self._t_end
+            data.nparray, data.xscale.to_dict(), self._x0, self._x1
         )
         segment = data.nparray[sl].astype(float)
         if len(segment) == 0:
@@ -1108,8 +1109,8 @@ class NMMainOpBaseline(NMMainOp):
             data.nparray = data.nparray.astype(float) - baseline
             self._add_note(
                 data,
-                "NMBaseline(t_begin=%.6g,t_end=%.6g,mode=per_wave,baseline=%.6g)"
-                % (self._t_begin, self._t_end, baseline),
+                "NMBaseline(x0=%.6g,x1=%.6g,mode=per_wave,baseline=%.6g)"
+                % (self._x0, self._x1, baseline),
             )
         else:  # "average"
             self._baseline_accum.setdefault(channel_name, []).append(baseline)
@@ -1136,8 +1137,8 @@ class NMMainOpBaseline(NMMainOp):
                 d.nparray = d.nparray.astype(float) - avg_baseline
                 self._add_note(
                     d,
-                    "NMBaseline(t_begin=%.6g,t_end=%.6g,mode=average,channel=%s,baseline=%.6g)"
-                    % (self._t_begin, self._t_end, channel_name, avg_baseline),
+                    "NMBaseline(x0=%.6g,x1=%.6g,mode=average,channel=%s,baseline=%.6g)"
+                    % (self._x0, self._x1, channel_name, avg_baseline),
                 )
 
 
@@ -1486,9 +1487,9 @@ class NMMainOpNormalize(NMMainOp):
 
     Two independent time windows are used:
 
-    - Window 1 (``t_begin1``/``t_end1``) computes the "low" reference via
+    - Window 1 (``x0_min``/``x1_min``) computes the "low" reference via
       ``fxn1`` (``"mean"``, ``"min"``, or ``"mean@min"``).
-    - Window 2 (``t_begin2``/``t_end2``) computes the "high" reference via
+    - Window 2 (``x0_max``/``x1_max``) computes the "high" reference via
       ``fxn2`` (``"mean"``, ``"max"``, or ``"mean@max"``).
 
     Two modes (matching NMMainOpBaseline):
@@ -1498,13 +1499,13 @@ class NMMainOpNormalize(NMMainOp):
       then applied to every wave in that channel.
 
     Parameters:
-        t_begin1: Window 1 start in time units (default 0.0).
-        t_end1: Window 1 end in time units (default 0.0).
+        x0_min: Window 1 start in time units (default 0.0).
+        x1_min: Window 1 end in time units (default 0.0).
         fxn1: Function for the low reference: ``"mean"``, ``"min"``, or
             ``"mean@min"`` (default ``"mean"``).
         n_mean1: Points around min for ``mean@min`` (default 1).
-        t_begin2: Window 2 start in time units (default 0.0).
-        t_end2: Window 2 end in time units (default 0.0).
+        x0_max: Window 2 start in time units (default 0.0).
+        x1_max: Window 2 end in time units (default 0.0).
         fxn2: Function for the high reference: ``"mean"``, ``"max"``, or
             ``"mean@max"`` (default ``"mean"``).
         n_mean2: Points around max for ``mean@max`` (default 1).
@@ -1521,24 +1522,24 @@ class NMMainOpNormalize(NMMainOp):
 
     def __init__(
         self,
-        t_begin1: float = 0.0,
-        t_end1: float = 0.0,
+        x0_min: float = 0.0,
+        x1_min: float = 0.0,
         fxn1: str = "mean",
         n_mean1: int = 1,
-        t_begin2: float = 0.0,
-        t_end2: float = 0.0,
+        x0_max: float = 0.0,
+        x1_max: float = 0.0,
         fxn2: str = "mean",
         n_mean2: int = 1,
         norm_min: float = 0.0,
         norm_max: float = 1.0,
         mode: str = "per_wave",
     ) -> None:
-        self.t_begin1 = t_begin1
-        self.t_end1 = t_end1
+        self.x0_min = x0_min
+        self.x1_min = x1_min
         self.fxn1 = fxn1
         self.n_mean1 = n_mean1
-        self.t_begin2 = t_begin2
-        self.t_end2 = t_end2
+        self.x0_max = x0_max
+        self.x1_max = x1_max
         self.fxn2 = fxn2
         self.n_mean2 = n_mean2
         self.norm_min = norm_min
@@ -1549,26 +1550,26 @@ class NMMainOpNormalize(NMMainOp):
     # Properties
 
     @property
-    def t_begin1(self) -> float:
+    def x0_min(self) -> float:
         """Window 1 start (time units)."""
-        return self._t_begin1
+        return self._x0_min
 
-    @t_begin1.setter
-    def t_begin1(self, value: float) -> None:
+    @x0_min.setter
+    def x0_min(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "t_begin1", "float"))
-        self._t_begin1 = float(value)
+            raise TypeError(nmu.type_error_str(value, "x0_min", "float"))
+        self._x0_min = float(value)
 
     @property
-    def t_end1(self) -> float:
+    def x1_min(self) -> float:
         """Window 1 end (time units)."""
-        return self._t_end1
+        return self._x1_min
 
-    @t_end1.setter
-    def t_end1(self, value: float) -> None:
+    @x1_min.setter
+    def x1_min(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "t_end1", "float"))
-        self._t_end1 = float(value)
+            raise TypeError(nmu.type_error_str(value, "x1_min", "float"))
+        self._x1_min = float(value)
 
     @property
     def fxn1(self) -> str:
@@ -1599,26 +1600,26 @@ class NMMainOpNormalize(NMMainOp):
         self._n_mean1 = value
 
     @property
-    def t_begin2(self) -> float:
+    def x0_max(self) -> float:
         """Window 2 start (time units)."""
-        return self._t_begin2
+        return self._x0_max
 
-    @t_begin2.setter
-    def t_begin2(self, value: float) -> None:
+    @x0_max.setter
+    def x0_max(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "t_begin2", "float"))
-        self._t_begin2 = float(value)
+            raise TypeError(nmu.type_error_str(value, "x0_max", "float"))
+        self._x0_max = float(value)
 
     @property
-    def t_end2(self) -> float:
+    def x1_max(self) -> float:
         """Window 2 end (time units)."""
-        return self._t_end2
+        return self._x1_max
 
-    @t_end2.setter
-    def t_end2(self, value: float) -> None:
+    @x1_max.setter
+    def x1_max(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "t_end2", "float"))
-        self._t_end2 = float(value)
+            raise TypeError(nmu.type_error_str(value, "x1_max", "float"))
+        self._x1_max = float(value)
 
     @property
     def fxn2(self) -> str:
@@ -1689,13 +1690,13 @@ class NMMainOpNormalize(NMMainOp):
     # Validation helper
 
     def _validate_windows(self) -> None:
-        if self._t_end1 < self._t_begin1:
+        if self._x1_min < self._x0_min:
             raise ValueError(
-                "t_end1 (%g) must be >= t_begin1 (%g)" % (self._t_end1, self._t_begin1)
+                "x1_min (%g) must be >= x0_min (%g)" % (self._x1_min, self._x0_min)
             )
-        if self._t_end2 < self._t_begin2:
+        if self._x1_max < self._x0_max:
             raise ValueError(
-                "t_end2 (%g) must be >= t_begin2 (%g)" % (self._t_end2, self._t_begin2)
+                "x1_max (%g) must be >= x0_max (%g)" % (self._x1_max, self._x0_max)
             )
 
     # ------------------------------------------------------------------
@@ -1710,12 +1711,12 @@ class NMMainOpNormalize(NMMainOp):
 
     def _note_str(self, ref_min: float, ref_max: float, channel_name: str | None = None) -> str:
         note = (
-            "NMNormalize(t_begin1=%.6g,t_end1=%.6g,fxn1=%s,"
-            "t_begin2=%.6g,t_end2=%.6g,fxn2=%s,"
+            "NMNormalize(x0_min=%.6g,x1_min=%.6g,fxn1=%s,"
+            "x0_max=%.6g,x1_max=%.6g,fxn2=%s,"
             "norm_min=%.6g,norm_max=%.6g,mode=%s"
         ) % (
-            self._t_begin1, self._t_end1, self._fxn1,
-            self._t_begin2, self._t_end2, self._fxn2,
+            self._x0_min, self._x1_min, self._fxn1,
+            self._x0_max, self._x1_max, self._fxn2,
             self._norm_min, self._norm_max, self._mode,
         )
         if channel_name is not None:
@@ -1754,8 +1755,8 @@ class NMMainOpNormalize(NMMainOp):
 
         arr = data.nparray.astype(float)
         xd = data.xscale.to_dict()
-        sl1 = nm_math.time_window_to_slice(arr, xd, self._t_begin1, self._t_end1)
-        sl2 = nm_math.time_window_to_slice(arr, xd, self._t_begin2, self._t_end2)
+        sl1 = nm_math.time_window_to_slice(arr, xd, self._x0_min, self._x1_min)
+        sl2 = nm_math.time_window_to_slice(arr, xd, self._x0_max, self._x1_max)
         ref_min = nm_math.compute_ref_value(arr[sl1], self._fxn1, self._n_mean1)
         ref_max = nm_math.compute_ref_value(arr[sl2], self._fxn2, self._n_mean2)
 
@@ -1929,6 +1930,183 @@ class NMMainOpInequality(NMMainOp):
 
 
 # =========================================================================
+# NMMainOpHistogram
+# =========================================================================
+
+
+class NMMainOpHistogram(NMMainOp):
+    """Compute an amplitude histogram for each data waveform.
+
+    For each wave, all sample values are passed to ``numpy.histogram``
+    and the resulting bin-counts array is written as a new wave
+    ``H_{data.name}`` in the source folder (non-destructive).
+
+    The output wave's x-scale represents the histogram bins:
+    ``xscale.start`` = left edge of the first bin,
+    ``xscale.delta`` = uniform bin width.
+    ``xscale.label`` / ``xscale.units`` are taken from the input
+    wave's y-scale so axis labels remain meaningful.
+
+    NaN and Inf values are silently excluded before histogramming
+    (same behaviour as ``NMToolStats2.histogram``).
+
+    Args:
+        bins:    Number of equal-width bins (int) or explicit bin-edge
+                 list.  Defaults to 10.
+        x0:      Start of the time window (default ``-inf`` = beginning
+                 of wave).
+        x1:      End of the time window (default ``+inf`` = end of wave).
+        xrange:  ``(min, max)`` tuple to restrict the amplitude range.
+                 Defaults to None (full range of each wave).
+        density: If True, return probability density instead of counts.
+                 Defaults to False.
+    """
+
+    name = "histogram"
+
+    def __init__(
+        self,
+        bins: int | list = 10,
+        x0: float = -math.inf,
+        x1: float = math.inf,
+        xrange: tuple | None = None,
+        density: bool = False,
+    ) -> None:
+        self.bins = bins
+        self.x0 = x0
+        self.x1 = x1
+        self.xrange = xrange
+        self.density = density
+        self._results: dict = {}
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def bins(self):
+        return self._bins
+
+    @bins.setter
+    def bins(self, value) -> None:
+        if isinstance(value, bool):
+            raise TypeError("bins must be int or list, not bool")
+        if isinstance(value, int):
+            if value < 1:
+                raise ValueError("bins must be >= 1, got %d" % value)
+        elif isinstance(value, list):
+            pass  # numpy validates content at histogram time
+        else:
+            raise TypeError(nmu.type_error_str(value, "bins", "int or list"))
+        self._bins = value
+
+    @property
+    def x0(self) -> float:
+        """Start of the time window (default ``-inf``)."""
+        return self._x0
+
+    @x0.setter
+    def x0(self, value: float) -> None:
+        value = float(value)
+        if math.isnan(value):
+            raise ValueError("x0 must not be NaN")
+        self._x0 = -math.inf if math.isinf(value) else value
+
+    @property
+    def x1(self) -> float:
+        """End of the time window (default ``+inf``)."""
+        return self._x1
+
+    @x1.setter
+    def x1(self, value: float) -> None:
+        value = float(value)
+        if math.isnan(value):
+            raise ValueError("x1 must not be NaN")
+        self._x1 = math.inf if math.isinf(value) else value
+
+    @property
+    def xrange(self) -> tuple | None:
+        return self._xrange
+
+    @xrange.setter
+    def xrange(self, value: tuple | None) -> None:
+        if value is None:
+            self._xrange = None
+            return
+        if not isinstance(value, tuple) or len(value) != 2:
+            raise TypeError("xrange must be a 2-tuple (min, max) or None")
+        self._xrange = value
+
+    @property
+    def density(self) -> bool:
+        return self._density
+
+    @density.setter
+    def density(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "density", "bool"))
+        self._density = value
+
+    @property
+    def results(self) -> dict:
+        """Per-output-wave dict; populated after :meth:`run_all`."""
+        return self._results
+
+    # ------------------------------------------------------------------
+    # NMMainOp interface
+    # ------------------------------------------------------------------
+
+    def run_init(self) -> None:
+        self._results = {}
+
+    def run(self, data: NMData, channel_name: str | None = None) -> None:
+        if not isinstance(data.nparray, np.ndarray):
+            return
+        arr = data.nparray.astype(float)
+
+        # Apply time window if either bound is finite
+        if not (self._x0 == -math.inf and self._x1 == math.inf):
+            sl = nm_math.time_window_to_slice(
+                arr, data.xscale.to_dict(), self._x0, self._x1
+            )
+            arr = arr[sl]
+
+        arr_finite = arr[np.isfinite(arr)]  # exclude NaN and Inf
+
+        counts, edges = np.histogram(
+            arr_finite, bins=self._bins,
+            range=self._xrange, density=self._density,
+        )
+
+        out_name = "H_" + data.name
+        if self._folder is not None:
+            xscale = {
+                "start": float(edges[0]),
+                "delta": float(edges[1] - edges[0]),
+                "label": data.yscale.label,  # input y-axis → output x-axis
+                "units": data.yscale.units,
+            }
+            yscale = {
+                "label": "density" if self._density else "counts",
+                "units": "",
+            }
+            self._folder.data.new(out_name, nparray=counts.astype(float),
+                                  xscale=xscale, yscale=yscale)
+            out_data = self._folder.data.get(out_name)
+            if out_data is not None:
+                self._add_note(
+                    out_data,
+                    "NMHistogram(bins=%s,x0=%s,x1=%s,density=%s)"
+                    % (self._bins, self._x0, self._x1, self._density),
+                )
+        self._results[out_name] = {
+            "counts": counts,
+            "edges": edges,
+            "n_excluded": data.nparray.size - len(arr_finite),
+        }
+
+
+# =========================================================================
 # Registry and lookup
 # =========================================================================
 
@@ -1941,6 +2119,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "delete_nans": NMMainOpDeleteNaNs,
     "delete_points": NMMainOpDeletePoints,
     "differentiate": NMMainOpDifferentiate,
+    "histogram": NMMainOpHistogram,
     "inequality": NMMainOpInequality,
     "insert_points": NMMainOpInsertPoints,
     "integrate": NMMainOpIntegrate,

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -733,8 +733,8 @@ class NMToolStats2:
                 Defaults to None (full data range).
             density: If True, return probability density instead of counts.
                 Defaults to False.
-            save_to_numpy: If True, save ``HIST_{name}_counts`` and
-                ``HIST_{name}_edges`` as NMData arrays in toolfolder.
+            save_to_numpy: If True, save ``H_{name}_counts`` and
+                ``H_{name}_edges`` as NMData arrays in toolfolder.
                 Defaults to True.
 
         Returns:
@@ -770,12 +770,12 @@ class NMToolStats2:
             xscale = {"start": float(edges[0]),
                       "delta": float(edges[1] - edges[0])}
             toolfolder.data.new(
-                "HIST_%s_counts" % name,
+                "H_%s_counts" % name,
                 nparray=counts.astype(float),
                 xscale=xscale,
             )
             toolfolder.data.new(
-                "HIST_%s_edges" % name,
+                "H_%s_edges" % name,
                 nparray=edges,
             )
 

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -203,19 +203,22 @@ def compute_ref_value(arr: np.ndarray, fxn: str, n_mean: int) -> float:
 def time_window_to_slice(
     arr: np.ndarray,
     xscale_dict: dict,
-    t_begin: float,
-    t_end: float,
+    x0: float,
+    x1: float,
 ) -> slice:
     """Convert a time window to an array slice using xscale start/delta.
 
     Clips to valid range; returns an empty slice if the window is fully
-    outside the array bounds.
+    outside the array bounds.  Infinite bounds are treated as array
+    boundaries (``-inf`` → index 0, ``+inf`` → index len(arr)).
 
     Args:
         arr:         Array whose length defines the valid index range.
         xscale_dict: Dict with ``"start"`` and ``"delta"`` keys (floats).
-        t_begin:     Start of the time window.
-        t_end:       End of the time window (inclusive).
+        x0:     Start of the time window.  ``-inf`` selects from the
+                     beginning of the array.
+        x1:       End of the time window (inclusive).  ``+inf`` selects
+                     to the end of the array.
 
     Returns:
         A :class:`slice` suitable for indexing *arr*.
@@ -224,8 +227,8 @@ def time_window_to_slice(
     delta = xscale_dict.get("delta", 1.0)
     if delta == 0:
         return slice(0, 0)
-    i0 = int(round((t_begin - start) / delta))
-    i1 = int(round((t_end - start) / delta)) + 1  # inclusive end
+    i0 = 0 if math.isinf(x0) else int(round((x0 - start) / delta))
+    i1 = len(arr) if math.isinf(x1) else int(round((x1 - start) / delta)) + 1
     i0 = max(0, i0)
     i1 = min(len(arr), i1)
     return slice(i0, i1)

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -24,6 +24,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpDeleteNaNs,
     NMMainOpDeletePoints,
     NMMainOpDifferentiate,
+    NMMainOpHistogram,
     NMMainOpInequality,
     NMMainOpInsertPoints,
     NMMainOpIntegrate,
@@ -637,7 +638,7 @@ class TestNMMainOpInsertPoints(unittest.TestCase):
         self._run()
         np.testing.assert_array_equal(self.data.nparray, [0.0, 1.0, 2.0, 3.0])
 
-    def test_insert_at_end(self):
+    def test_insert_ax1(self):
         self.op.index = 3
         self._run()
         np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 0.0])
@@ -716,7 +717,7 @@ class TestNMMainOpDeletePoints(unittest.TestCase):
         self._run()
         np.testing.assert_array_equal(self.data.nparray, [2.0, 3.0, 4.0, 5.0])
 
-    def test_delete_at_end(self):
+    def test_delete_ax1(self):
         self.op.index = 4
         self._run()
         np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 4.0])
@@ -880,7 +881,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
 
     def test_per_wave_subtracts_correct_baseline(self):
         # window [0,1] covers first 2 points [2,2] → baseline=2
-        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="per_wave")
+        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="per_wave")
         d = _make_data("RecordA0", [2.0, 2.0, 4.0, 4.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
@@ -888,7 +889,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
 
     def test_per_wave_different_baselines(self):
         # Two waves with different values in baseline window → independent shifts
-        op = NMMainOpBaseline(t_begin=0.0, t_end=0.0, mode="per_wave")
+        op = NMMainOpBaseline(x0=0.0, x1=0.0, mode="per_wave")
         d1 = _make_data("RecordA0", [1.0, 5.0], xstart=0.0, xdelta=1.0)
         d2 = _make_data("RecordA1", [3.0, 7.0], xstart=0.0, xdelta=1.0)
         op.run_init()
@@ -898,7 +899,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
         np.testing.assert_array_almost_equal(d2.nparray, [0.0, 4.0])
 
     def test_per_wave_nan_ignored(self):
-        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="per_wave", ignore_nans=True)
+        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="per_wave", ignore_nans=True)
         d = _make_data("RecordA0", [np.nan, 2.0, 5.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
@@ -907,7 +908,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
         self.assertAlmostEqual(float(d.nparray[2]), 3.0)
 
     def test_per_wave_nan_propagates(self):
-        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="per_wave", ignore_nans=False)
+        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="per_wave", ignore_nans=False)
         d = _make_data("RecordA0", [np.nan, 2.0, 5.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
@@ -916,7 +917,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
 
     def test_window_out_of_range_no_subtraction(self):
         # Window is past end of array → empty slice → baseline=0 → no change
-        op = NMMainOpBaseline(t_begin=100.0, t_end=200.0, mode="per_wave")
+        op = NMMainOpBaseline(x0=100.0, x1=200.0, mode="per_wave")
         d = _make_data("RecordA0", [5.0, 6.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
@@ -924,7 +925,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
 
     def test_window_partial_clip(self):
         # Window extends beyond array end — only existing samples used
-        op = NMMainOpBaseline(t_begin=1.0, t_end=10.0, mode="per_wave")
+        op = NMMainOpBaseline(x0=1.0, x1=10.0, mode="per_wave")
         # xdelta=1, array=[0,1,2,3]; window 1..10 clips to indices 1..4
         d = _make_data("RecordA0", [0.0, 2.0, 4.0, 6.0], xstart=0.0, xdelta=1.0)
         op.run_init()
@@ -938,7 +939,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
     def test_average_mode_shared_baseline(self):
         # 3 waves [2,2], [4,4], [6,6]; window covers full wave → baselines 2,4,6
         # avg baseline = 4; all shifted by -4
-        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="average")
+        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="average")
         d1 = _make_data("RecordA0", [2.0, 2.0], xstart=0.0, xdelta=1.0)
         d2 = _make_data("RecordA1", [4.0, 4.0], xstart=0.0, xdelta=1.0)
         d3 = _make_data("RecordA2", [6.0, 6.0], xstart=0.0, xdelta=1.0)
@@ -953,7 +954,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
 
     def test_average_mode_per_channel(self):
         # Channel A: baselines 2,4 → avg=3; Channel B: baseline 10 → avg=10
-        op = NMMainOpBaseline(t_begin=0.0, t_end=0.0, mode="average")
+        op = NMMainOpBaseline(x0=0.0, x1=0.0, mode="average")
         a0 = _make_data("RecordA0", [2.0, 8.0], xstart=0.0, xdelta=1.0)
         a1 = _make_data("RecordA1", [4.0, 8.0], xstart=0.0, xdelta=1.0)
         b0 = _make_data("RecordB0", [10.0, 5.0], xstart=0.0, xdelta=1.0)
@@ -970,7 +971,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
 
     def test_average_mode_nan_ignored(self):
         # NaN in baseline window → nanmean used, result finite
-        op = NMMainOpBaseline(t_begin=0.0, t_end=1.0, mode="average", ignore_nans=True)
+        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="average", ignore_nans=True)
         d = _make_data("RecordA0", [np.nan, 4.0, 10.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d, "A")
@@ -989,18 +990,18 @@ class TestNMMainOpBaseline(unittest.TestCase):
         with self.assertRaises(TypeError):
             NMMainOpBaseline(mode=1)
 
-    def test_t_end_before_t_begin_raises(self):
-        op = NMMainOpBaseline(t_begin=5.0, t_end=2.0)
+    def test_x1_before_x0_raises(self):
+        op = NMMainOpBaseline(x0=5.0, x1=2.0)
         with self.assertRaises(ValueError):
             op.run_init()  # calls _validate_window → raises
 
-    def test_t_begin_rejects_bool(self):
+    def test_x0_rejects_bool(self):
         with self.assertRaises(TypeError):
-            NMMainOpBaseline(t_begin=True)
+            NMMainOpBaseline(x0=True)
 
-    def test_t_end_rejects_bool(self):
+    def test_x1_rejects_bool(self):
         with self.assertRaises(TypeError):
-            NMMainOpBaseline(t_end=True)
+            NMMainOpBaseline(x1=True)
 
     def test_ignore_nans_rejects_non_bool(self):
         with self.assertRaises(TypeError):
@@ -1015,16 +1016,16 @@ class TestNMMainOpBaseline(unittest.TestCase):
     # --- notes ---
 
     def test_per_wave_note_written(self):
-        op = NMMainOpBaseline(t_begin=0.0, t_end=0.0, mode="per_wave")
+        op = NMMainOpBaseline(x0=0.0, x1=0.0, mode="per_wave")
         d = _make_data("RecordA0", [3.0, 5.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
         self.assertEqual(len(d.notes), 1)
         note = d.notes[0]["note"]
-        self.assertIn("NMBaseline(t_begin=0,t_end=0,mode=per_wave,baseline=3)", note)
+        self.assertIn("NMBaseline(x0=0,x1=0,mode=per_wave,baseline=3)", note)
 
     def test_average_note_written(self):
-        op = NMMainOpBaseline(t_begin=0.0, t_end=0.0, mode="average")
+        op = NMMainOpBaseline(x0=0.0, x1=0.0, mode="average")
         d1 = _make_data("RecordA0", [2.0, 8.0], xstart=0.0, xdelta=1.0)
         d2 = _make_data("RecordA1", [4.0, 6.0], xstart=0.0, xdelta=1.0)
         op.run_init()
@@ -1035,7 +1036,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
         for d in (d1, d2):
             self.assertEqual(len(d.notes), 1)
             note = d.notes[0]["note"]
-            self.assertIn("NMBaseline(t_begin=0,t_end=0,mode=average,channel=A,baseline=3)", note)
+            self.assertIn("NMBaseline(x0=0,x1=0,mode=average,channel=A,baseline=3)", note)
 
 
 # ===========================================================================
@@ -1443,8 +1444,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_per_wave_min_max(self):
         # [0,5,10], fxn1=min→0, fxn2=max→10, range=10 → [0.0, 0.5, 1.0]
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=2.0, fxn1="min",
-            t_begin2=0.0, t_end2=2.0, fxn2="max",
+            x0_min=0.0, x1_min=2.0, fxn1="min",
+            x0_max=0.0, x1_max=2.0, fxn2="max",
         )
         data = _make_data("RecordA0", [0.0, 5.0, 10.0])
         op.run_init()
@@ -1454,8 +1455,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_per_wave_mean_zero_range(self):
         # fxn1=mean and fxn2=mean over same window → ref_min==ref_max → norm_min everywhere
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=4.0, fxn1="mean",
-            t_begin2=0.0, t_end2=4.0, fxn2="mean",
+            x0_min=0.0, x1_min=4.0, fxn1="mean",
+            x0_max=0.0, x1_max=4.0, fxn2="mean",
             norm_min=-99.0,
         )
         data = _make_data("RecordA0", [0.0, 2.0, 4.0, 6.0, 8.0])
@@ -1466,8 +1467,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_per_wave_uses_windows(self):
         # [0,1,2,3,4] xdelta=1; window1=[0,0]→first point(0), window2=[4,4]→last point(4)
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=0.0, fxn1="mean",
-            t_begin2=4.0, t_end2=4.0, fxn2="mean",
+            x0_min=0.0, x1_min=0.0, fxn1="mean",
+            x0_max=4.0, x1_max=4.0, fxn2="mean",
         )
         data = _make_data("RecordA0", [0.0, 1.0, 2.0, 3.0, 4.0])
         op.run_init()
@@ -1477,8 +1478,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_per_wave_custom_norm_range(self):
         # norm_min=-1, norm_max=1; [0,5,10]→ref_min=0,ref_max=10 → [-1,0,1]
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=2.0, fxn1="min",
-            t_begin2=0.0, t_end2=2.0, fxn2="max",
+            x0_min=0.0, x1_min=2.0, fxn1="min",
+            x0_max=0.0, x1_max=2.0, fxn2="max",
             norm_min=-1.0, norm_max=1.0,
         )
         data = _make_data("RecordA0", [0.0, 5.0, 10.0])
@@ -1490,8 +1491,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
         # [3,1,2], fxn1=mean@min, n_mean1=3; min at i=1, mean of [3,1,2]=2.0 → ref_min=2.0
         # fxn2=max → ref_max=3.0; range=1; normalized: arr-2.0 → [1,-1,0]
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=2.0, fxn1="mean@min", n_mean1=3,
-            t_begin2=0.0, t_end2=2.0, fxn2="max",
+            x0_min=0.0, x1_min=2.0, fxn1="mean@min", n_mean1=3,
+            x0_max=0.0, x1_max=2.0, fxn2="max",
         )
         data = _make_data("RecordA0", [3.0, 1.0, 2.0])
         op.run_init()
@@ -1502,8 +1503,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
         # [1,5,3], fxn2=mean@max, n_mean2=3; max at i=1, mean of [1,5,3]=3.0 → ref_max=3.0
         # fxn1=min → ref_min=1.0; range=2; normalized: (arr-1)/2 → [0,2,1]
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=2.0, fxn1="min",
-            t_begin2=0.0, t_end2=2.0, fxn2="mean@max", n_mean2=3,
+            x0_min=0.0, x1_min=2.0, fxn1="min",
+            x0_max=0.0, x1_max=2.0, fxn2="mean@max", n_mean2=3,
         )
         data = _make_data("RecordA0", [1.0, 5.0, 3.0])
         op.run_init()
@@ -1512,8 +1513,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
 
     def test_per_wave_preserves_length(self):
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=99.0, fxn1="min",
-            t_begin2=0.0, t_end2=99.0, fxn2="max",
+            x0_min=0.0, x1_min=99.0, fxn1="min",
+            x0_max=0.0, x1_max=99.0, fxn2="max",
         )
         data = _make_data("RecordA0", list(range(100)))
         op.run_init()
@@ -1526,8 +1527,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_average_mode_shared_refs(self):
         # 2 waves same channel; ref_mins=[0,2]→avg=1, ref_maxes=[4,6]→avg=5, range=4
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=1.0, fxn1="min",
-            t_begin2=0.0, t_end2=1.0, fxn2="max",
+            x0_min=0.0, x1_min=1.0, fxn1="min",
+            x0_max=0.0, x1_max=1.0, fxn2="max",
             mode="average",
         )
         d0 = _make_data("RecordA0", [0.0, 4.0])
@@ -1539,8 +1540,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_average_mode_per_channel(self):
         # Channel A ref_max=10, channel B ref_max=5 — independent
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=1.0, fxn1="min",
-            t_begin2=0.0, t_end2=1.0, fxn2="max",
+            x0_min=0.0, x1_min=1.0, fxn1="min",
+            x0_max=0.0, x1_max=1.0, fxn2="max",
             mode="average",
         )
         dA = _make_data("RecordA0", [0.0, 10.0])
@@ -1589,8 +1590,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
         with self.assertRaises(ValueError):
             NMMainOpNormalize(mode="bad")
 
-    def test_t_end1_before_t_begin1_raises(self):
-        op = NMMainOpNormalize(t_begin1=5.0, t_end1=0.0)
+    def test_x1_min_before_x0_min_raises(self):
+        op = NMMainOpNormalize(x0_min=5.0, x1_min=0.0)
         with self.assertRaises(ValueError):
             op.run_init()
 
@@ -1606,8 +1607,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
 
     def test_note_per_wave(self):
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=2.0, fxn1="min",
-            t_begin2=0.0, t_end2=2.0, fxn2="max",
+            x0_min=0.0, x1_min=2.0, fxn1="min",
+            x0_max=0.0, x1_max=2.0, fxn2="max",
             mode="per_wave",
         )
         data = _make_data("RecordA0", [0.0, 5.0, 10.0])
@@ -1622,8 +1623,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
 
     def test_note_average(self):
         op = NMMainOpNormalize(
-            t_begin1=0.0, t_end1=1.0, fxn1="min",
-            t_begin2=0.0, t_end2=1.0, fxn2="max",
+            x0_min=0.0, x1_min=1.0, fxn1="min",
+            x0_max=0.0, x1_max=1.0, fxn2="max",
             mode="average",
         )
         data = _make_data("RecordA0", [0.0, 10.0])
@@ -2104,6 +2105,260 @@ class TestNMMainOpInequality(unittest.TestCase):
     def test_inequality_by_name(self):
         op = op_from_name("inequality")
         self.assertIsInstance(op, NMMainOpInequality)
+
+
+# ===========================================================================
+# TestNMMainOpHistogram
+# ===========================================================================
+
+
+class TestNMMainOpHistogram(unittest.TestCase):
+    """Tests for NMMainOpHistogram."""
+
+    def _run(self, op, arrays_by_name):
+        return _run_op_directly(op, arrays_by_name)
+
+    def _run_with_yscale(self, op, arrays_by_name, yscale):
+        """Like _run_op_directly but sets yscale on each NMData wave."""
+        folder = NMFolder(name="folder0")
+        data_items = []
+        for name, arr in arrays_by_name.items():
+            d = folder.data.new(name, nparray=np.array(arr, dtype=float),
+                                yscale=yscale)
+            data_items.append((d, None))
+        op.run_all(data_items, folder)
+        return folder
+
+    # --- output wave created ---
+
+    def test_output_wave_created(self):
+        op = NMMainOpHistogram()
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        self.assertIsNotNone(folder.data.get("H_RecordA0"))
+
+    def test_counts_length_equals_bins(self):
+        op = NMMainOpHistogram(bins=5)
+        folder = self._run(op, {"RecordA0": list(range(20))})
+        out = folder.data.get("H_RecordA0")
+        self.assertEqual(len(out.nparray), 5)
+
+    def test_counts_sum_equals_n_finite(self):
+        arr = [1.0, 2.0, 3.0, 4.0, 5.0]
+        op = NMMainOpHistogram(bins=5)
+        folder = self._run(op, {"RecordA0": arr})
+        out = folder.data.get("H_RecordA0")
+        self.assertEqual(int(out.nparray.sum()), len(arr))
+
+    # --- default and custom bins ---
+
+    def test_default_bins_is_10(self):
+        self.assertEqual(NMMainOpHistogram().bins, 10)
+
+    def test_custom_bins(self):
+        op = NMMainOpHistogram(bins=5)
+        folder = self._run(op, {"RecordA0": list(range(10))})
+        out = folder.data.get("H_RecordA0")
+        self.assertEqual(len(out.nparray), 5)
+
+    def test_list_bins(self):
+        op = NMMainOpHistogram(bins=[0.0, 2.0, 4.0, 6.0])
+        folder = self._run(op, {"RecordA0": [1.0, 3.0, 5.0]})
+        out = folder.data.get("H_RecordA0")
+        # 3 bin edges → 3 bins, all values land in one of them
+        self.assertEqual(len(out.nparray), 3)
+
+    # --- xrange ---
+
+    def test_xrange(self):
+        op = NMMainOpHistogram(bins=3, xrange=(1.0, 4.0))
+        folder = self._run(op, {"RecordA0": [0.0, 1.5, 2.5, 3.5, 5.0]})
+        out = folder.data.get("H_RecordA0")
+        # values outside [1,4] are not counted
+        self.assertEqual(int(out.nparray.sum()), 3)
+
+    # --- density ---
+
+    def test_density_output(self):
+        arr = list(range(100))
+        op = NMMainOpHistogram(bins=10, density=True)
+        folder = self._run(op, {"RecordA0": arr})
+        out = folder.data.get("H_RecordA0")
+        counts = out.nparray
+        bin_width = out.xscale.delta
+        self.assertAlmostEqual(float((counts * bin_width).sum()), 1.0, places=10)
+
+    # --- xscale ---
+
+    def test_xscale_start(self):
+        arr = [1.0, 2.0, 3.0, 4.0, 5.0]
+        op = NMMainOpHistogram(bins=5)
+        folder = self._run(op, {"RecordA0": arr})
+        out = folder.data.get("H_RecordA0")
+        import numpy as _np
+        _, edges = _np.histogram(arr, bins=5)
+        self.assertAlmostEqual(out.xscale.start, float(edges[0]))
+
+    def test_xscale_delta(self):
+        arr = [1.0, 2.0, 3.0, 4.0, 5.0]
+        op = NMMainOpHistogram(bins=5)
+        folder = self._run(op, {"RecordA0": arr})
+        out = folder.data.get("H_RecordA0")
+        import numpy as _np
+        _, edges = _np.histogram(arr, bins=5)
+        self.assertAlmostEqual(out.xscale.delta, float(edges[1] - edges[0]))
+
+    def test_xscale_label_from_yscale(self):
+        op = NMMainOpHistogram(bins=5)
+        yscale = {"label": "Vm", "units": "mV"}
+        folder = self._run_with_yscale(op, {"RecordA0": [1.0, 2.0, 3.0]}, yscale)
+        out = folder.data.get("H_RecordA0")
+        self.assertEqual(out.xscale.label, "Vm")
+        self.assertEqual(out.xscale.units, "mV")
+
+    # --- yscale of output ---
+
+    def test_yscale_counts_label(self):
+        op = NMMainOpHistogram(density=False)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0]})
+        out = folder.data.get("H_RecordA0")
+        self.assertEqual(out.yscale.label, "counts")
+
+    def test_yscale_density_label(self):
+        op = NMMainOpHistogram(density=True)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0]})
+        out = folder.data.get("H_RecordA0")
+        self.assertEqual(out.yscale.label, "density")
+
+    # --- NaN / Inf exclusion ---
+
+    def test_nan_inf_excluded(self):
+        arr = [1.0, float("nan"), 3.0, float("inf"), 5.0]
+        op = NMMainOpHistogram(bins=5)
+        folder = self._run(op, {"RecordA0": arr})
+        out = folder.data.get("H_RecordA0")
+        # 3 finite values should be counted
+        self.assertEqual(int(out.nparray.sum()), 3)
+
+    def test_n_excluded_in_results(self):
+        arr = [1.0, float("nan"), 3.0, float("inf")]
+        op = NMMainOpHistogram(bins=3)
+        folder = self._run(op, {"RecordA0": arr})
+        r = op.results["H_RecordA0"]
+        self.assertEqual(r["n_excluded"], 2)
+
+    # --- results dict ---
+
+    def test_results_populated(self):
+        op = NMMainOpHistogram(bins=5)
+        self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        r = op.results["H_RecordA0"]
+        self.assertIn("counts", r)
+        self.assertIn("edges", r)
+        self.assertIn("n_excluded", r)
+
+    def test_multiple_waves(self):
+        op = NMMainOpHistogram(bins=5)
+        arrays = {"RecordA0": [1.0, 2.0], "RecordA1": [3.0, 4.0],
+                  "RecordA2": [5.0, 6.0]}
+        folder = self._run(op, arrays)
+        self.assertEqual(len(op.results), 3)
+        for name in ("RecordA0", "RecordA1", "RecordA2"):
+            self.assertIsNotNone(folder.data.get("H_" + name))
+
+    # --- skips non-nparray ---
+
+    def test_skips_non_nparray(self):
+        op = NMMainOpHistogram()
+        folder = NMFolder(name="folder0")
+        d = folder.data.new("RecordA0")  # no nparray
+        op.run_all([(d, None)], folder)
+        self.assertIsNone(folder.data.get("H_RecordA0"))
+
+    # --- note ---
+
+    def test_note_written(self):
+        op = NMMainOpHistogram(bins=5)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0]})
+        out = folder.data.get("H_RecordA0")
+        notes = [e["note"] for e in out.notes._entries]
+        self.assertTrue(any("NMHistogram" in n for n in notes))
+
+    # --- time window (x0 / x1) ---
+
+    def test_default_x0_is_neg_inf(self):
+        self.assertTrue(math.isinf(NMMainOpHistogram().x0))
+        self.assertLess(NMMainOpHistogram().x0, 0)
+
+    def test_default_x1_is_pos_inf(self):
+        self.assertTrue(math.isinf(NMMainOpHistogram().x1))
+        self.assertGreater(NMMainOpHistogram().x1, 0)
+
+    def test_x0_x1_window(self):
+        # 10 samples at x=0..9; window x0=2, x1=4 → 3 samples (indices 2,3,4)
+        op = NMMainOpHistogram(bins=3, x0=2.0, x1=4.0)
+        folder = NMFolder(name="folder0")
+        d = folder.data.new(
+            "RecordA0",
+            nparray=np.arange(10, dtype=float),
+            xscale={"start": 0.0, "delta": 1.0},
+        )
+        op.run_all([(d, None)], folder)
+        out = folder.data.get("H_RecordA0")
+        self.assertEqual(int(out.nparray.sum()), 3)
+
+    def test_x1_only(self):
+        # window = -inf..4 → samples at x=0..4 = 5 samples
+        op = NMMainOpHistogram(bins=5, x1=4.0)
+        folder = NMFolder(name="folder0")
+        d = folder.data.new(
+            "RecordA0",
+            nparray=np.arange(10, dtype=float),
+            xscale={"start": 0.0, "delta": 1.0},
+        )
+        op.run_all([(d, None)], folder)
+        out = folder.data.get("H_RecordA0")
+        self.assertEqual(int(out.nparray.sum()), 5)
+
+    def test_x0_only(self):
+        # window = 7.0..+inf → samples at x=7,8,9 = 3 samples
+        op = NMMainOpHistogram(bins=3, x0=7.0)
+        folder = NMFolder(name="folder0")
+        d = folder.data.new(
+            "RecordA0",
+            nparray=np.arange(10, dtype=float),
+            xscale={"start": 0.0, "delta": 1.0},
+        )
+        op.run_all([(d, None)], folder)
+        out = folder.data.get("H_RecordA0")
+        self.assertEqual(int(out.nparray.sum()), 3)
+
+    def test_x0_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpHistogram(x0=float("nan"))
+
+    def test_x1_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpHistogram(x1=float("nan"))
+
+    # --- validation ---
+
+    def test_bins_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpHistogram(bins=True)
+
+    def test_bins_rejects_zero(self):
+        with self.assertRaises(ValueError):
+            NMMainOpHistogram(bins=0)
+
+    def test_density_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpHistogram(density=1)
+
+    # --- registry ---
+
+    def test_histogram_by_name(self):
+        op = op_from_name("histogram")
+        self.assertIsInstance(op, NMMainOpHistogram)
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -435,28 +435,28 @@ class TestNMToolStats2Histogram(unittest.TestCase):
 
     def test_histogram_saves_counts_array(self):
         nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4)
-        self.assertIn("HIST_ST_w0_mean_y_counts", self.tf.data)
+        self.assertIn("H_ST_w0_mean_y_counts", self.tf.data)
 
     def test_histogram_saves_edges_array(self):
         nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4)
-        self.assertIn("HIST_ST_w0_mean_y_edges", self.tf.data)
+        self.assertIn("H_ST_w0_mean_y_edges", self.tf.data)
 
     def test_histogram_xscale_start(self):
         nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4)
-        d = self.tf.data.get("HIST_ST_w0_mean_y_counts")
+        d = self.tf.data.get("H_ST_w0_mean_y_counts")
         self.assertAlmostEqual(d.xscale.start, 1.0)
 
     def test_histogram_xscale_delta(self):
         nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4)
-        d = self.tf.data.get("HIST_ST_w0_mean_y_counts")
+        d = self.tf.data.get("H_ST_w0_mean_y_counts")
         self.assertAlmostEqual(d.xscale.delta, 1.0)  # (5 - 1) / 4 = 1.0
 
     # --- save_to_numpy=False ---
 
     def test_histogram_no_save_skips_arrays(self):
         nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4, save_to_numpy=False)
-        self.assertNotIn("HIST_ST_w0_mean_y_counts", self.tf.data)
-        self.assertNotIn("HIST_ST_w0_mean_y_edges", self.tf.data)
+        self.assertNotIn("H_ST_w0_mean_y_counts", self.tf.data)
+        self.assertNotIn("H_ST_w0_mean_y_edges", self.tf.data)
 
     def test_histogram_no_save_still_returns_dict(self):
         r = nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4,

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -274,6 +274,18 @@ class TestTimeWindowToSlice:
         # i0 = round((1.0-0)/0.5)=2, i1 = round((2.0-0)/0.5)+1=5
         assert s == slice(2, 5)
 
+    def test_neg_inf_begin(self):
+        s = time_window_to_slice(self.ARR, self.XD, -math.inf, 4.0)
+        assert s.start == 0
+
+    def test_pos_inf_end(self):
+        s = time_window_to_slice(self.ARR, self.XD, 2.0, math.inf)
+        assert s.stop == len(self.ARR)
+
+    def test_both_inf(self):
+        s = time_window_to_slice(self.ARR, self.XD, -math.inf, math.inf)
+        assert s == slice(0, len(self.ARR))
+
 
 # ---------------------------------------------------------------------------
 # TestArrayStats


### PR DESCRIPTION
## Summary
- Adds `NMMainOpHistogram` (non-destructive): bins amplitude values of each
  wave with `np.histogram`, writes `H_{name}` to the source folder
- Parameters: `bins`, `x0`/`x1` (time window, default ±inf), `xrange`
  (amplitude range), `density`; NaN/Inf excluded automatically
- Output xscale derives from input yscale (amplitude axis → histogram x-axis)
- `time_window_to_slice()` extended to handle ±inf bounds natively
- `t_begin`/`t_end` renamed to `x0`/`x1` throughout `NMMainOpBaseline`,
  `NMMainOpNormalize`, and `time_window_to_slice()` — consistent with
  `NMStatWin` and the agreed codebase convention
- 30 new tests in `TestNMMainOpHistogram`; 3 new tests in
  `TestTimeWindowToSlice`

## Test plan
- [ ] `pytest tests/test_analysis/test_nm_tool_main.py::TestNMMainOpHistogram -v` → 30 passed
- [ ] `pytest tests/test_core/test_nm_math.py::TestTimeWindowToSlice -v` → 8 passed
- [ ] `pytest tests/ -q` → 1883 passed

Closes #199 
