### PR TITLE
feat(analysis): add overwrite and out_prefix options to NMMainOp output ops

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -51,9 +51,81 @@ class NMMainOp:
 
     Subclasses should set the class attribute ``name`` to a short lowercase
     string matching the registry key (e.g. ``"scale"``).
+
+    Attributes:
+        overwrite: If True (default), an existing output array with the same
+            name is replaced in-place.  If False, a sequence number
+            (``_0``, ``_1``, …) is appended to find a free name so previous
+            results are preserved.
     """
 
     name: str = ""
+    _overwrite: bool = True  # class-level default; overridden per-instance
+
+    @property
+    def overwrite(self) -> bool:
+        """If True, replace an existing output array; if False, auto-sequence."""
+        return self._overwrite
+
+    @overwrite.setter
+    def overwrite(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "overwrite", "bool"))
+        self._overwrite = value
+
+    def _make_out_name(self, folder: NMFolder, base_name: str) -> str:
+        """Return the output array name, respecting the overwrite setting.
+
+        If ``overwrite`` is True, returns *base_name* unchanged (existing
+        array is replaced in-place).  If ``overwrite`` is False, always
+        appends a sequence number (``_0``, ``_1``, …) so every run produces
+        a new array and previous results are preserved.
+        """
+        if self._overwrite:
+            return base_name
+        i = 0
+        while True:
+            candidate = "%s_%d" % (base_name, i)
+            if candidate not in folder.data:
+                return candidate
+            i += 1
+
+    def _write_out_array(
+        self,
+        folder: NMFolder,
+        out_name: str,
+        nparray: np.ndarray,
+        xscale: dict | None = None,
+        yscale: dict | None = None,
+    ) -> "NMData | None":
+        """Create or overwrite an output array in *folder*.
+
+        If an array named *out_name* already exists (overwrite=True case),
+        its array and scales are updated in-place.  Otherwise a new NMData
+        is created via ``folder.data.new()``.
+        """
+        existing = folder.data.get(out_name)
+        if existing is not None:
+            existing.nparray = nparray
+            if xscale:
+                xs = existing.xscale
+                if "start" in xscale:
+                    xs.start = xscale["start"]
+                if "delta" in xscale:
+                    xs.delta = xscale["delta"]
+                if "label" in xscale:
+                    xs.label = xscale["label"]
+                if "units" in xscale:
+                    xs.units = xscale["units"]
+            if yscale:
+                ys = existing.yscale
+                if "label" in yscale:
+                    ys.label = yscale["label"]
+                if "units" in yscale:
+                    ys.units = yscale["units"]
+            return existing
+        return folder.data.new(out_name, nparray=nparray,
+                               xscale=xscale, yscale=yscale)
 
     def run_all(
         self,
@@ -74,7 +146,7 @@ class NMMainOp:
                 (no dataseries context).
             folder: The NMFolder that owns the source data.  Passed to
                 ``run_finish()`` so ops can write output there.
-            prefix: Dataseries name to use as the output wave prefix.  If
+            prefix: Dataseries name to use as the output array prefix.  If
                 ``None``, ops fall back to parsing the prefix from the data
                 name.
 
@@ -127,394 +199,6 @@ class NMMainOp:
         notes = getattr(data, "notes", None)
         if notes is not None:
             notes.add(text)
-
-
-# =========================================================================
-# Accumulate (base for Average, Sum, SumSqr, Min, Max)
-# =========================================================================
-
-
-class NMMainOpAccumulate(NMMainOp):
-    """Base class for ops that accumulate waves and reduce them per channel.
-
-    Subclasses set two class attributes and override ``_reduce()``:
-
-    - ``_output_prefix``: prefix for the output wave name (e.g. ``"Avg_"``).
-    - ``_note_name``: op name used in the note string (e.g. ``"NMAverage"``).
-    - ``_reduce(stack)``: compute the per-channel result from the stacked array.
-
-    The full lifecycle is handled here: ``run_init`` resets buffers,
-    ``run`` accumulates per-channel arrays, and ``run_finish`` reduces
-    and writes one output wave per channel.
-
-    Parameters:
-        ignore_nans: If True (default) use NaN-aware reductions
-            (``np.nanmean``, ``np.nansum``, etc.); otherwise NaN propagates.
-    """
-
-    _output_prefix: str = ""
-    _note_name: str = ""
-
-    def __init__(self, ignore_nans: bool = True) -> None:
-        if not isinstance(ignore_nans, bool):
-            raise TypeError(
-                nmu.type_error_str(ignore_nans, "ignore_nans", "boolean")
-            )
-        self._ignore_nans = ignore_nans
-        self._results: dict[str, str] = {}  # channel → output name
-
-    @property
-    def ignore_nans(self) -> bool:
-        """If True, NaN values are excluded from the reduction."""
-        return self._ignore_nans
-
-    @ignore_nans.setter
-    def ignore_nans(self, value: bool) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
-        self._ignore_nans = value
-
-    @property
-    def results(self) -> dict[str, str]:
-        """Read-only dict mapping channel name → output NMData name."""
-        return dict(self._results)
-
-    def _reduce(self, stack: np.ndarray) -> np.ndarray:
-        """Reduce the stacked array to a single output array.
-
-        Args:
-            stack: 2-D array of shape (n_waves, n_points).
-
-        Returns:
-            1-D reduced array of shape (n_points,).
-
-        Raises:
-            NotImplementedError: If the subclass does not override this method.
-        """
-        raise NotImplementedError(
-            "%s._reduce() not implemented" % self.__class__.__name__
-        )
-
-    def run_init(self) -> None:
-        """Reset accumulation state for a new run."""
-        self._results.clear()
-        self._accum: dict[str, list[np.ndarray]] = {}
-        self._data_names: dict[str, list[str]] = {}
-        self._xscales: dict[str, dict] = {}
-        self._yscales: dict[str, dict] = {}
-        self._parsed_prefix: str | None = None  # fallback if prefix not passed
-
-    def run(
-        self,
-        data: NMData,
-        channel_name: str | None = None,
-    ) -> None:
-        """Accumulate one wave into the per-channel buffer.
-
-        Args:
-            data: The NMData object to accumulate.
-            channel_name: Channel name from the selection context, or None
-                (parsed from data.name as a fallback).
-        """
-        if not isinstance(data.nparray, np.ndarray):
-            return
-
-        if channel_name is None:
-            parsed = nmu.parse_data_name(data.name)
-            channel_name = parsed[1] if parsed is not None else "A"
-
-        if self._parsed_prefix is None:
-            parsed = nmu.parse_data_name(data.name)
-            self._parsed_prefix = parsed[0] if parsed is not None else ""
-
-        if channel_name not in self._accum:
-            self._accum[channel_name] = []
-            self._xscales[channel_name] = data.xscale.to_dict()
-            self._yscales[channel_name] = data.yscale.to_dict()
-
-        self._accum[channel_name].append(data.nparray.astype(float).copy())
-        self._data_names.setdefault(channel_name, []).append(data.name)
-
-    def _epoch_str(self, cname: str) -> str:
-        """Format the epoch list for the note string."""
-        return nmu.format_epoch_string(self._data_names.get(cname, []))
-
-    def _make_note_str(
-        self,
-        note_name: str,
-        folder_name: str,
-        ds_name: str,
-        cname: str,
-        epoch_str: str,
-        n: int,
-    ) -> str:
-        """Build the note string for an output wave."""
-        return (
-            "%s(folder=%s,dataseries=%s,channel=%s,epochs=%s,n_epochs=%d)"
-            % (note_name, folder_name, ds_name, cname, epoch_str, n)
-        )
-
-    def _write_output_wave(
-        self,
-        folder: NMFolder,
-        out_name: str,
-        arr: np.ndarray,
-        note_name: str,
-        folder_name: str,
-        ds_name: str,
-        cname: str,
-        epoch_str: str,
-        n: int,
-    ) -> None:
-        """Create an output wave in folder and add a note to it."""
-        folder.data.new(
-            out_name,
-            nparray=arr,
-            xscale=self._xscales[cname],
-            yscale=self._yscales[cname],
-        )
-        out_data = folder.data.get(out_name)
-        if out_data is not None:
-            self._add_note(
-                out_data,
-                self._make_note_str(note_name, folder_name, ds_name, cname, epoch_str, n),
-            )
-
-    def _process_channel(
-        self,
-        folder: NMFolder,
-        pfx: str,
-        cname: str,
-        arrays: list[np.ndarray],
-    ) -> None:
-        """Reduce and write one output wave for a single channel.
-
-        Subclasses may override to write additional output waves (e.g.
-        Stdv, Var, SEM alongside the mean).
-
-        Args:
-            folder: Destination NMFolder.
-            pfx: Dataseries prefix for the output wave name.
-            cname: Channel name.
-            arrays: List of accumulated arrays for this channel.
-        """
-        min_len = min(len(a) for a in arrays)
-        stack = np.stack([a[:min_len] for a in arrays])
-        n = len(arrays)
-        epoch_str = self._epoch_str(cname)
-        arr = self._reduce(stack)
-        out_name = self._output_prefix + pfx + cname
-        self._write_output_wave(
-            folder, out_name, arr, self._note_name, folder.name, pfx, cname, epoch_str, n
-        )
-        self._results[cname] = out_name
-
-    def run_finish(
-        self,
-        folder: NMFolder | None = None,
-        prefix: str | None = None,
-    ) -> None:
-        """Reduce and write one output wave per channel to folder.
-
-        Args:
-            folder: Destination NMFolder for the output waves.
-            prefix: Dataseries name used as the output wave prefix.  Falls
-                back to the prefix parsed from the first wave name if None.
-        """
-        if not self._accum or folder is None:
-            return
-
-        pfx = prefix if prefix is not None else (self._parsed_prefix or "")
-        for cname, arrays in self._accum.items():
-            self._process_channel(folder, pfx, cname, arrays)
-
-
-# =========================================================================
-# Average
-# =========================================================================
-
-
-class NMMainOpAverage(NMMainOpAccumulate):
-    """Average selected data waves per channel.
-
-    Accumulates arrays by channel, truncates all arrays to the shortest
-    length, and writes the mean as ``Avg_{prefix}{channel}``
-    (e.g. ``Avg_RecordA``) into the source folder.
-
-    Optionally also writes Stdv, Var, and/or SEM waves (sample statistics,
-    ``ddof=1``) when the corresponding ``compute_*`` parameter is True.
-
-    Parameters:
-        ignore_nans: If True (default) use ``np.nanmean``; otherwise
-            ``np.mean`` (NaN propagates to the result).
-        compute_stdv: If True, write ``Stdv_{prefix}{channel}`` (default False).
-        compute_var: If True, write ``Var_{prefix}{channel}`` (default False).
-        compute_sem: If True, write ``SEM_{prefix}{channel}`` (default False).
-    """
-
-    name = "average"
-    _output_prefix = "Avg_"
-    _note_name = "NMAverage"
-
-    def __init__(
-        self,
-        ignore_nans: bool = True,
-        compute_stdv: bool = False,
-        compute_var: bool = False,
-        compute_sem: bool = False,
-    ) -> None:
-        super().__init__(ignore_nans)
-        self.compute_stdv = compute_stdv  # setters validate bool
-        self.compute_var = compute_var
-        self.compute_sem = compute_sem
-
-    @property
-    def compute_stdv(self) -> bool:
-        """If True, write a Stdv output wave alongside the mean."""
-        return self._compute_stdv
-
-    @compute_stdv.setter
-    def compute_stdv(self, value: bool) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "compute_stdv", "boolean"))
-        self._compute_stdv = value
-
-    @property
-    def compute_var(self) -> bool:
-        """If True, write a Var output wave alongside the mean."""
-        return self._compute_var
-
-    @compute_var.setter
-    def compute_var(self, value: bool) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "compute_var", "boolean"))
-        self._compute_var = value
-
-    @property
-    def compute_sem(self) -> bool:
-        """If True, write a SEM output wave alongside the mean."""
-        return self._compute_sem
-
-    @compute_sem.setter
-    def compute_sem(self, value: bool) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "compute_sem", "boolean"))
-        self._compute_sem = value
-
-    def _reduce(self, stack: np.ndarray) -> np.ndarray:
-        return np.nanmean(stack, axis=0) if self._ignore_nans else np.mean(stack, axis=0)
-
-    def _process_channel(
-        self,
-        folder: NMFolder,
-        pfx: str,
-        cname: str,
-        arrays: list[np.ndarray],
-    ) -> None:
-        """Write mean wave, then optionally Stdv/Var/SEM waves."""
-        super()._process_channel(folder, pfx, cname, arrays)
-        if not (self._compute_stdv or self._compute_var or self._compute_sem):
-            return
-        min_len = min(len(a) for a in arrays)
-        stack = np.stack([a[:min_len] for a in arrays])
-        n = len(arrays)
-        epoch_str = self._epoch_str(cname)
-        std_fn = np.nanstd if self._ignore_nans else np.std
-        std = std_fn(stack, axis=0, ddof=1)
-        if self._compute_stdv:
-            self._write_output_wave(
-                folder, "Stdv_" + pfx + cname, std,
-                "NMStdv", folder.name, pfx, cname, epoch_str, n,
-            )
-        if self._compute_var:
-            self._write_output_wave(
-                folder, "Var_" + pfx + cname, std ** 2,
-                "NMVar", folder.name, pfx, cname, epoch_str, n,
-            )
-        if self._compute_sem:
-            self._write_output_wave(
-                folder, "SEM_" + pfx + cname, std / np.sqrt(n),
-                "NMSEM", folder.name, pfx, cname, epoch_str, n,
-            )
-
-
-# =========================================================================
-# Sum, SumSqr, Min, Max  (NMMainOpAccumulate subclasses)
-# =========================================================================
-
-
-class NMMainOpSum(NMMainOpAccumulate):
-    """Sum selected data waves point-by-point per channel.
-
-    Writes ``Sum_{prefix}{channel}`` (e.g. ``Sum_RecordA``) to the folder.
-
-    Parameters:
-        ignore_nans: If True (default) use ``np.nansum`` (NaN treated as 0);
-            otherwise ``np.sum`` (NaN propagates).
-    """
-
-    name = "sum"
-    _output_prefix = "Sum_"
-    _note_name = "NMSum"
-
-    def _reduce(self, stack: np.ndarray) -> np.ndarray:
-        return np.nansum(stack, axis=0) if self._ignore_nans else np.sum(stack, axis=0)
-
-
-class NMMainOpSumSqr(NMMainOpAccumulate):
-    """Sum of squares of selected data waves point-by-point per channel.
-
-    Squares each wave then sums, writing ``SumSqr_{prefix}{channel}``
-    (e.g. ``SumSqr_RecordA``) to the folder.
-
-    Parameters:
-        ignore_nans: If True (default) use ``np.nansum`` on the squared array;
-            otherwise ``np.sum`` (NaN propagates).
-    """
-
-    name = "sum_sqr"
-    _output_prefix = "SumSqr_"
-    _note_name = "NMSumSqr"
-
-    def _reduce(self, stack: np.ndarray) -> np.ndarray:
-        sq = stack ** 2
-        return np.nansum(sq, axis=0) if self._ignore_nans else np.sum(sq, axis=0)
-
-
-class NMMainOpMin(NMMainOpAccumulate):
-    """Point-by-point minimum across selected data waves per channel.
-
-    Writes ``Min_{prefix}{channel}`` (e.g. ``Min_RecordA``) to the folder.
-
-    Parameters:
-        ignore_nans: If True (default) use ``np.nanmin`` (NaN ignored);
-            otherwise ``np.min`` (NaN propagates).
-    """
-
-    name = "min"
-    _output_prefix = "Min_"
-    _note_name = "NMMin"
-
-    def _reduce(self, stack: np.ndarray) -> np.ndarray:
-        return np.nanmin(stack, axis=0) if self._ignore_nans else np.min(stack, axis=0)
-
-
-class NMMainOpMax(NMMainOpAccumulate):
-    """Point-by-point maximum across selected data waves per channel.
-
-    Writes ``Max_{prefix}{channel}`` (e.g. ``Max_RecordA``) to the folder.
-
-    Parameters:
-        ignore_nans: If True (default) use ``np.nanmax`` (NaN ignored);
-            otherwise ``np.max`` (NaN propagates).
-    """
-
-    name = "max"
-    _output_prefix = "Max_"
-    _note_name = "NMMax"
-
-    def _reduce(self, stack: np.ndarray) -> np.ndarray:
-        return np.nanmax(stack, axis=0) if self._ignore_nans else np.max(stack, axis=0)
 
 
 # =========================================================================
@@ -744,7 +428,7 @@ class NMMainOpArithmeticByArray(NMMainOp):
 
 
 class NMMainOpRedimension(NMMainOp):
-    """Change the number of points in each selected wave (in-place).
+    """Change the number of points in each selected array (in-place).
 
     Truncates when ``n_points`` < current length; pads with ``fill`` when
     ``n_points`` > current length.  Equivalent to Igor's ``Redimension/N=``.
@@ -775,7 +459,7 @@ class NMMainOpRedimension(NMMainOp):
 
     @property
     def fill(self) -> float:
-        """Pad value used when extending a wave."""
+        """Pad value used when extending an array."""
         return self._fill
 
     @fill.setter
@@ -814,10 +498,9 @@ class NMMainOpRedimension(NMMainOp):
 
 
 class NMMainOpInsertPoints(NMMainOp):
-    """Insert points into each selected wave at a given index (in-place).
+    """Insert points into each selected array at a given index (in-place).
 
-    Points at and after ``index`` are shifted right.  Equivalent to Igor's
-    ``InsertPoints pos, n, wave``.
+    Points at and after ``index`` are shifted right.
 
     Parameters:
         index: Position at which to insert (0-based, default 0).
@@ -898,9 +581,7 @@ class NMMainOpInsertPoints(NMMainOp):
 
 
 class NMMainOpDeletePoints(NMMainOp):
-    """Delete points from each selected wave at a given index (in-place).
-
-    Equivalent to Igor's ``DeletePoints pos, n, wave``.
+    """Delete points from each selected array at a given index (in-place).
 
     Parameters:
         index: Position of the first point to delete (0-based, default 0).
@@ -963,42 +644,40 @@ class NMMainOpDeletePoints(NMMainOp):
         )
 
 
-
-
 # =========================================================================
 # Baseline
 # =========================================================================
 
 
 class NMMainOpBaseline(NMMainOp):
-    """Subtract a baseline from each selected wave.
+    """Subtract a baseline from each selected array.
 
     Two modes are supported:
 
-    - **per_wave**: Each wave's own baseline (mean of the window) is subtracted
-      from that wave independently.
+    - **per_array**: Each array's own baseline (mean of the window) is subtracted
+      from that array independently.
     - **average**: A single shared baseline per channel is computed as the mean
-      of all per-wave baselines for that channel, then subtracted from every
-      wave in that channel.
+      of all per-array baselines for that channel, then subtracted from every
+      array in that channel.
 
     Parameters:
         x0: Baseline window start in time units (default 0.0).
         x1: Baseline window end in time units (default 0.0).  Must be >=
             ``x0``.
-        mode: ``"per_wave"`` (default) or ``"average"``.
+        mode: ``"per_array"`` (default) or ``"average"``.
         ignore_nans: If True (default) use ``np.nanmean``; otherwise ``np.mean``
             (NaN propagates to the result).
     """
 
     name = "baseline"
 
-    _VALID_MODES = {"per_wave", "average"}
+    _VALID_MODES = {"per_array", "average"}
 
     def __init__(
         self,
         x0: float = 0.0,
         x1: float = 0.0,
-        mode: str = "per_wave",
+        mode: str = "per_array",
         ignore_nans: bool = True,
     ) -> None:
         self.x0 = x0
@@ -1033,7 +712,7 @@ class NMMainOpBaseline(NMMainOp):
 
     @property
     def mode(self) -> str:
-        """Subtraction mode: ``'per_wave'`` or ``'average'``."""
+        """Subtraction mode: ``'per_array'`` or ``'average'``."""
         return self._mode
 
     @mode.setter
@@ -1080,7 +759,7 @@ class NMMainOpBaseline(NMMainOp):
         data: NMData,
         channel_name: str | None = None,
     ) -> None:
-        """Compute and (optionally) apply baseline for one wave.
+        """Compute and (optionally) apply baseline for one array.
 
         Args:
             data: The NMData object to process.
@@ -1105,11 +784,11 @@ class NMMainOpBaseline(NMMainOp):
         else:
             baseline = float(np.mean(segment))
 
-        if self._mode == "per_wave":
+        if self._mode == "per_array":
             data.nparray = data.nparray.astype(float) - baseline
             self._add_note(
                 data,
-                "NMBaseline(x0=%.6g,x1=%.6g,mode=per_wave,baseline=%.6g)"
+                "NMBaseline(x0=%.6g,x1=%.6g,mode=per_array,baseline=%.6g)"
                 % (self._x0, self._x1, baseline),
             )
         else:  # "average"
@@ -1123,11 +802,11 @@ class NMMainOpBaseline(NMMainOp):
     ) -> None:
         """Apply averaged baseline (average mode only).
 
-        In ``per_wave`` mode this is a no-op (subtraction was done in ``run()``).
-        In ``average`` mode the average of all per-wave baselines for each channel
-        is computed and subtracted from every wave in that channel.
+        In ``per_array`` mode this is a no-op (subtraction was done in ``run()``).
+        In ``average`` mode the average of all per-array baselines for each channel
+        is computed and subtracted from every array in that channel.
         """
-        if self._mode == "per_wave":
+        if self._mode == "per_array":
             return
         for channel_name, baselines in self._baseline_accum.items():
             avg_baseline = float(
@@ -1148,7 +827,7 @@ class NMMainOpBaseline(NMMainOp):
 
 
 class NMMainOpReverse(NMMainOp):
-    """Reverse each selected wave in-place.
+    """Reverse each selected array in-place.
 
     Equivalent to ``np.flip(arr)``.  No parameters.
     """
@@ -1178,7 +857,7 @@ class NMMainOpReverse(NMMainOp):
 
 
 class NMMainOpRotate(NMMainOp):
-    """Rotate each selected wave by ``n_points`` positions (in-place).
+    """Rotate each selected array by ``n_points`` positions (in-place).
 
     Uses ``np.roll(arr, n_points)``.  Positive values shift elements to
     the right (last element wraps to the front); negative values shift
@@ -1228,7 +907,7 @@ class NMMainOpRotate(NMMainOp):
 
 
 class NMMainOpIntegrate(NMMainOp):
-    """Cumulative integration of each selected wave (in-place).
+    """Cumulative integration of each selected array (in-place).
 
     Two methods are supported:
 
@@ -1293,7 +972,7 @@ class NMMainOpIntegrate(NMMainOp):
 
 
 class NMMainOpDifferentiate(NMMainOp):
-    """First derivative of each selected wave using ``np.gradient`` (in-place).
+    """First derivative of each selected array using ``np.gradient`` (in-place).
 
     Uses central differences for interior points and one-sided differences at
     the boundaries.  Preserves array length.  Scales by ``xscale.delta`` so
@@ -1405,7 +1084,7 @@ class NMMainOpReplaceValues(NMMainOp):
 
 
 class NMMainOpDeleteNaNs(NMMainOp):
-    """Remove NaN and/or ±Inf points from each selected wave (in-place).
+    """Remove NaN and/or ±Inf points from each selected array (in-place).
 
     Shortens the array.  The note reports how many points were removed;
     it is written even when n=0.
@@ -1483,7 +1162,7 @@ class NMMainOpDeleteNaNs(NMMainOp):
 
 
 class NMMainOpNormalize(NMMainOp):
-    """Rescale each wave so a low reference maps to norm_min and a high reference maps to norm_max.
+    """Rescale each array so a low reference maps to norm_min and a high reference maps to norm_max.
 
     Two independent time windows are used:
 
@@ -1494,9 +1173,9 @@ class NMMainOpNormalize(NMMainOp):
 
     Two modes (matching NMMainOpBaseline):
 
-    - **per_wave**: Each wave is normalized to its own references.
-    - **average**: Per-channel mean references are computed across all waves,
-      then applied to every wave in that channel.
+    - **per_array**: Each array is normalized to its own references.
+    - **average**: Per-channel mean references are computed across all arrays,
+      then applied to every array in that channel.
 
     Parameters:
         x0_min: Window 1 start in time units (default 0.0).
@@ -1511,14 +1190,14 @@ class NMMainOpNormalize(NMMainOp):
         n_mean2: Points around max for ``mean@max`` (default 1).
         norm_min: Target normalized minimum (default 0.0).
         norm_max: Target normalized maximum (default 1.0).
-        mode: ``"per_wave"`` (default) or ``"average"``.
+        mode: ``"per_array"`` (default) or ``"average"``.
     """
 
     name = "normalize"
 
     _VALID_FXN1 = {"mean", "min", "mean@min"}
     _VALID_FXN2 = {"mean", "max", "mean@max"}
-    _VALID_MODES = {"per_wave", "average"}
+    _VALID_MODES = {"per_array", "average"}
 
     def __init__(
         self,
@@ -1532,7 +1211,7 @@ class NMMainOpNormalize(NMMainOp):
         n_mean2: int = 1,
         norm_min: float = 0.0,
         norm_max: float = 1.0,
-        mode: str = "per_wave",
+        mode: str = "per_array",
     ) -> None:
         self.x0_min = x0_min
         self.x1_min = x1_min
@@ -1673,7 +1352,7 @@ class NMMainOpNormalize(NMMainOp):
 
     @property
     def mode(self) -> str:
-        """Normalization mode: ``'per_wave'`` or ``'average'``."""
+        """Normalization mode: ``'per_array'`` or ``'average'``."""
         return self._mode
 
     @mode.setter
@@ -1739,7 +1418,7 @@ class NMMainOpNormalize(NMMainOp):
         data: NMData,
         channel_name: str | None = None,
     ) -> None:
-        """Compute references and (optionally) normalize one wave.
+        """Compute references and (optionally) normalize one array.
 
         Args:
             data: The NMData object to process.
@@ -1760,7 +1439,7 @@ class NMMainOpNormalize(NMMainOp):
         ref_min = nm_math.compute_ref_value(arr[sl1], self._fxn1, self._n_mean1)
         ref_max = nm_math.compute_ref_value(arr[sl2], self._fxn2, self._n_mean2)
 
-        if self._mode == "per_wave":
+        if self._mode == "per_array":
             data.nparray = self._apply(arr, ref_min, ref_max)
             self._add_note(data, self._note_str(ref_min, ref_max))
         else:  # "average"
@@ -1775,11 +1454,11 @@ class NMMainOpNormalize(NMMainOp):
     ) -> None:
         """Apply averaged references (average mode only).
 
-        In ``per_wave`` mode this is a no-op (normalization was done in
-        ``run()``).  In ``average`` mode the mean of all per-wave references
-        for each channel is computed and applied to every wave in that channel.
+        In ``per_array`` mode this is a no-op (normalization was done in
+        ``run()``).  In ``average`` mode the mean of all per-array references
+        for each channel is computed and applied to every array in that channel.
         """
-        if self._mode == "per_wave":
+        if self._mode == "per_array":
             return
         for channel_name, ref_mins in self._ref_min_accum.items():
             avg_ref_min = float(np.nanmean(ref_mins))
@@ -1788,6 +1467,410 @@ class NMMainOpNormalize(NMMainOp):
                 arr = d.nparray.astype(float)
                 d.nparray = self._apply(arr, avg_ref_min, avg_ref_max)
                 self._add_note(d, self._note_str(avg_ref_min, avg_ref_max, channel_name))
+
+
+# =========================================================================
+# Accumulate (base for Average, Sum, SumSqr, Min, Max)
+# =========================================================================
+
+
+class NMMainOpAccumulate(NMMainOp):
+    """Base class for ops that accumulate arrays and reduce them per channel.
+
+    Subclasses set two class attributes and override ``_reduce()``:
+
+    - ``_output_prefix``: prefix for the output array name (e.g. ``"Avg_"``).
+    - ``_note_name``: op name used in the note string (e.g. ``"NMAverage"``).
+    - ``_reduce(stack)``: compute the per-channel result from the stacked array.
+
+    The full lifecycle is handled here: ``run_init`` resets buffers,
+    ``run`` accumulates per-channel arrays, and ``run_finish`` reduces
+    and writes one output array per channel.
+
+    Parameters:
+        ignore_nans: If True (default) use NaN-aware reductions
+            (``np.nanmean``, ``np.nansum``, etc.); otherwise NaN propagates.
+    """
+
+    _output_prefix: str = ""
+    _note_name: str = ""
+
+    def __init__(self, ignore_nans: bool = True) -> None:
+        if not isinstance(ignore_nans, bool):
+            raise TypeError(
+                nmu.type_error_str(ignore_nans, "ignore_nans", "boolean")
+            )
+        self._ignore_nans = ignore_nans
+        self._results: dict[str, str] = {}  # channel → output name
+        self._out_prefix: str = self._output_prefix  # settable per-instance
+
+    @property
+    def ignore_nans(self) -> bool:
+        """If True, NaN values are excluded from the reduction."""
+        return self._ignore_nans
+
+    @ignore_nans.setter
+    def ignore_nans(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
+        self._ignore_nans = value
+
+    @property
+    def out_prefix(self) -> str:
+        """Prefix for output array names (default is op-specific, e.g. ``"Avg_"``)."""
+        return self._out_prefix
+
+    @out_prefix.setter
+    def out_prefix(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "out_prefix", "string"))
+        self._out_prefix = value
+
+    @property
+    def results(self) -> dict[str, str]:
+        """Read-only dict mapping channel name → output NMData name."""
+        return dict(self._results)
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        """Reduce the stacked array to a single output array.
+
+        Args:
+            stack: 2-D array of shape (n_arrays, n_points).
+
+        Returns:
+            1-D reduced array of shape (n_points,).
+
+        Raises:
+            NotImplementedError: If the subclass does not override this method.
+        """
+        raise NotImplementedError(
+            "%s._reduce() not implemented" % self.__class__.__name__
+        )
+
+    def run_init(self) -> None:
+        """Reset accumulation state for a new run."""
+        self._results.clear()
+        self._accum: dict[str, list[np.ndarray]] = {}
+        self._data_names: dict[str, list[str]] = {}
+        self._xscales: dict[str, dict] = {}
+        self._yscales: dict[str, dict] = {}
+        self._parsed_prefix: str | None = None  # fallback if prefix not passed
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Accumulate one array into the per-channel buffer.
+
+        Args:
+            data: The NMData object to accumulate.
+            channel_name: Channel name from the selection context, or None
+                (parsed from data.name as a fallback).
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+
+        if channel_name is None:
+            parsed = nmu.parse_data_name(data.name)
+            channel_name = parsed[1] if parsed is not None else "A"
+
+        if self._parsed_prefix is None:
+            parsed = nmu.parse_data_name(data.name)
+            self._parsed_prefix = parsed[0] if parsed is not None else ""
+
+        if channel_name not in self._accum:
+            self._accum[channel_name] = []
+            self._xscales[channel_name] = data.xscale.to_dict()
+            self._yscales[channel_name] = data.yscale.to_dict()
+
+        self._accum[channel_name].append(data.nparray.astype(float).copy())
+        self._data_names.setdefault(channel_name, []).append(data.name)
+
+    def _epoch_str(self, cname: str) -> str:
+        """Format the epoch list for the note string."""
+        return nmu.format_epoch_string(self._data_names.get(cname, []))
+
+    def _make_note_str(
+        self,
+        note_name: str,
+        folder_name: str,
+        ds_name: str,
+        cname: str,
+        epoch_str: str,
+        n: int,
+    ) -> str:
+        """Build the note string for an output array."""
+        return (
+            "%s(folder=%s,dataseries=%s,channel=%s,epochs=%s,n_epochs=%d)"
+            % (note_name, folder_name, ds_name, cname, epoch_str, n)
+        )
+
+    def _write_output_array(
+        self,
+        folder: NMFolder,
+        out_name: str,
+        arr: np.ndarray,
+        note_name: str,
+        folder_name: str,
+        ds_name: str,
+        cname: str,
+        epoch_str: str,
+        n: int,
+    ) -> None:
+        """Create or overwrite an output array in folder and add a note to it."""
+        out_data = self._write_out_array(
+            folder, out_name, arr,
+            xscale=self._xscales[cname],
+            yscale=self._yscales[cname],
+        )
+        if out_data is not None:
+            self._add_note(
+                out_data,
+                self._make_note_str(note_name, folder_name, ds_name, cname, epoch_str, n),
+            )
+
+    def _process_channel(
+        self,
+        folder: NMFolder,
+        pfx: str,
+        cname: str,
+        arrays: list[np.ndarray],
+    ) -> None:
+        """Reduce and write one output array for a single channel.
+
+        Subclasses may override to write additional output arrays (e.g.
+        Stdv, Var, SEM alongside the mean).
+
+        Args:
+            folder: Destination NMFolder.
+            pfx: Dataseries prefix for the output array name.
+            cname: Channel name.
+            arrays: List of accumulated arrays for this channel.
+        """
+        min_len = min(len(a) for a in arrays)
+        stack = np.stack([a[:min_len] for a in arrays])
+        n = len(arrays)
+        epoch_str = self._epoch_str(cname)
+        arr = self._reduce(stack)
+        base_name = self._out_prefix + pfx + cname
+        out_name = self._make_out_name(folder, base_name)
+        self._write_output_array(
+            folder, out_name, arr, self._note_name, folder.name, pfx, cname, epoch_str, n
+        )
+        self._results[cname] = out_name
+
+    def run_finish(
+        self,
+        folder: NMFolder | None = None,
+        prefix: str | None = None,
+    ) -> None:
+        """Reduce and write one output array per channel to folder.
+
+        Args:
+            folder: Destination NMFolder for the output arrays.
+            prefix: Dataseries name used as the output array prefix.  Falls
+                back to the prefix parsed from the first array name if None.
+        """
+        if not self._accum or folder is None:
+            return
+
+        pfx = prefix if prefix is not None else (self._parsed_prefix or "")
+        for cname, arrays in self._accum.items():
+            self._process_channel(folder, pfx, cname, arrays)
+
+
+# =========================================================================
+# Average
+# =========================================================================
+
+
+class NMMainOpAverage(NMMainOpAccumulate):
+    """Average selected data arrays per channel.
+
+    Accumulates arrays by channel, truncates all arrays to the shortest
+    length, and writes the mean as ``Avg_{prefix}{channel}``
+    (e.g. ``Avg_RecordA``) into the source folder.
+
+    Optionally also writes Stdv, Var, and/or SEM arrays (sample statistics,
+    ``ddof=1``) when the corresponding ``compute_*`` parameter is True.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nanmean``; otherwise
+            ``np.mean`` (NaN propagates to the result).
+        compute_stdv: If True, write ``Stdv_{prefix}{channel}`` (default False).
+        compute_var: If True, write ``Var_{prefix}{channel}`` (default False).
+        compute_sem: If True, write ``SEM_{prefix}{channel}`` (default False).
+    """
+
+    name = "average"
+    _output_prefix = "Avg_"
+    _note_name = "NMAverage"
+
+    def __init__(
+        self,
+        ignore_nans: bool = True,
+        compute_stdv: bool = False,
+        compute_var: bool = False,
+        compute_sem: bool = False,
+    ) -> None:
+        super().__init__(ignore_nans)
+        self.compute_stdv = compute_stdv  # setters validate bool
+        self.compute_var = compute_var
+        self.compute_sem = compute_sem
+
+    @property
+    def compute_stdv(self) -> bool:
+        """If True, write a Stdv output array alongside the mean."""
+        return self._compute_stdv
+
+    @compute_stdv.setter
+    def compute_stdv(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "compute_stdv", "boolean"))
+        self._compute_stdv = value
+
+    @property
+    def compute_var(self) -> bool:
+        """If True, write a Var output array alongside the mean."""
+        return self._compute_var
+
+    @compute_var.setter
+    def compute_var(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "compute_var", "boolean"))
+        self._compute_var = value
+
+    @property
+    def compute_sem(self) -> bool:
+        """If True, write a SEM output array alongside the mean."""
+        return self._compute_sem
+
+    @compute_sem.setter
+    def compute_sem(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "compute_sem", "boolean"))
+        self._compute_sem = value
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        return np.nanmean(stack, axis=0) if self._ignore_nans else np.mean(stack, axis=0)
+
+    def _process_channel(
+        self,
+        folder: NMFolder,
+        pfx: str,
+        cname: str,
+        arrays: list[np.ndarray],
+    ) -> None:
+        """Write mean array, then optionally Stdv/Var/SEM arrays."""
+        super()._process_channel(folder, pfx, cname, arrays)
+        if not (self._compute_stdv or self._compute_var or self._compute_sem):
+            return
+        # Derive sequence suffix from the main output name so companion
+        # arrays always share the same suffix (e.g. _0, _1, ...).
+        main_out_name = self._results[cname]
+        base_main = self._out_prefix + pfx + cname
+        suffix = main_out_name[len(base_main):]  # "" or "_0", "_1", ...
+        min_len = min(len(a) for a in arrays)
+        stack = np.stack([a[:min_len] for a in arrays])
+        n = len(arrays)
+        epoch_str = self._epoch_str(cname)
+        std_fn = np.nanstd if self._ignore_nans else np.std
+        std = std_fn(stack, axis=0, ddof=1)
+        if self._compute_stdv:
+            self._write_output_array(
+                folder, "Stdv_" + pfx + cname + suffix, std,
+                "NMStdv", folder.name, pfx, cname, epoch_str, n,
+            )
+        if self._compute_var:
+            self._write_output_array(
+                folder, "Var_" + pfx + cname + suffix, std ** 2,
+                "NMVar", folder.name, pfx, cname, epoch_str, n,
+            )
+        if self._compute_sem:
+            self._write_output_array(
+                folder, "SEM_" + pfx + cname + suffix, std / np.sqrt(n),
+                "NMSEM", folder.name, pfx, cname, epoch_str, n,
+            )
+
+
+# =========================================================================
+# Sum, SumSqr, Min, Max  (NMMainOpAccumulate subclasses)
+# =========================================================================
+
+
+class NMMainOpSum(NMMainOpAccumulate):
+    """Sum selected data arrays point-by-point per channel.
+
+    Writes ``Sum_{prefix}{channel}`` (e.g. ``Sum_RecordA``) to the folder.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nansum`` (NaN treated as 0);
+            otherwise ``np.sum`` (NaN propagates).
+    """
+
+    name = "sum"
+    _output_prefix = "Sum_"
+    _note_name = "NMSum"
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        return np.nansum(stack, axis=0) if self._ignore_nans else np.sum(stack, axis=0)
+
+
+class NMMainOpSumSqr(NMMainOpAccumulate):
+    """Sum of squares of selected data arrays point-by-point per channel.
+
+    Squares each array then sums, writing ``SumSqr_{prefix}{channel}``
+    (e.g. ``SumSqr_RecordA``) to the folder.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nansum`` on the squared array;
+            otherwise ``np.sum`` (NaN propagates).
+    """
+
+    name = "sum_sqr"
+    _output_prefix = "SumSqr_"
+    _note_name = "NMSumSqr"
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        sq = stack ** 2
+        return np.nansum(sq, axis=0) if self._ignore_nans else np.sum(sq, axis=0)
+
+
+class NMMainOpMin(NMMainOpAccumulate):
+    """Point-by-point minimum across selected data arrays per channel.
+
+    Writes ``Min_{prefix}{channel}`` (e.g. ``Min_RecordA``) to the folder.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nanmin`` (NaN ignored);
+            otherwise ``np.min`` (NaN propagates).
+    """
+
+    name = "min"
+    _output_prefix = "Min_"
+    _note_name = "NMMin"
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        return np.nanmin(stack, axis=0) if self._ignore_nans else np.min(stack, axis=0)
+
+
+class NMMainOpMax(NMMainOpAccumulate):
+    """Point-by-point maximum across selected data arrays per channel.
+
+    Writes ``Max_{prefix}{channel}`` (e.g. ``Max_RecordA``) to the folder.
+
+    Parameters:
+        ignore_nans: If True (default) use ``np.nanmax`` (NaN ignored);
+            otherwise ``np.max`` (NaN propagates).
+    """
+
+    name = "max"
+    _output_prefix = "Max_"
+    _note_name = "NMMax"
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        return np.nanmax(stack, axis=0) if self._ignore_nans else np.max(stack, axis=0)
 
 
 # =========================================================================
@@ -1824,7 +1907,19 @@ class NMMainOpInequality(NMMainOp):
         self.a = a
         self.b = b
         self.binary_output = binary_output
+        self._out_prefix: str = "IQ_"
         self._results: dict = {}
+
+    @property
+    def out_prefix(self) -> str:
+        """Prefix for output array names (default ``"IQ_"``)."""
+        return self._out_prefix
+
+    @out_prefix.setter
+    def out_prefix(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "out_prefix", "string"))
+        self._out_prefix = value
 
     # ------------------------------------------------------------------
     # Properties
@@ -1884,7 +1979,7 @@ class NMMainOpInequality(NMMainOp):
 
     @property
     def results(self) -> dict:
-        """Per-output-wave dict; populated after :meth:`run_all`."""
+        """Per-output-array dict; populated after :meth:`run_all`."""
         return self._results
 
     # ------------------------------------------------------------------
@@ -1908,7 +2003,8 @@ class NMMainOpInequality(NMMainOp):
         )
         successes = int(np.sum(mask))
         condition = nm_math.inequality_condition_str(self._op, self._a, self._b)
-        out_name = "IQ_" + data.name
+        base_name = self._out_prefix + data.name
+        out_name = self._make_out_name(self._folder, base_name) if self._folder is not None else base_name
         if self._folder is not None:
             xscale = {
                 "start": data.xscale.start,
@@ -1917,9 +2013,8 @@ class NMMainOpInequality(NMMainOp):
                 "units": data.xscale.units,
             }
             yscale = {"label": data.yscale.label, "units": data.yscale.units}
-            self._folder.data.new(out_name, nparray=result,
-                                  xscale=xscale, yscale=yscale)
-            out_data = self._folder.data.get(out_name)
+            out_data = self._write_out_array(self._folder, out_name, result,
+                                            xscale=xscale, yscale=yscale)
             if out_data is not None:
                 self._add_note(out_data, "NMInequality(%s)" % condition)
         self._results[out_name] = {
@@ -1935,17 +2030,17 @@ class NMMainOpInequality(NMMainOp):
 
 
 class NMMainOpHistogram(NMMainOp):
-    """Compute an amplitude histogram for each data waveform.
+    """Compute an amplitude histogram for each data array.
 
-    For each wave, all sample values are passed to ``numpy.histogram``
-    and the resulting bin-counts array is written as a new wave
+    For each array, all sample values are passed to ``numpy.histogram``
+    and the resulting bin-counts array is written as a new array
     ``H_{data.name}`` in the source folder (non-destructive).
 
-    The output wave's x-scale represents the histogram bins:
+    The output array's x-scale represents the histogram bins:
     ``xscale.start`` = left edge of the first bin,
     ``xscale.delta`` = uniform bin width.
     ``xscale.label`` / ``xscale.units`` are taken from the input
-    wave's y-scale so axis labels remain meaningful.
+    array's y-scale so axis labels remain meaningful.
 
     NaN and Inf values are silently excluded before histogramming
     (same behaviour as ``NMToolStats2.histogram``).
@@ -1954,10 +2049,10 @@ class NMMainOpHistogram(NMMainOp):
         bins:    Number of equal-width bins (int) or explicit bin-edge
                  list.  Defaults to 10.
         x0:      Start of the time window (default ``-inf`` = beginning
-                 of wave).
-        x1:      End of the time window (default ``+inf`` = end of wave).
+                 of array).
+        x1:      End of the time window (default ``+inf`` = end of array).
         xrange:  ``(min, max)`` tuple to restrict the amplitude range.
-                 Defaults to None (full range of each wave).
+                 Defaults to None (full range of each array).
         density: If True, return probability density instead of counts.
                  Defaults to False.
     """
@@ -1977,6 +2072,18 @@ class NMMainOpHistogram(NMMainOp):
         self.x1 = x1
         self.xrange = xrange
         self.density = density
+        self._out_prefix: str = "H_"
+
+    @property
+    def out_prefix(self) -> str:
+        """Prefix for output array names (default ``"H_"``)."""
+        return self._out_prefix
+
+    @out_prefix.setter
+    def out_prefix(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "out_prefix", "string"))
+        self._out_prefix = value
         self._results: dict = {}
 
     # ------------------------------------------------------------------
@@ -2049,7 +2156,7 @@ class NMMainOpHistogram(NMMainOp):
 
     @property
     def results(self) -> dict:
-        """Per-output-wave dict; populated after :meth:`run_all`."""
+        """Per-output-array dict; populated after :meth:`run_all`."""
         return self._results
 
     # ------------------------------------------------------------------
@@ -2078,7 +2185,8 @@ class NMMainOpHistogram(NMMainOp):
             range=self._xrange, density=self._density,
         )
 
-        out_name = "H_" + data.name
+        base_name = self._out_prefix + data.name
+        out_name = self._make_out_name(self._folder, base_name) if self._folder is not None else base_name
         if self._folder is not None:
             xscale = {
                 "start": float(edges[0]),
@@ -2090,9 +2198,10 @@ class NMMainOpHistogram(NMMainOp):
                 "label": "density" if self._density else "counts",
                 "units": "",
             }
-            self._folder.data.new(out_name, nparray=counts.astype(float),
-                                  xscale=xscale, yscale=yscale)
-            out_data = self._folder.data.get(out_name)
+            out_data = self._write_out_array(
+                self._folder, out_name, counts.astype(float),
+                xscale=xscale, yscale=yscale,
+            )
             if out_data is not None:
                 self._add_note(
                     out_data,

--- a/pyneuromatic/analysis/nm_tool_main.py
+++ b/pyneuromatic/analysis/nm_tool_main.py
@@ -30,7 +30,7 @@ import pyneuromatic.core.nm_utilities as nmu
 class NMToolMain(NMTool):
     """Main NM Tool — always loaded by default.
 
-    Provides core waveform operations (Average, Scale, …) via a pluggable
+    Provides core array operations (Average, Scale, …) via a pluggable
     ``op`` property.  Setting ``op`` to a string name (e.g. ``"average"``)
     looks up and instantiates the corresponding :class:`NMMainOp` subclass
     from the registry.  Setting it to an :class:`NMMainOp` instance allows

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -504,25 +504,25 @@ class NMToolStats(NMTool):
                 i += 1
 
         for wname, vlist in self.__results.items():
-            # vlist: list of lists, one inner list per data wave
-            # Each inner list contains result dicts for that wave
+            # vlist: list of lists, one inner list per data array
+            # Each inner list contains result dicts for that array
 
-            # Collect data path strings (one per wave, from first rdict)
+            # Collect data path strings (one per array, from first rdict)
             data_paths: list[str] = []
             # Collect result dicts grouped by id: {id_str: [rdict, ...]}
             id_rdicts: dict[str, list[dict]] = {}
 
             for ilist in vlist:
-                wave_path: str | None = None
+                array_path: str | None = None
                 for rdict in ilist:
                     id_str = rdict.get("id", "main")
-                    if wave_path is None:
-                        wave_path = rdict.get("data", "")
+                    if array_path is None:
+                        array_path = rdict.get("data", "")
                     if id_str not in id_rdicts:
                         id_rdicts[id_str] = []
                     id_rdicts[id_str].append(rdict)
-                if wave_path is not None:
-                    data_paths.append(wave_path)
+                if array_path is not None:
+                    data_paths.append(array_path)
 
             # Save data path strings
             if data_paths and f.data is not None:
@@ -906,7 +906,7 @@ class NMToolStats2:
     ) -> None:
         """Populate epoch sets from a boolean mask aligned to an ST_ array.
 
-        Looks up the ``ST_{wname}_data`` wave-name array in *toolfolder*,
+        Looks up the ``ST_{wname}_data`` array name in *toolfolder*,
         maps each index to an epoch via *dataseries*, and adds matching
         epoch names to *set_name_true* (where mask is True) and/or
         *set_name_false* (where mask is False).
@@ -938,10 +938,10 @@ class NMToolStats2:
 
         true_epochs: list[str] = []
         false_epochs: list[str] = []
-        for i, wave_name in enumerate(data_arr.nparray):
+        for i, array_name in enumerate(data_arr.nparray):
             if i >= len(mask):
                 break
-            parsed = nmu.parse_data_name(str(wave_name))
+            parsed = nmu.parse_data_name(str(array_name))
             if parsed is None:
                 continue
             ep_name = epoch_map.get(parsed[2])
@@ -1033,7 +1033,7 @@ class NMToolStats2:
         if not isinstance(d2.nparray, np.ndarray):
             raise ValueError("array has no nparray: %s" % name2)
 
-        # Strip NaN/Inf — matches Igor's Redimension after Sort + WaveStats
+        # Strip NaN/Inf
         arr1 = d1.nparray.astype(float)
         arr2 = d2.nparray.astype(float)
         arr1 = arr1[np.isfinite(arr1)]

--- a/pyneuromatic/core/nm_utilities.py
+++ b/pyneuromatic/core/nm_utilities.py
@@ -562,7 +562,7 @@ def parse_data_name(
 
 
 def format_epoch_string(data_names: list[str]) -> str:
-    """Format a list of wave names as a compact epoch string for notes.
+    """Format a list of array names as a compact epoch string for notes.
 
     Extracts epoch numbers via ``parse_data_name``, sorts them, then chooses
     the most compact representation:
@@ -573,7 +573,7 @@ def format_epoch_string(data_names: list[str]) -> str:
     4. **Everything else**: ``"[0,2,5]"``
 
     Args:
-        data_names: List of NMData wave names (e.g. ``["RecordA0", "RecordA2"]``).
+        data_names: List of NMData array names (e.g. ``["RecordA0", "RecordA2"]``).
 
     Returns:
         Compact epoch string.

--- a/tests/test_analysis/test_nm_stat_igor.py
+++ b/tests/test_analysis/test_nm_stat_igor.py
@@ -54,7 +54,7 @@ _X0, _X1 = 500.0, 1000.0  # ms
 _N_MEAN = 500  # n_mean for mean@max and mean@min (10 ms window at 0.02 ms sampling)
 
 # ---------------------------------------------------------------------------
-# Sine wave test parameters
+# Sine-wave test parameters
 # ---------------------------------------------------------------------------
 # Half-sine pulse: y = AMP * sin(π*(t - T0) / TAU) for t in [T0, T0+TAU],
 #                  y = 0 elsewhere.
@@ -318,7 +318,7 @@ class TestIgorFWHM(unittest.TestCase):
 
 
 # ===========================================================================
-# Sine wave analytical tests (synthetic data, analytically known values)
+# Sine-wave analytical tests (synthetic data, analytically known values)
 # ===========================================================================
 
 class TestSineWaveLevelCrossings(unittest.TestCase):

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -96,7 +96,7 @@ class TestNMMainOpAverage(unittest.TestCase):
 
     def setUp(self):
         self.op = NMMainOpAverage()
-        # Three A-channel waves; expected average = [4, 4, 4]
+        # Three A-channel arrays; expected average = [4, 4, 4]
         self.arrays = {
             "RecordA0": [2.0, 2.0, 2.0],
             "RecordA1": [4.0, 4.0, 4.0],
@@ -221,7 +221,7 @@ class TestNMMainOpAverage(unittest.TestCase):
 
     # --- notes ---
 
-    def test_note_on_output_wave(self):
+    def test_note_on_output_array(self):
         # consecutive epochs → range notation
         folder = self._run({"RecordA0": [1.0, 2.0], "RecordA1": [3.0, 4.0], "RecordA2": [5.0, 6.0]})
         out = folder.data.get("Avg_RecordA")
@@ -263,7 +263,7 @@ class TestNMMainOpAverage(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.op.compute_sem = 0
 
-    def test_compute_stdv_writes_wave(self):
+    def test_compute_stdv_writes_array(self):
         self.op.compute_stdv = True
         folder = self._run()
         self.assertIsNotNone(folder.data.get("Stdv_RecordA"))
@@ -293,7 +293,7 @@ class TestNMMainOpAverage(unittest.TestCase):
         expected = 2.0 / math.sqrt(3)
         np.testing.assert_array_almost_equal(out.nparray, [expected, expected, expected])
 
-    def test_all_three_writes_three_extra_waves(self):
+    def test_all_three_writes_three_extra_arrays(self):
         self.op.compute_stdv = True
         self.op.compute_var = True
         self.op.compute_sem = True
@@ -302,7 +302,7 @@ class TestNMMainOpAverage(unittest.TestCase):
         self.assertIsNotNone(folder.data.get("Var_RecordA"))
         self.assertIsNotNone(folder.data.get("SEM_RecordA"))
 
-    def test_stdv_note_on_output_wave(self):
+    def test_stdv_note_on_output_array(self):
         self.op.compute_stdv = True
         folder = self._run({"RecordA0": [2.0, 2.0], "RecordA1": [4.0, 4.0], "RecordA2": [6.0, 6.0]})
         out = folder.data.get("Stdv_RecordA")
@@ -874,22 +874,22 @@ class TestOpFromName(unittest.TestCase):
 
 
 class TestNMMainOpBaseline(unittest.TestCase):
-    """Tests for NMMainOpBaseline (per_wave and average modes)."""
+    """Tests for NMMainOpBaseline (per_array and average modes)."""
 
     # ------------------------------------------------------------------
-    # per_wave mode
+    # per_array mode
 
-    def test_per_wave_subtracts_correct_baseline(self):
+    def test_per_array_subtracts_correct_baseline(self):
         # window [0,1] covers first 2 points [2,2] → baseline=2
-        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="per_wave")
+        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="per_array")
         d = _make_data("RecordA0", [2.0, 2.0, 4.0, 4.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
         np.testing.assert_array_almost_equal(d.nparray, [0.0, 0.0, 2.0, 2.0])
 
-    def test_per_wave_different_baselines(self):
-        # Two waves with different values in baseline window → independent shifts
-        op = NMMainOpBaseline(x0=0.0, x1=0.0, mode="per_wave")
+    def test_per_array_different_baselines(self):
+        # Two arrays with different values in baseline window → independent shifts
+        op = NMMainOpBaseline(x0=0.0, x1=0.0, mode="per_array")
         d1 = _make_data("RecordA0", [1.0, 5.0], xstart=0.0, xdelta=1.0)
         d2 = _make_data("RecordA1", [3.0, 7.0], xstart=0.0, xdelta=1.0)
         op.run_init()
@@ -898,8 +898,8 @@ class TestNMMainOpBaseline(unittest.TestCase):
         np.testing.assert_array_almost_equal(d1.nparray, [0.0, 4.0])
         np.testing.assert_array_almost_equal(d2.nparray, [0.0, 4.0])
 
-    def test_per_wave_nan_ignored(self):
-        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="per_wave", ignore_nans=True)
+    def test_per_array_nan_ignored(self):
+        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="per_array", ignore_nans=True)
         d = _make_data("RecordA0", [np.nan, 2.0, 5.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
@@ -907,8 +907,8 @@ class TestNMMainOpBaseline(unittest.TestCase):
         self.assertTrue(math.isfinite(float(d.nparray[2])))
         self.assertAlmostEqual(float(d.nparray[2]), 3.0)
 
-    def test_per_wave_nan_propagates(self):
-        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="per_wave", ignore_nans=False)
+    def test_per_array_nan_propagates(self):
+        op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="per_array", ignore_nans=False)
         d = _make_data("RecordA0", [np.nan, 2.0, 5.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
@@ -917,7 +917,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
 
     def test_window_out_of_range_no_subtraction(self):
         # Window is past end of array → empty slice → baseline=0 → no change
-        op = NMMainOpBaseline(x0=100.0, x1=200.0, mode="per_wave")
+        op = NMMainOpBaseline(x0=100.0, x1=200.0, mode="per_array")
         d = _make_data("RecordA0", [5.0, 6.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
@@ -925,7 +925,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
 
     def test_window_partial_clip(self):
         # Window extends beyond array end — only existing samples used
-        op = NMMainOpBaseline(x0=1.0, x1=10.0, mode="per_wave")
+        op = NMMainOpBaseline(x0=1.0, x1=10.0, mode="per_array")
         # xdelta=1, array=[0,1,2,3]; window 1..10 clips to indices 1..4
         d = _make_data("RecordA0", [0.0, 2.0, 4.0, 6.0], xstart=0.0, xdelta=1.0)
         op.run_init()
@@ -937,7 +937,7 @@ class TestNMMainOpBaseline(unittest.TestCase):
     # average mode
 
     def test_average_mode_shared_baseline(self):
-        # 3 waves [2,2], [4,4], [6,6]; window covers full wave → baselines 2,4,6
+        # 3 arrays [2,2], [4,4], [6,6]; window covers full array → baselines 2,4,6
         # avg baseline = 4; all shifted by -4
         op = NMMainOpBaseline(x0=0.0, x1=1.0, mode="average")
         d1 = _make_data("RecordA0", [2.0, 2.0], xstart=0.0, xdelta=1.0)
@@ -1015,14 +1015,14 @@ class TestNMMainOpBaseline(unittest.TestCase):
 
     # --- notes ---
 
-    def test_per_wave_note_written(self):
-        op = NMMainOpBaseline(x0=0.0, x1=0.0, mode="per_wave")
+    def test_per_array_note_written(self):
+        op = NMMainOpBaseline(x0=0.0, x1=0.0, mode="per_array")
         d = _make_data("RecordA0", [3.0, 5.0], xstart=0.0, xdelta=1.0)
         op.run_init()
         op.run(d)
         self.assertEqual(len(d.notes), 1)
         note = d.notes[0]["note"]
-        self.assertIn("NMBaseline(x0=0,x1=0,mode=per_wave,baseline=3)", note)
+        self.assertIn("NMBaseline(x0=0,x1=0,mode=per_array,baseline=3)", note)
 
     def test_average_note_written(self):
         op = NMMainOpBaseline(x0=0.0, x1=0.0, mode="average")
@@ -1247,14 +1247,14 @@ class TestNMMainOpDifferentiate(unittest.TestCase):
         np.testing.assert_array_almost_equal(d.nparray, expected)
 
     def test_uses_delta(self):
-        # same wave with delta=0.5 → result scaled by 1/0.5
+        # same array with delta=0.5 → result scaled by 1/0.5
         arr = [0.0, 1.0, 4.0, 9.0]
         d = _make_data("RecordA0", arr, xdelta=0.5)
         NMMainOpDifferentiate().run(d)
         expected = np.gradient(np.array(arr), 0.5)
         np.testing.assert_array_almost_equal(d.nparray, expected)
 
-    def test_constant_wave_is_zero(self):
+    def test_constant_array_is_zero(self):
         d = _make_data("RecordA0", [5.0, 5.0, 5.0, 5.0], xdelta=1.0)
         NMMainOpDifferentiate().run(d)
         np.testing.assert_array_almost_equal(d.nparray, [0.0, 0.0, 0.0, 0.0])
@@ -1436,12 +1436,12 @@ class TestNMMainOpDeleteNaNs(unittest.TestCase):
 
 
 class TestNMMainOpNormalize(unittest.TestCase):
-    """Tests for NMMainOpNormalize (per_wave and average modes)."""
+    """Tests for NMMainOpNormalize (per_array and average modes)."""
 
     # ------------------------------------------------------------------
-    # per_wave mode — correct values
+    # per_array mode — correct values
 
-    def test_per_wave_min_max(self):
+    def test_per_array_min_max(self):
         # [0,5,10], fxn1=min→0, fxn2=max→10, range=10 → [0.0, 0.5, 1.0]
         op = NMMainOpNormalize(
             x0_min=0.0, x1_min=2.0, fxn1="min",
@@ -1452,7 +1452,7 @@ class TestNMMainOpNormalize(unittest.TestCase):
         op.run(data, "A")
         np.testing.assert_array_almost_equal(data.nparray, [0.0, 0.5, 1.0])
 
-    def test_per_wave_mean_zero_range(self):
+    def test_per_array_mean_zero_range(self):
         # fxn1=mean and fxn2=mean over same window → ref_min==ref_max → norm_min everywhere
         op = NMMainOpNormalize(
             x0_min=0.0, x1_min=4.0, fxn1="mean",
@@ -1464,7 +1464,7 @@ class TestNMMainOpNormalize(unittest.TestCase):
         op.run(data, "A")
         np.testing.assert_array_equal(data.nparray, [-99.0] * 5)
 
-    def test_per_wave_uses_windows(self):
+    def test_per_array_uses_windows(self):
         # [0,1,2,3,4] xdelta=1; window1=[0,0]→first point(0), window2=[4,4]→last point(4)
         op = NMMainOpNormalize(
             x0_min=0.0, x1_min=0.0, fxn1="mean",
@@ -1475,7 +1475,7 @@ class TestNMMainOpNormalize(unittest.TestCase):
         op.run(data, "A")
         np.testing.assert_array_almost_equal(data.nparray, [0.0, 0.25, 0.5, 0.75, 1.0])
 
-    def test_per_wave_custom_norm_range(self):
+    def test_per_array_custom_norm_range(self):
         # norm_min=-1, norm_max=1; [0,5,10]→ref_min=0,ref_max=10 → [-1,0,1]
         op = NMMainOpNormalize(
             x0_min=0.0, x1_min=2.0, fxn1="min",
@@ -1487,7 +1487,7 @@ class TestNMMainOpNormalize(unittest.TestCase):
         op.run(data, "A")
         np.testing.assert_array_almost_equal(data.nparray, [-1.0, 0.0, 1.0])
 
-    def test_per_wave_mean_at_min(self):
+    def test_per_array_mean_at_min(self):
         # [3,1,2], fxn1=mean@min, n_mean1=3; min at i=1, mean of [3,1,2]=2.0 → ref_min=2.0
         # fxn2=max → ref_max=3.0; range=1; normalized: arr-2.0 → [1,-1,0]
         op = NMMainOpNormalize(
@@ -1499,7 +1499,7 @@ class TestNMMainOpNormalize(unittest.TestCase):
         op.run(data, "A")
         np.testing.assert_array_almost_equal(data.nparray, [1.0, -1.0, 0.0])
 
-    def test_per_wave_mean_at_max(self):
+    def test_per_array_mean_at_max(self):
         # [1,5,3], fxn2=mean@max, n_mean2=3; max at i=1, mean of [1,5,3]=3.0 → ref_max=3.0
         # fxn1=min → ref_min=1.0; range=2; normalized: (arr-1)/2 → [0,2,1]
         op = NMMainOpNormalize(
@@ -1511,7 +1511,7 @@ class TestNMMainOpNormalize(unittest.TestCase):
         op.run(data, "A")
         np.testing.assert_array_almost_equal(data.nparray, [0.0, 2.0, 1.0])
 
-    def test_per_wave_preserves_length(self):
+    def test_per_array_preserves_length(self):
         op = NMMainOpNormalize(
             x0_min=0.0, x1_min=99.0, fxn1="min",
             x0_max=0.0, x1_max=99.0, fxn2="max",
@@ -1525,7 +1525,7 @@ class TestNMMainOpNormalize(unittest.TestCase):
     # average mode
 
     def test_average_mode_shared_refs(self):
-        # 2 waves same channel; ref_mins=[0,2]→avg=1, ref_maxes=[4,6]→avg=5, range=4
+        # 2 arrays same channel; ref_mins=[0,2]→avg=1, ref_maxes=[4,6]→avg=5, range=4
         op = NMMainOpNormalize(
             x0_min=0.0, x1_min=1.0, fxn1="min",
             x0_max=0.0, x1_max=1.0, fxn2="max",
@@ -1605,11 +1605,11 @@ class TestNMMainOpNormalize(unittest.TestCase):
         op.run(d, "A")  # should not raise
         self.assertEqual(len(d.notes), 0)
 
-    def test_note_per_wave(self):
+    def test_note_per_array(self):
         op = NMMainOpNormalize(
             x0_min=0.0, x1_min=2.0, fxn1="min",
             x0_max=0.0, x1_max=2.0, fxn2="max",
-            mode="per_wave",
+            mode="per_array",
         )
         data = _make_data("RecordA0", [0.0, 5.0, 10.0])
         op.run_init()
@@ -1617,7 +1617,7 @@ class TestNMMainOpNormalize(unittest.TestCase):
         self.assertEqual(len(data.notes), 1)
         note = data.notes[0]["note"]
         self.assertIn("NMNormalize", note)
-        self.assertIn("mode=per_wave", note)
+        self.assertIn("mode=per_array", note)
         self.assertIn("ref_min=", note)
         self.assertIn("ref_max=", note)
 
@@ -1913,23 +1913,23 @@ class TestNMMainOpArithmeticByArray(unittest.TestCase):
         np.testing.assert_array_almost_equal(result, [9.0, 8.0, 7.0])
 
     def test_ref_by_name(self):
-        folder, _ = _make_folder_with_ref("Folder1", "RefWave", [2.0, 4.0, 6.0])
+        folder, _ = _make_folder_with_ref("Folder1", "RefArray", [2.0, 4.0, 6.0])
         d = _make_data("RecordA0", [1.0, 2.0, 3.0])
         items = [(d, None)]
-        op = NMMainOpArithmeticByArray(ref="RefWave", op="x")
+        op = NMMainOpArithmeticByArray(ref="RefArray", op="x")
         op.run_all(items, folder=folder)
         np.testing.assert_array_almost_equal(d.nparray, [2.0, 8.0, 18.0])
 
-    def test_ref_wave_not_found_raises(self):
+    def test_ref_array_not_found_raises(self):
         folder = NMFolder(name="Folder1")
         d = _make_data("RecordA0", [1.0, 2.0])
-        op = NMMainOpArithmeticByArray(ref="NoSuchWave", op="x")
+        op = NMMainOpArithmeticByArray(ref="NoSuchArray", op="x")
         with self.assertRaises(ValueError):
             op.run_all([(d, None)], folder=folder)
 
     def test_no_folder_with_string_ref_raises(self):
         d = _make_data("RecordA0", [1.0, 2.0])
-        op = NMMainOpArithmeticByArray(ref="RefWave", op="x")
+        op = NMMainOpArithmeticByArray(ref="RefArray", op="x")
         with self.assertRaises(ValueError):
             op.run_all([(d, None)], folder=None)
 
@@ -1956,12 +1956,12 @@ class TestNMMainOpArithmeticByArray(unittest.TestCase):
             NMMainOpArithmeticByArray(ref=42)
 
     def test_note_with_name_ref(self):
-        folder, _ = _make_folder_with_ref("Folder1", "RefWave", [1.0, 1.0])
+        folder, _ = _make_folder_with_ref("Folder1", "RefArray", [1.0, 1.0])
         d = _make_data("RecordA0", [2.0, 3.0])
-        op = NMMainOpArithmeticByArray(ref="RefWave", op="x")
+        op = NMMainOpArithmeticByArray(ref="RefArray", op="x")
         op.run_all([(d, None)], folder=folder)
         notes = [e["note"] for e in d.notes._entries]
-        self.assertTrue(any("NMArithmeticByArray(ref=RefWave,op=x)" in n for n in notes))
+        self.assertTrue(any("NMArithmeticByArray(ref=RefArray,op=x)" in n for n in notes))
 
     def test_note_with_array_ref(self):
         d = _make_data("RecordA0", [2.0, 3.0])
@@ -2008,14 +2008,14 @@ class TestNMMainOpInequality(unittest.TestCase):
         out = folder.data.get("IQ_RecordA0")
         np.testing.assert_array_equal(out.nparray, [0.0, 1.0, 1.0, 1.0, 0.0])
 
-    # --- output wave in folder ---
+    # --- output array in folder ---
 
-    def test_output_wave_created_in_folder(self):
+    def test_output_array_created_in_folder(self):
         op = NMMainOpInequality(op=">", a=0.0)
         folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0]})
         self.assertIsNotNone(folder.data.get("IQ_RecordA0"))
 
-    def test_output_wave_values(self):
+    def test_output_array_values(self):
         op = NMMainOpInequality(op=">=", a=3.0, binary_output=True)
         folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0]})
         out = folder.data.get("IQ_RecordA0")
@@ -2046,7 +2046,7 @@ class TestNMMainOpInequality(unittest.TestCase):
         self.assertEqual(r["failures"], 2)
         self.assertEqual(r["condition"], "y > 2")
 
-    def test_multiple_waves(self):
+    def test_multiple_arrays(self):
         op = NMMainOpInequality(op=">", a=0.0)
         folder = self._run(op, {
             "RecordA0": [1.0],
@@ -2088,7 +2088,7 @@ class TestNMMainOpInequality(unittest.TestCase):
         folder = NMFolder(name="folder0")
         d = folder.data.new("RecordA0")   # no nparray
         op.run_all([(d, None)], folder=folder)
-        # no output wave created, no error
+        # no output array created, no error
         self.assertIsNone(folder.data.get("IQ_RecordA0"))
 
     # --- note ---
@@ -2119,7 +2119,7 @@ class TestNMMainOpHistogram(unittest.TestCase):
         return _run_op_directly(op, arrays_by_name)
 
     def _run_with_yscale(self, op, arrays_by_name, yscale):
-        """Like _run_op_directly but sets yscale on each NMData wave."""
+        """Like _run_op_directly but sets yscale on each NMData array."""
         folder = NMFolder(name="folder0")
         data_items = []
         for name, arr in arrays_by_name.items():
@@ -2129,9 +2129,9 @@ class TestNMMainOpHistogram(unittest.TestCase):
         op.run_all(data_items, folder)
         return folder
 
-    # --- output wave created ---
+    # --- output array created ---
 
-    def test_output_wave_created(self):
+    def test_output_array_created(self):
         op = NMMainOpHistogram()
         folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0]})
         self.assertIsNotNone(folder.data.get("H_RecordA0"))
@@ -2256,7 +2256,7 @@ class TestNMMainOpHistogram(unittest.TestCase):
         self.assertIn("edges", r)
         self.assertIn("n_excluded", r)
 
-    def test_multiple_waves(self):
+    def test_multiple_arrays(self):
         op = NMMainOpHistogram(bins=5)
         arrays = {"RecordA0": [1.0, 2.0], "RecordA1": [3.0, 4.0],
                   "RecordA2": [5.0, 6.0]}
@@ -2359,6 +2359,155 @@ class TestNMMainOpHistogram(unittest.TestCase):
     def test_histogram_by_name(self):
         op = op_from_name("histogram")
         self.assertIsInstance(op, NMMainOpHistogram)
+
+    # --- out_prefix ---
+
+    def test_default_out_prefix(self):
+        self.assertEqual(NMMainOpHistogram().out_prefix, "H_")
+
+    def test_custom_out_prefix(self):
+        op = NMMainOpHistogram(bins=5)
+        op.out_prefix = "Histo_"
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0]})
+        self.assertIsNotNone(folder.data.get("Histo_RecordA0"))
+        self.assertIsNone(folder.data.get("H_RecordA0"))
+
+    def test_out_prefix_rejects_non_string(self):
+        op = NMMainOpHistogram()
+        with self.assertRaises(TypeError):
+            op.out_prefix = 123
+
+    # --- overwrite ---
+
+    def test_overwrite_default_is_true(self):
+        self.assertTrue(NMMainOpHistogram().overwrite)
+
+    def test_overwrite_true_replaces_existing(self):
+        op = NMMainOpHistogram(bins=5)
+        folder = self._run(op, {"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0]})
+        out_first = folder.data.get("H_RecordA0")
+        first_sum = float(out_first.nparray.sum())
+        # run again with different data → same name, updated content
+        d2 = folder.data.new("RecordA1", nparray=np.array([10.0, 20.0, 30.0]))
+        d2.name  # confirm created
+        op2 = NMMainOpHistogram(bins=5)
+        op2.overwrite = True
+        folder2 = NMFolder(name="folder0")
+        d_new = folder2.data.new("RecordA0",
+                                 nparray=np.array([10.0, 20.0, 30.0, 40.0, 50.0]))
+        op2.run_all([(d_new, None)], folder2)
+        op2.run_all([(d_new, None)], folder2)  # second run: same name
+        out = folder2.data.get("H_RecordA0")
+        self.assertIsNotNone(out)  # still one array, not two
+
+    def test_overwrite_false_sequences_from_zero(self):
+        op = NMMainOpHistogram(bins=5)
+        op.overwrite = False
+        folder = NMFolder(name="folder0")
+        d = folder.data.new("RecordA0",
+                            nparray=np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
+        op.run_all([(d, None)], folder)  # → H_RecordA0_0
+        op.run_all([(d, None)], folder)  # → H_RecordA0_1
+        op.run_all([(d, None)], folder)  # → H_RecordA0_2
+        self.assertIsNotNone(folder.data.get("H_RecordA0_0"))
+        self.assertIsNotNone(folder.data.get("H_RecordA0_1"))
+        self.assertIsNotNone(folder.data.get("H_RecordA0_2"))
+        self.assertIsNone(folder.data.get("H_RecordA0"))  # bare name never created
+
+    def test_overwrite_false_sequence_starts_at_zero(self):
+        op = NMMainOpHistogram(bins=5)
+        op.overwrite = False
+        folder = NMFolder(name="folder0")
+        d = folder.data.new("RecordA0",
+                            nparray=np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
+        op.run_all([(d, None)], folder)  # first run → H_RecordA0_0
+        self.assertIsNotNone(folder.data.get("H_RecordA0_0"))
+        self.assertIsNone(folder.data.get("H_RecordA0"))   # bare name not used
+        self.assertIsNone(folder.data.get("H_RecordA0_1"))
+
+    def test_overwrite_rejects_non_bool(self):
+        op = NMMainOpHistogram()
+        with self.assertRaises(TypeError):
+            op.overwrite = 1
+
+
+# ===========================================================================
+# TestOverwriteAndPrefixInequality
+# ===========================================================================
+
+
+class TestOverwriteAndPrefixInequality(unittest.TestCase):
+    """overwrite / out_prefix behaviour for NMMainOpInequality."""
+
+    def test_default_out_prefix(self):
+        self.assertEqual(NMMainOpInequality(op=">", a=0.0).out_prefix, "IQ_")
+
+    def test_custom_out_prefix(self):
+        op = NMMainOpInequality(op=">", a=2.0)
+        op.out_prefix = "MyIQ_"
+        folder = _run_op_directly(op, {"RecordA0": [1.0, 3.0]})
+        self.assertIsNotNone(folder.data.get("MyIQ_RecordA0"))
+        self.assertIsNone(folder.data.get("IQ_RecordA0"))
+
+    def test_overwrite_false_sequences(self):
+        op = NMMainOpInequality(op=">", a=0.0)
+        op.overwrite = False
+        folder = NMFolder(name="folder0")
+        d = folder.data.new("RecordA0", nparray=np.array([1.0, 2.0]))
+        op.run_all([(d, None)], folder)  # → IQ_RecordA0_0
+        op.run_all([(d, None)], folder)  # → IQ_RecordA0_1
+        self.assertIsNotNone(folder.data.get("IQ_RecordA0_0"))
+        self.assertIsNotNone(folder.data.get("IQ_RecordA0_1"))
+        self.assertIsNone(folder.data.get("IQ_RecordA0"))  # bare name never created
+
+
+# ===========================================================================
+# TestOverwriteAndPrefixAccumulate
+# ===========================================================================
+
+
+class TestOverwriteAndPrefixAccumulate(unittest.TestCase):
+    """overwrite / out_prefix behaviour for NMMainOpAccumulate subclasses."""
+
+    def _run_average(self, op, arrays_by_name):
+        return _run_op_directly(op, arrays_by_name)
+
+    def test_default_out_prefix_average(self):
+        self.assertEqual(NMMainOpAverage().out_prefix, "Avg_")
+
+    def test_custom_out_prefix_average(self):
+        op = NMMainOpAverage()
+        op.out_prefix = "Mean_"
+        folder = _run_op_directly(op, {"RecordA0": [1.0, 2.0],
+                                       "RecordA1": [3.0, 4.0]})
+        self.assertIsNotNone(folder.data.get("Mean_RecordA"))
+        self.assertIsNone(folder.data.get("Avg_RecordA"))
+
+    def test_overwrite_false_sequences_accumulate(self):
+        op = NMMainOpSum()
+        op.overwrite = False
+        folder = NMFolder(name="folder0")
+        d = folder.data.new("RecordA0", nparray=np.array([1.0, 2.0]))
+        op.run_all([(d, None)], folder)  # → Sum_RecordA_0
+        op.run_all([(d, None)], folder)  # → Sum_RecordA_1
+        self.assertIsNotNone(folder.data.get("Sum_RecordA_0"))
+        self.assertIsNotNone(folder.data.get("Sum_RecordA_1"))
+        self.assertIsNone(folder.data.get("Sum_RecordA"))  # bare name never created
+
+    def test_companion_arrays_share_suffix(self):
+        # overwrite=False: companions (Stdv_) always get same suffix as Avg_
+        op = NMMainOpAverage(compute_stdv=True)
+        op.overwrite = False
+        folder = NMFolder(name="folder0")
+        d0 = folder.data.new("RecordA0", nparray=np.array([1.0, 2.0]))
+        d1 = folder.data.new("RecordA1", nparray=np.array([3.0, 4.0]))
+        op.run_all([(d0, None), (d1, None)], folder)  # → Avg_RecordA_0, Stdv_RecordA_0
+        op.run_all([(d0, None), (d1, None)], folder)  # → Avg_RecordA_1, Stdv_RecordA_1
+        self.assertIsNotNone(folder.data.get("Avg_RecordA_0"))
+        self.assertIsNotNone(folder.data.get("Stdv_RecordA_0"))
+        self.assertIsNotNone(folder.data.get("Avg_RecordA_1"))
+        self.assertIsNotNone(folder.data.get("Stdv_RecordA_1"))
+        self.assertIsNone(folder.data.get("Avg_RecordA"))  # bare name never created
 
 
 if __name__ == "__main__":

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -127,11 +127,11 @@ class TestNMToolStats(unittest.TestCase):
         self.tool._select["folder"] = folder
         return folder
 
-    def _run_compute(self, func="mean", n_waves=3):
-        """Compute stat for n_waves and accumulate into tool results."""
+    def _run_compute(self, func="mean", n_arrays=3):
+        """Compute stat for n_arrays and accumulate into tool results."""
         w = list(self.tool.windows)[0]
         w.func = func
-        for k in range(n_waves):
+        for k in range(n_arrays):
             data = _make_data(name="recordA%d" % k)
             w.compute(data)
             wname = w.name
@@ -141,13 +141,13 @@ class TestNMToolStats(unittest.TestCase):
             else:
                 self.tool._NMToolStats__results[wname] = [results]
 
-    def _run_compute_with_bsln(self, func="mean", bsln_func="mean", n_waves=3):
-        """Compute stat with baseline enabled for n_waves."""
+    def _run_compute_with_bsln(self, func="mean", bsln_func="mean", n_arrays=3):
+        """Compute stat with baseline enabled for n_arrays."""
         w = list(self.tool.windows)[0]
         w.func = func
         w._bsln_on_set(True, quiet=True)
         w._bsln_func_set({"name": bsln_func}, quiet=True)
-        for k in range(n_waves):
+        for k in range(n_arrays):
             data = _make_data(name="recordA%d" % k)
             w.compute(data)
             wname = w.name
@@ -213,26 +213,26 @@ class TestNMToolStats(unittest.TestCase):
 
     def test_results_to_numpy_creates_data_array(self):
         self._setup_folder()
-        self._run_compute(n_waves=3)
+        self._run_compute(n_arrays=3)
         f = self.tool._results_to_numpy()
         self.assertIn("ST_w0_data", f.data)
 
     def test_results_to_numpy_data_array_length(self):
         self._setup_folder()
-        self._run_compute(n_waves=3)
+        self._run_compute(n_arrays=3)
         f = self.tool._results_to_numpy()
         d = f.data.get("ST_w0_data")
         self.assertEqual(len(d.nparray), 3)
 
     def test_results_to_numpy_creates_mean_y_array(self):
         self._setup_folder()
-        self._run_compute(func="mean", n_waves=3)
+        self._run_compute(func="mean", n_arrays=3)
         f = self.tool._results_to_numpy()
         self.assertIn("ST_w0_mean_y", f.data)
 
     def test_results_to_numpy_mean_y_array_length(self):
         self._setup_folder()
-        self._run_compute(func="mean", n_waves=3)
+        self._run_compute(func="mean", n_arrays=3)
         f = self.tool._results_to_numpy()
         d = f.data.get("ST_w0_mean_y")
         self.assertEqual(len(d.nparray), 3)
@@ -240,7 +240,7 @@ class TestNMToolStats(unittest.TestCase):
     def test_results_to_numpy_compound_mean_std_splits(self):
         # mean+std → ST_w0_mean_y AND ST_w0_std_y
         self._setup_folder()
-        self._run_compute(func="mean+std", n_waves=3)
+        self._run_compute(func="mean+std", n_arrays=3)
         f = self.tool._results_to_numpy()
         self.assertIn("ST_w0_mean_y", f.data)
         self.assertIn("ST_w0_std_y", f.data)
@@ -504,12 +504,12 @@ class TestNMToolStats2Inequality(unittest.TestCase):
         # ST_w0_mean_y: values 1..5
         self.arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
         self.tf.data.new("ST_w0_mean_y", nparray=self.arr.copy())
-        # ST_w0_data: wave names for epoch set creation
-        self.wave_names = ["RecordA0", "RecordA1", "RecordA2",
+        # ST_w0_data: array names for epoch set creation
+        self.array_names = ["RecordA0", "RecordA1", "RecordA2",
                            "RecordA3", "RecordA4"]
         self.tf.data.new(
             "ST_w0_data",
-            nparray=np.array(self.wave_names, dtype=object),
+            nparray=np.array(self.array_names, dtype=object),
         )
 
         # Build a real NMDataSeries with 5 epochs for set-creation tests
@@ -937,11 +937,11 @@ class TestNMToolStats2StabilityTest(unittest.TestCase):
         nan_arr[15] = np.nan
         self.tf.data.new("ST_w0_nan_y", nparray=nan_arr)
 
-        # Wave-name array and dataseries for epoch-set tests
-        wave_names = ["RecordA%d" % i for i in range(20)]
+        # array names and dataseries for epoch-set tests
+        array_names = ["RecordA%d" % i for i in range(20)]
         self.tf.data.new(
             "ST_w0_data",
-            nparray=np.array(wave_names, dtype=object),
+            nparray=np.array(array_names, dtype=object),
         )
         self.nm = NMManager(quiet=True)
         assert self.nm.project.folders is not None
@@ -1127,11 +1127,11 @@ class TestNMToolStats2AddEpochSetsFromMask(unittest.TestCase):
         self.tf = NMToolFolder(name="stats0")
         # mask: [T, T, F, F, T] → true indices 0,1,4; false indices 2,3
         self.mask = np.array([True, True, False, False, True])
-        wave_names = ["RecordA0", "RecordA1", "RecordA2", "RecordA3", "RecordA4"]
+        array_names = ["RecordA0", "RecordA1", "RecordA2", "RecordA3", "RecordA4"]
         self.tf.data.new("ST_w0_mean_y", nparray=np.zeros(5))
         self.tf.data.new(
             "ST_w0_data",
-            nparray=np.array(wave_names, dtype=object),
+            nparray=np.array(array_names, dtype=object),
         )
         self.nm = NMManager(quiet=True)
         assert self.nm.project.folders is not None

--- a/tests/test_core/test_nm_utilities.py
+++ b/tests/test_core/test_nm_utilities.py
@@ -411,9 +411,9 @@ class TestFormatEpochString(unittest.TestCase):
     def test_single_gap(self):
         self.assertEqual(nmu.format_epoch_string(["RecordA0", "RecordA2"]), "[0,2]")
 
-    # --- single wave ---
+    # --- single array ---
 
-    def test_single_wave_returns_single_number(self):
+    def test_single_array_returns_single_number(self):
         self.assertEqual(nmu.format_epoch_string(["RecordA3"]), "[3]")
 
     # --- unparseable names fall back to the raw name ---


### PR DESCRIPTION
## Summary
- Add `overwrite` and `out_prefix` properties to non-destructive `NMMainOp` ops (`Accumulate`, `Average`, `Inequality`, `Histogram`)
- `overwrite=False` sequences output names from `_0` (Igor NeuroMatic convention): first run → `H_RecordA0_0`, second → `H_RecordA0_1`, etc.
- Rename `t_begin`/`t_end` → `x0`/`x1` for consistency (x-axis may not be time)
- `time_window_to_slice()` now handles ±inf arguments natively
- File reorganized: destructive ops first, output-creating ops grouped at end

## Test plan
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py -v`
- [ ] `python3 -m pytest tests/ -x -q` (all 1898 tests pass)

Closes #201