### PR TITLE
feat(analysis): add NMMainOpDFOF op (dF/F₀ fluorescence normalisation)

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -645,183 +645,6 @@ class NMMainOpDeletePoints(NMMainOp):
 
 
 # =========================================================================
-# Baseline
-# =========================================================================
-
-
-class NMMainOpBaseline(NMMainOp):
-    """Subtract a baseline from each selected array.
-
-    Two modes are supported:
-
-    - **per_array**: Each array's own baseline (mean of the window) is subtracted
-      from that array independently.
-    - **average**: A single shared baseline per channel is computed as the mean
-      of all per-array baselines for that channel, then subtracted from every
-      array in that channel.
-
-    Parameters:
-        x0: Baseline window start in time units (default 0.0).
-        x1: Baseline window end in time units (default 0.0).  Must be >=
-            ``x0``.
-        mode: ``"per_array"`` (default) or ``"average"``.
-        ignore_nans: If True (default) use ``np.nanmean``; otherwise ``np.mean``
-            (NaN propagates to the result).
-    """
-
-    name = "baseline"
-
-    _VALID_MODES = {"per_array", "average"}
-
-    def __init__(
-        self,
-        x0: float = 0.0,
-        x1: float = 0.0,
-        mode: str = "per_array",
-        ignore_nans: bool = True,
-    ) -> None:
-        self.x0 = x0
-        self.x1 = x1
-        self.mode = mode
-        self.ignore_nans = ignore_nans
-
-    # ------------------------------------------------------------------
-    # Properties
-
-    @property
-    def x0(self) -> float:
-        """Baseline window start (time units)."""
-        return self._x0
-
-    @x0.setter
-    def x0(self, value: float) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "x0", "float"))
-        self._x0 = float(value)
-
-    @property
-    def x1(self) -> float:
-        """Baseline window end (time units)."""
-        return self._x1
-
-    @x1.setter
-    def x1(self, value: float) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "x1", "float"))
-        self._x1 = float(value)
-
-    @property
-    def mode(self) -> str:
-        """Subtraction mode: ``'per_array'`` or ``'average'``."""
-        return self._mode
-
-    @mode.setter
-    def mode(self, value: str) -> None:
-        if not isinstance(value, str):
-            raise TypeError(nmu.type_error_str(value, "mode", "string"))
-        if value not in self._VALID_MODES:
-            raise ValueError(
-                "mode must be one of %s, got %r" % (sorted(self._VALID_MODES), value)
-            )
-        self._mode = value
-
-    @property
-    def ignore_nans(self) -> bool:
-        """If True, NaN values are excluded from baseline mean (np.nanmean)."""
-        return self._ignore_nans
-
-    @ignore_nans.setter
-    def ignore_nans(self, value: bool) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
-        self._ignore_nans = value
-
-    # ------------------------------------------------------------------
-    # Validation helper
-
-    def _validate_window(self) -> None:
-        if self._x1 < self._x0:
-            raise ValueError(
-                "x1 (%g) must be >= x0 (%g)" % (self._x1, self._x0)
-            )
-
-    # ------------------------------------------------------------------
-    # Lifecycle
-
-    def run_init(self) -> None:
-        """Reset per-run accumulators."""
-        self._validate_window()
-        self._baseline_accum: dict[str, list[float]] = {}
-        self._data_refs: dict[str, list[NMData]] = {}
-
-    def run(
-        self,
-        data: NMData,
-        channel_name: str | None = None,
-    ) -> None:
-        """Compute and (optionally) apply baseline for one array.
-
-        Args:
-            data: The NMData object to process.
-            channel_name: Channel name from the selection context, or None
-                (parsed from data.name as a fallback).
-        """
-        if not isinstance(data.nparray, np.ndarray):
-            return
-
-        if channel_name is None:
-            parsed = nmu.parse_data_name(data.name)
-            channel_name = parsed[1] if parsed is not None else "A"
-
-        sl = nm_math.time_window_to_slice(
-            data.nparray, data.xscale.to_dict(), self._x0, self._x1
-        )
-        segment = data.nparray[sl].astype(float)
-        if len(segment) == 0:
-            baseline = 0.0
-        elif self._ignore_nans:
-            baseline = float(np.nanmean(segment))
-        else:
-            baseline = float(np.mean(segment))
-
-        if self._mode == "per_array":
-            data.nparray = data.nparray.astype(float) - baseline
-            self._add_note(
-                data,
-                "NMBaseline(x0=%.6g,x1=%.6g,mode=per_array,baseline=%.6g)"
-                % (self._x0, self._x1, baseline),
-            )
-        else:  # "average"
-            self._baseline_accum.setdefault(channel_name, []).append(baseline)
-            self._data_refs.setdefault(channel_name, []).append(data)
-
-    def run_finish(
-        self,
-        folder: NMFolder | None = None,
-        prefix: str | None = None,
-    ) -> None:
-        """Apply averaged baseline (average mode only).
-
-        In ``per_array`` mode this is a no-op (subtraction was done in ``run()``).
-        In ``average`` mode the average of all per-array baselines for each channel
-        is computed and subtracted from every array in that channel.
-        """
-        if self._mode == "per_array":
-            return
-        for channel_name, baselines in self._baseline_accum.items():
-            avg_baseline = float(
-                np.nanmean(baselines) if self._ignore_nans else np.mean(baselines)
-            )
-            for d in self._data_refs[channel_name]:
-                d.nparray = d.nparray.astype(float) - avg_baseline
-                self._add_note(
-                    d,
-                    "NMBaseline(x0=%.6g,x1=%.6g,mode=average,channel=%s,baseline=%.6g)"
-                    % (self._x0, self._x1, channel_name, avg_baseline),
-                )
-
-
-# =========================================================================
 # Reverse
 # =========================================================================
 
@@ -1157,6 +980,187 @@ class NMMainOpDeleteNaNs(NMMainOp):
 
 
 # =========================================================================
+# Baseline
+# =========================================================================
+
+
+class NMMainOpBaseline(NMMainOp):
+    """Subtract a baseline from each selected array.
+
+    Two modes are supported:
+
+    - **per_array**: Each array's own baseline (mean of the window) is subtracted
+      from that array independently.
+    - **average**: A single shared baseline per channel is computed as the mean
+      of all per-array baselines for that channel, then subtracted from every
+      array in that channel.
+
+    Parameters:
+        x0: Baseline window start in time units (default 0.0).
+        x1: Baseline window end in time units (default 0.0).  Must be >=
+            ``x0``.
+        mode: ``"per_array"`` (default) or ``"average"``.
+        ignore_nans: If True (default) use ``np.nanmean``; otherwise ``np.mean``
+            (NaN propagates to the result).
+    """
+
+    name = "baseline"
+
+    _VALID_MODES = {"per_array", "average"}
+
+    def __init__(
+        self,
+        x0: float = 0.0,
+        x1: float = 0.0,
+        mode: str = "per_array",
+        ignore_nans: bool = True,
+    ) -> None:
+        self.x0 = x0
+        self.x1 = x1
+        self.mode = mode
+        self.ignore_nans = ignore_nans
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def x0(self) -> float:
+        """Baseline window start (time units)."""
+        return self._x0
+
+    @x0.setter
+    def x0(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "x0", "float"))
+        if math.isnan(float(value)):
+            raise ValueError("x0 must not be NaN")
+        self._x0 = float(value)
+
+    @property
+    def x1(self) -> float:
+        """Baseline window end (time units)."""
+        return self._x1
+
+    @x1.setter
+    def x1(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "x1", "float"))
+        if math.isnan(float(value)):
+            raise ValueError("x1 must not be NaN")
+        self._x1 = float(value)
+
+    @property
+    def mode(self) -> str:
+        """Subtraction mode: ``'per_array'`` or ``'average'``."""
+        return self._mode
+
+    @mode.setter
+    def mode(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "mode", "string"))
+        if value not in self._VALID_MODES:
+            raise ValueError(
+                "mode must be one of %s, got %r" % (sorted(self._VALID_MODES), value)
+            )
+        self._mode = value
+
+    @property
+    def ignore_nans(self) -> bool:
+        """If True, NaN values are excluded from baseline mean (np.nanmean)."""
+        return self._ignore_nans
+
+    @ignore_nans.setter
+    def ignore_nans(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
+        self._ignore_nans = value
+
+    # ------------------------------------------------------------------
+    # Validation helper
+
+    def _validate_window(self) -> None:
+        if self._x1 < self._x0:
+            raise ValueError(
+                "x1 (%g) must be >= x0 (%g)" % (self._x1, self._x0)
+            )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run_init(self) -> None:
+        """Reset per-run accumulators."""
+        self._validate_window()
+        self._baseline_accum: dict[str, list[float]] = {}
+        self._data_refs: dict[str, list[NMData]] = {}
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Compute and (optionally) apply baseline for one array.
+
+        Args:
+            data: The NMData object to process.
+            channel_name: Channel name from the selection context, or None
+                (parsed from data.name as a fallback).
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+
+        if channel_name is None:
+            parsed = nmu.parse_data_name(data.name)
+            channel_name = parsed[1] if parsed is not None else "A"
+
+        sl = nm_math.time_window_to_slice(
+            data.nparray, data.xscale.to_dict(), self._x0, self._x1
+        )
+        segment = data.nparray[sl].astype(float)
+        if len(segment) == 0:
+            baseline = 0.0
+        elif self._ignore_nans:
+            baseline = float(np.nanmean(segment))
+        else:
+            baseline = float(np.mean(segment))
+
+        if self._mode == "per_array":
+            data.nparray = data.nparray.astype(float) - baseline
+            self._add_note(
+                data,
+                "NMBaseline(x0=%.6g,x1=%.6g,mode=per_array,baseline=%.6g)"
+                % (self._x0, self._x1, baseline),
+            )
+        else:  # "average"
+            self._baseline_accum.setdefault(channel_name, []).append(baseline)
+            self._data_refs.setdefault(channel_name, []).append(data)
+
+    def run_finish(
+        self,
+        folder: NMFolder | None = None,
+        prefix: str | None = None,
+    ) -> None:
+        """Apply averaged baseline (average mode only).
+
+        In ``per_array`` mode this is a no-op (subtraction was done in ``run()``).
+        In ``average`` mode the average of all per-array baselines for each channel
+        is computed and subtracted from every array in that channel.
+        """
+        if self._mode == "per_array":
+            return
+        for channel_name, baselines in self._baseline_accum.items():
+            avg_baseline = float(
+                np.nanmean(baselines) if self._ignore_nans else np.mean(baselines)
+            )
+            for d in self._data_refs[channel_name]:
+                d.nparray = d.nparray.astype(float) - avg_baseline
+                self._add_note(
+                    d,
+                    "NMBaseline(x0=%.6g,x1=%.6g,mode=average,channel=%s,baseline=%.6g)"
+                    % (self._x0, self._x1, channel_name, avg_baseline),
+                )
+
+
+# =========================================================================
 # Normalize
 # =========================================================================
 
@@ -1237,6 +1241,8 @@ class NMMainOpNormalize(NMMainOp):
     def x0_min(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise TypeError(nmu.type_error_str(value, "x0_min", "float"))
+        if math.isnan(float(value)):
+            raise ValueError("x0_min must not be NaN")
         self._x0_min = float(value)
 
     @property
@@ -1248,6 +1254,8 @@ class NMMainOpNormalize(NMMainOp):
     def x1_min(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise TypeError(nmu.type_error_str(value, "x1_min", "float"))
+        if math.isnan(float(value)):
+            raise ValueError("x1_min must not be NaN")
         self._x1_min = float(value)
 
     @property
@@ -1287,6 +1295,8 @@ class NMMainOpNormalize(NMMainOp):
     def x0_max(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise TypeError(nmu.type_error_str(value, "x0_max", "float"))
+        if math.isnan(float(value)):
+            raise ValueError("x0_max must not be NaN")
         self._x0_max = float(value)
 
     @property
@@ -1298,6 +1308,8 @@ class NMMainOpNormalize(NMMainOp):
     def x1_max(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise TypeError(nmu.type_error_str(value, "x1_max", "float"))
+        if math.isnan(float(value)):
+            raise ValueError("x1_max must not be NaN")
         self._x1_max = float(value)
 
     @property
@@ -1467,6 +1479,207 @@ class NMMainOpNormalize(NMMainOp):
                 arr = d.nparray.astype(float)
                 d.nparray = self._apply(arr, avg_ref_min, avg_ref_max)
                 self._add_note(d, self._note_str(avg_ref_min, avg_ref_max, channel_name))
+
+
+# =========================================================================
+# DFOF
+# =========================================================================
+
+
+class NMMainOpDFOF(NMMainOp):
+    """Compute dF/F₀ = (F − F₀) / F₀ in-place for each data array.
+
+    F₀ is the mean fluorescence over the baseline time window [x0, x1].
+    The array name is unchanged; a note records the transformation and F₀.
+    After transformation, ``yscale.label`` is set to ``"dF/F"`` and
+    ``yscale.units`` to ``""`` (dimensionless).
+
+    Two modes are supported:
+
+    - **per_array**: Each array's own F₀ (mean of the window) is used
+      independently.
+    - **average**: A single shared F₀ per channel is computed as the mean
+      of all per-array F₀ values for that channel, then applied to every
+      array in that channel.
+
+    Parameters:
+        x0:          Baseline window start in x-axis units.  Default ``-inf``
+                     (start of array).
+        x1:          Baseline window end in x-axis units.  Default ``+inf``
+                     (end of array).
+        mode:        ``"per_array"`` (default) or ``"average"``.
+        ignore_nans: If True (default) use ``np.nanmean``; otherwise
+                     ``np.mean`` (NaN propagates to the result).
+    """
+
+    name = "dfof"
+
+    _VALID_MODES = {"per_array", "average"}
+
+    def __init__(
+        self,
+        x0: float = -math.inf,
+        x1: float = math.inf,
+        mode: str = "per_array",
+        ignore_nans: bool = True,
+    ) -> None:
+        self.x0 = x0
+        self.x1 = x1
+        self.mode = mode
+        self.ignore_nans = ignore_nans
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def x0(self) -> float:
+        """Baseline window start (x-axis units)."""
+        return self._x0
+
+    @x0.setter
+    def x0(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "x0", "float"))
+        if math.isnan(float(value)):
+            raise ValueError("x0 must not be NaN")
+        self._x0 = float(value)
+
+    @property
+    def x1(self) -> float:
+        """Baseline window end (x-axis units)."""
+        return self._x1
+
+    @x1.setter
+    def x1(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "x1", "float"))
+        if math.isnan(float(value)):
+            raise ValueError("x1 must not be NaN")
+        self._x1 = float(value)
+
+    @property
+    def mode(self) -> str:
+        """F₀ mode: ``'per_array'`` or ``'average'``."""
+        return self._mode
+
+    @mode.setter
+    def mode(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "mode", "string"))
+        if value not in self._VALID_MODES:
+            raise ValueError(
+                "mode must be one of %s, got %r" % (sorted(self._VALID_MODES), value)
+            )
+        self._mode = value
+
+    @property
+    def ignore_nans(self) -> bool:
+        """If True, NaN values are excluded from F₀ mean (np.nanmean)."""
+        return self._ignore_nans
+
+    @ignore_nans.setter
+    def ignore_nans(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
+        self._ignore_nans = value
+
+    # ------------------------------------------------------------------
+    # Validation helper
+
+    def _validate_window(self) -> None:
+        if self._x1 < self._x0:
+            raise ValueError(
+                "x1 (%g) must be >= x0 (%g)" % (self._x1, self._x0)
+            )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run_init(self) -> None:
+        """Reset per-run accumulators."""
+        self._validate_window()
+        self._f0_accum: dict[str, list[float]] = {}
+        self._data_refs: dict[str, list[NMData]] = {}
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Compute and (optionally) apply dF/F₀ for one array.
+
+        Args:
+            data: The NMData object to process.
+            channel_name: Channel name from the selection context, or None
+                (parsed from data.name as a fallback).
+        """
+        if not isinstance(data.nparray, np.ndarray):
+            return
+
+        if channel_name is None:
+            parsed = nmu.parse_data_name(data.name)
+            channel_name = parsed[1] if parsed is not None else "A"
+
+        arr = data.nparray.astype(float)
+        sl = nm_math.time_window_to_slice(
+            arr, data.xscale.to_dict(), self._x0, self._x1
+        )
+        segment = arr[sl]
+        if len(segment) == 0:
+            f0 = 0.0
+        elif self._ignore_nans:
+            f0 = float(np.nanmean(segment))
+        else:
+            f0 = float(np.mean(segment))
+
+        if self._mode == "per_array":
+            self._apply(data, arr, f0, "per_array")
+        else:  # "average"
+            self._f0_accum.setdefault(channel_name, []).append(f0)
+            self._data_refs.setdefault(channel_name, []).append(data)
+
+    def run_finish(
+        self,
+        folder: NMFolder | None = None,
+        prefix: str | None = None,
+    ) -> None:
+        """Apply averaged F₀ (average mode only).
+
+        In ``per_array`` mode this is a no-op (transform was done in ``run()``).
+        In ``average`` mode the mean of all per-array F₀ values for each channel
+        is computed and used to transform every array in that channel.
+        """
+        if self._mode == "per_array":
+            return
+        for channel_name, f0_list in self._f0_accum.items():
+            mean_f0 = float(
+                np.nanmean(f0_list) if self._ignore_nans else np.mean(f0_list)
+            )
+            for d in self._data_refs[channel_name]:
+                self._apply(d, d.nparray.astype(float), mean_f0, "average",
+                            channel_name=channel_name)
+
+    def _apply(
+        self,
+        data: NMData,
+        arr: np.ndarray,
+        f0: float,
+        mode_label: str,
+        channel_name: str | None = None,
+    ) -> None:
+        data.nparray = nm_math.apply_dfof(arr, f0)
+        data.yscale.label = "dF/F"
+        data.yscale.units = ""
+        note = "NMdFoF(x0=%.6g,x1=%.6g,mode=%s,F0=%.6g)" % (
+            self._x0, self._x1, mode_label, f0
+        )
+        if channel_name is not None:
+            note = (
+                "NMdFoF(x0=%.6g,x1=%.6g,mode=%s,channel=%s,F0=%.6g)" % (
+                    self._x0, self._x1, mode_label, channel_name, f0
+                )
+            )
+        self._add_note(data, note)
 
 
 # =========================================================================
@@ -2114,10 +2327,11 @@ class NMMainOpHistogram(NMMainOp):
 
     @x0.setter
     def x0(self, value: float) -> None:
-        value = float(value)
-        if math.isnan(value):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "x0", "float"))
+        if math.isnan(float(value)):
             raise ValueError("x0 must not be NaN")
-        self._x0 = -math.inf if math.isinf(value) else value
+        self._x0 = float(value)
 
     @property
     def x1(self) -> float:
@@ -2126,10 +2340,11 @@ class NMMainOpHistogram(NMMainOp):
 
     @x1.setter
     def x1(self, value: float) -> None:
-        value = float(value)
-        if math.isnan(value):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "x1", "float"))
+        if math.isnan(float(value)):
             raise ValueError("x1 must not be NaN")
-        self._x1 = math.inf if math.isinf(value) else value
+        self._x1 = float(value)
 
     @property
     def xrange(self) -> tuple | None:
@@ -2160,10 +2375,20 @@ class NMMainOpHistogram(NMMainOp):
         return self._results
 
     # ------------------------------------------------------------------
+    # Validation helper
+
+    def _validate_window(self) -> None:
+        if self._x1 < self._x0:
+            raise ValueError(
+                "x1 (%g) must be >= x0 (%g)" % (self._x1, self._x0)
+            )
+
+    # ------------------------------------------------------------------
     # NMMainOp interface
     # ------------------------------------------------------------------
 
     def run_init(self) -> None:
+        self._validate_window()
         self._results = {}
 
     def run(self, data: NMData, channel_name: str | None = None) -> None:
@@ -2226,6 +2451,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "average": NMMainOpAverage,
     "baseline": NMMainOpBaseline,
     "delete_nans": NMMainOpDeleteNaNs,
+    "dfof": NMMainOpDFOF,
     "delete_points": NMMainOpDeletePoints,
     "differentiate": NMMainOpDifferentiate,
     "histogram": NMMainOpHistogram,

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -235,6 +235,28 @@ def time_window_to_slice(
 
 
 # =========================================================================
+# Fluorescence dF/F₀ helper
+# =========================================================================
+
+
+def apply_dfof(arr: np.ndarray, f0: float) -> np.ndarray:
+    """Return dF/F₀ = (arr − f0) / f0.
+
+    If *f0* is zero, returns an array of NaN (avoids division by zero).
+
+    Args:
+        arr: Input fluorescence array (float).
+        f0:  Baseline scalar F₀.
+
+    Returns:
+        ndarray with same shape as *arr*.
+    """
+    if f0 == 0.0:
+        return np.full_like(arr, np.nan, dtype=float)
+    return (arr - f0) / f0
+
+
+# =========================================================================
 # Array statistics
 # =========================================================================
 

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -23,6 +23,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpBaseline,
     NMMainOpDeleteNaNs,
     NMMainOpDeletePoints,
+    NMMainOpDFOF,
     NMMainOpDifferentiate,
     NMMainOpHistogram,
     NMMainOpInequality,
@@ -1003,6 +1004,14 @@ class TestNMMainOpBaseline(unittest.TestCase):
         with self.assertRaises(TypeError):
             NMMainOpBaseline(x1=True)
 
+    def test_x0_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpBaseline(x0=float("nan"))
+
+    def test_x1_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpBaseline(x1=float("nan"))
+
     def test_ignore_nans_rejects_non_bool(self):
         with self.assertRaises(TypeError):
             NMMainOpBaseline(ignore_nans=1)
@@ -1594,6 +1603,22 @@ class TestNMMainOpNormalize(unittest.TestCase):
         op = NMMainOpNormalize(x0_min=5.0, x1_min=0.0)
         with self.assertRaises(ValueError):
             op.run_init()
+
+    def test_x0_min_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpNormalize(x0_min=float("nan"))
+
+    def test_x1_min_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpNormalize(x1_min=float("nan"))
+
+    def test_x0_max_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpNormalize(x0_max=float("nan"))
+
+    def test_x1_max_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpNormalize(x1_max=float("nan"))
 
     # ------------------------------------------------------------------
     # edge cases / notes
@@ -2332,6 +2357,14 @@ class TestNMMainOpHistogram(unittest.TestCase):
         out = folder.data.get("H_RecordA0")
         self.assertEqual(int(out.nparray.sum()), 3)
 
+    def test_x0_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpHistogram(x0=True)
+
+    def test_x1_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpHistogram(x1=True)
+
     def test_x0_rejects_nan(self):
         with self.assertRaises(ValueError):
             NMMainOpHistogram(x0=float("nan"))
@@ -2339,6 +2372,11 @@ class TestNMMainOpHistogram(unittest.TestCase):
     def test_x1_rejects_nan(self):
         with self.assertRaises(ValueError):
             NMMainOpHistogram(x1=float("nan"))
+
+    def test_x1_before_x0_raises(self):
+        op = NMMainOpHistogram(x0=5.0, x1=2.0)
+        with self.assertRaises(ValueError):
+            op.run_init()
 
     # --- validation ---
 
@@ -2508,6 +2546,244 @@ class TestOverwriteAndPrefixAccumulate(unittest.TestCase):
         self.assertIsNotNone(folder.data.get("Avg_RecordA_1"))
         self.assertIsNotNone(folder.data.get("Stdv_RecordA_1"))
         self.assertIsNone(folder.data.get("Avg_RecordA"))  # bare name never created
+
+
+class TestNMMainOpDFOF(unittest.TestCase):
+    """Tests for NMMainOpDFOF (per_array and average modes)."""
+
+    # ------------------------------------------------------------------
+    # per_array mode — basic behaviour
+
+    def test_in_place_modification(self):
+        op = NMMainOpDFOF(x0=0.0, x1=1.0)
+        d = _make_data("RecordA0", [2.0, 2.0, 4.0], xstart=0.0, xdelta=1.0)
+        original_id = id(d)
+        op.run_init()
+        op.run(d)
+        self.assertEqual(id(d), original_id)  # same NMData object
+        self.assertFalse(np.array_equal(d.nparray, [2.0, 2.0, 4.0]))
+
+    def test_basic_computation(self):
+        # window [0,1] → F0 = mean([1.0, 3.0]) = 2.0
+        # dF/F = ([1,3,5] - 2) / 2 = [-0.5, 0.5, 1.5]
+        op = NMMainOpDFOF(x0=0.0, x1=1.0)
+        d = _make_data("RecordA0", [1.0, 3.0, 5.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [-0.5, 0.5, 1.5])
+
+    def test_f0_zero_sets_nan(self):
+        op = NMMainOpDFOF(x0=0.0, x1=1.0)
+        d = _make_data("RecordA0", [0.0, 0.0, 1.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        self.assertTrue(np.all(np.isnan(d.nparray)))
+
+    def test_default_window_uses_full_array(self):
+        # x0=-inf, x1=+inf → F0 = mean of entire array = 3.0
+        op = NMMainOpDFOF()
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0, 4.0, 5.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        # (arr - 3) / 3
+        f0 = 3.0
+        np.testing.assert_array_almost_equal(
+            d.nparray, [(1-f0)/f0, (2-f0)/f0, (3-f0)/f0, (4-f0)/f0, (5-f0)/f0]
+        )
+
+    def test_x0_x1_window(self):
+        # window [2,3] → indices 2,3 → values [3,4] → F0 = 3.5
+        op = NMMainOpDFOF(x0=2.0, x1=3.0)
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0, 4.0, 5.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        f0 = 3.5
+        np.testing.assert_array_almost_equal(
+            d.nparray, [(1-f0)/f0, (2-f0)/f0, (3-f0)/f0, (4-f0)/f0, (5-f0)/f0]
+        )
+
+    def test_mode_per_array_independent_f0(self):
+        # Two arrays with different baselines → independent F0 per array
+        op = NMMainOpDFOF(x0=0.0, x1=0.0)
+        d1 = _make_data("RecordA0", [2.0, 4.0], xstart=0.0, xdelta=1.0)
+        d2 = _make_data("RecordA1", [4.0, 8.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d1)
+        op.run(d2)
+        # d1: F0=2 → [0, 1]; d2: F0=4 → [0, 1]
+        np.testing.assert_array_almost_equal(d1.nparray, [0.0, 1.0])
+        np.testing.assert_array_almost_equal(d2.nparray, [0.0, 1.0])
+
+    # ------------------------------------------------------------------
+    # average mode
+
+    def test_mode_average_shared_f0(self):
+        # F0 values: 2, 4, 6 → mean F0 = 4 per channel
+        op = NMMainOpDFOF(x0=0.0, x1=1.0, mode="average")
+        d1 = _make_data("RecordA0", [2.0, 2.0], xstart=0.0, xdelta=1.0)
+        d2 = _make_data("RecordA1", [4.0, 4.0], xstart=0.0, xdelta=1.0)
+        d3 = _make_data("RecordA2", [6.0, 6.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d1, "A")
+        op.run(d2, "A")
+        op.run(d3, "A")
+        op.run_finish()
+        # mean_f0 = 4; dF/F = (val - 4) / 4
+        np.testing.assert_array_almost_equal(d1.nparray, [-0.5, -0.5])
+        np.testing.assert_array_almost_equal(d2.nparray, [0.0, 0.0])
+        np.testing.assert_array_almost_equal(d3.nparray, [0.5, 0.5])
+
+    def test_mode_average_per_channel(self):
+        # Channel A: F0 values 2, 4 → mean=3; Channel B: F0=10 → mean=10
+        op = NMMainOpDFOF(x0=0.0, x1=0.0, mode="average")
+        a0 = _make_data("RecordA0", [2.0, 6.0], xstart=0.0, xdelta=1.0)
+        a1 = _make_data("RecordA1", [4.0, 6.0], xstart=0.0, xdelta=1.0)
+        b0 = _make_data("RecordB0", [10.0, 20.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(a0, "A")
+        op.run(a1, "A")
+        op.run(b0, "B")
+        op.run_finish()
+        # A: mean_f0=3 → (2-3)/3=-1/3, (6-3)/3=1
+        np.testing.assert_array_almost_equal(a0.nparray, [-1/3, 1.0])
+        np.testing.assert_array_almost_equal(a1.nparray, [1/3, 1.0])
+        # B: mean_f0=10 → (10-10)/10=0, (20-10)/10=1
+        np.testing.assert_array_almost_equal(b0.nparray, [0.0, 1.0])
+
+    # ------------------------------------------------------------------
+    # NaN handling
+
+    def test_ignore_nans_true(self):
+        # NaN in baseline window excluded → nanmean([nan, 4]) = 4
+        op = NMMainOpDFOF(x0=0.0, x1=1.0, ignore_nans=True)
+        d = _make_data("RecordA0", [np.nan, 4.0, 8.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        # F0=4 → (8-4)/4 = 1.0
+        self.assertAlmostEqual(float(d.nparray[2]), 1.0)
+
+    def test_ignore_nans_false(self):
+        # NaN in window → F0=nan → all-NaN result
+        op = NMMainOpDFOF(x0=0.0, x1=1.0, ignore_nans=False)
+        d = _make_data("RecordA0", [np.nan, 4.0, 8.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        self.assertTrue(np.all(np.isnan(d.nparray)))
+
+    # ------------------------------------------------------------------
+    # yscale update
+
+    def test_yscale_label_updated(self):
+        op = NMMainOpDFOF(x0=0.0, x1=1.0)
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        self.assertEqual(d.yscale.label, "dF/F")
+
+    def test_yscale_units_cleared(self):
+        op = NMMainOpDFOF(x0=0.0, x1=1.0)
+        d = _make_data("RecordA0", [1.0, 2.0, 3.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        self.assertEqual(d.yscale.units, "")
+
+    # ------------------------------------------------------------------
+    # Notes
+
+    def test_note_written(self):
+        op = NMMainOpDFOF(x0=0.0, x1=1.0)
+        d = _make_data("RecordA0", [2.0, 2.0, 4.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        self.assertGreater(len(d.notes), 0)
+        self.assertIn("NMdFoF", d.notes[0]["note"])
+
+    def test_note_contains_f0(self):
+        op = NMMainOpDFOF(x0=0.0, x1=1.0)
+        d = _make_data("RecordA0", [2.0, 2.0, 4.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        self.assertIn("F0=", d.notes[0]["note"])
+
+    def test_note_mode_per_array(self):
+        op = NMMainOpDFOF(x0=0.0, x1=1.0, mode="per_array")
+        d = _make_data("RecordA0", [2.0, 2.0, 4.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d)
+        self.assertIn("per_array", d.notes[0]["note"])
+
+    def test_note_mode_average(self):
+        op = NMMainOpDFOF(x0=0.0, x1=1.0, mode="average")
+        d = _make_data("RecordA0", [2.0, 2.0, 4.0], xstart=0.0, xdelta=1.0)
+        op.run_init()
+        op.run(d, "A")
+        op.run_finish()
+        self.assertGreater(len(d.notes), 0)
+        self.assertIn("average", d.notes[0]["note"])
+
+    # ------------------------------------------------------------------
+    # Edge cases
+
+    def test_skips_non_ndarray(self):
+        op = NMMainOpDFOF()
+        d = NMData(NM, name="RecordA0")  # no nparray
+        op.run_init()
+        op.run(d)  # should not raise
+
+    def test_multiple_waves(self):
+        op = NMMainOpDFOF(x0=0.0, x1=0.0)
+        waves = [
+            _make_data("RecordA0", [1.0, 5.0], xstart=0.0, xdelta=1.0),
+            _make_data("RecordA1", [2.0, 6.0], xstart=0.0, xdelta=1.0),
+            _make_data("RecordA2", [4.0, 8.0], xstart=0.0, xdelta=1.0),
+        ]
+        op.run_init()
+        for w in waves:
+            op.run(w)
+        # Each wave transformed independently
+        np.testing.assert_array_almost_equal(waves[0].nparray, [0.0, 4.0])
+        np.testing.assert_array_almost_equal(waves[1].nparray, [0.0, 2.0])
+        np.testing.assert_array_almost_equal(waves[2].nparray, [0.0, 1.0])
+
+    # ------------------------------------------------------------------
+    # Validation
+
+    def test_x0_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpDFOF(x0=True)
+
+    def test_x1_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpDFOF(x1=True)
+
+    def test_x0_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpDFOF(x0=float("nan"))
+
+    def test_x1_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            NMMainOpDFOF(x1=float("nan"))
+
+    def test_x1_before_x0_raises(self):
+        op = NMMainOpDFOF(x0=5.0, x1=2.0)
+        with self.assertRaises(ValueError):
+            op.run_init()
+
+    def test_mode_rejects_invalid(self):
+        with self.assertRaises(ValueError):
+            NMMainOpDFOF(mode="median")
+
+    def test_mode_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            NMMainOpDFOF(mode=1)
+
+    def test_ignore_nans_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            NMMainOpDFOF(ignore_nans=1)
+
+    def test_dfof_by_name(self):
+        op = op_from_name("dfof")
+        self.assertIsInstance(op, NMMainOpDFOF)
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -11,6 +11,7 @@ from pyneuromatic.core.nm_math import (
     VALID_ARITH_OPS,
     VALID_INEQUALITY_OPS,
     apply_arithmetic,
+    apply_dfof,
     apply_inequality,
     array_stats,
     compute_ref_value,
@@ -416,3 +417,38 @@ class TestLinearRegression:
     def test_non_array_raises(self):
         with pytest.raises(TypeError):
             linear_regression([1.0, 2.0, 3.0])
+
+
+# ---------------------------------------------------------------------------
+# TestApplyDFOF
+# ---------------------------------------------------------------------------
+
+
+class TestApplyDFOF:
+    def test_basic_dfof(self):
+        arr = np.array([0.0, 1.0, 2.0])
+        result = apply_dfof(arr, f0=1.0)
+        np.testing.assert_array_almost_equal(result, [-1.0, 0.0, 1.0])
+
+    def test_f0_zero_returns_nan(self):
+        arr = np.array([1.0, 2.0])
+        result = apply_dfof(arr, f0=0.0)
+        assert np.all(np.isnan(result))
+
+    def test_negative_f0(self):
+        arr = np.array([0.0, -1.0, -2.0])
+        result = apply_dfof(arr, f0=-1.0)
+        # (arr - (-1)) / (-1) = (arr + 1) / (-1) = -(arr + 1)
+        np.testing.assert_array_almost_equal(result, [-1.0, 0.0, 1.0])
+
+    def test_shape_preserved(self):
+        arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = apply_dfof(arr, f0=2.0)
+        assert result.shape == arr.shape
+
+    def test_nan_in_arr_propagates(self):
+        arr = np.array([1.0, np.nan, 3.0])
+        result = apply_dfof(arr, f0=1.0)
+        assert np.isnan(result[1])
+        assert not np.isnan(result[0])
+        assert not np.isnan(result[2])


### PR DESCRIPTION
## Summary
- Add `NMMainOpDFOF` computing dF/F₀ = (F − F₀) / F₀ in-place per data array; baseline F₀ taken as mean over window [x0, x1]; supports `per_array` and `average` modes
- Add `nm_math.apply_dfof()` pure function (shared with future `NMTransformDFOF`)
- Group `Baseline`, `Normalize`, `DFOF` ops together in `nm_main_op.py`
- Unify x0/x1 setter validation across `Baseline`, `Normalize`, `DFOF`, `Histogram`: bool rejection, type checking, NaN rejection
- Add missing `_validate_window` to `NMMainOpHistogram`; simplify `NMMainOpDFOF._validate_window`

## Test plan
- [ ] `python3 -m pytest tests/test_core/test_nm_math.py::TestApplyDFOF -v`
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py::TestNMMainOpDFOF -v`
- [ ] `python3 -m pytest tests/ -x -q` (all 1939 tests pass)

Closes #203
