### PR TITLE
feat: add NMMainOpRescale for SI unit rescaling

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -1683,6 +1683,96 @@ class NMMainOpDFOF(NMMainOp):
 
 
 # =========================================================================
+# Rescale
+# =========================================================================
+
+
+class NMMainOpRescale(NMMainOp):
+    """Rescale each data array between SI-prefixed unit variants in-place.
+
+    Multiplies the array by the power-of-10 factor implied by the unit
+    conversion and updates ``yscale.units``.
+
+    Supported base units include ``"V"`` (volts), ``"A"`` (amperes),
+    ``"Ohm"`` or ``"Ω"`` (ohms), and ``"s"`` (seconds).
+
+    Parameters:
+        to_units:   Target units string (e.g. ``"nA"``).  Required; must
+                    not be empty at run time.
+        from_units: Source units string.  Defaults to ``None``, which
+                    means the source units are read from
+                    ``data.yscale.units`` at runtime.  Raises
+                    ``ValueError`` if that field is also empty.
+    """
+
+    name = "rescale"
+
+    def __init__(
+        self,
+        to_units: str = "",
+        from_units: str | None = None,
+    ) -> None:
+        self.to_units = to_units
+        self.from_units = from_units
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def to_units(self) -> str:
+        return self._to_units
+
+    @to_units.setter
+    def to_units(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "to_units", "string"))
+        self._to_units = value
+
+    @property
+    def from_units(self) -> str | None:
+        return self._from_units
+
+    @from_units.setter
+    def from_units(self, value: str | None) -> None:
+        if value is not None and not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "from_units", "string or None"))
+        self._from_units = value
+
+    # ------------------------------------------------------------------
+    # Validation
+
+    def _validate(self) -> None:
+        if not self._to_units:
+            raise ValueError("to_units must not be empty")
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run_init(self) -> None:
+        self._validate()
+
+    def run(self, data: NMData, channel_name: str | None = None) -> None:
+        if not isinstance(data.nparray, np.ndarray):
+            return
+
+        from_units = self._from_units if self._from_units is not None \
+            else data.yscale.units
+        if not from_units:
+            raise ValueError(
+                "from_units not set and data.yscale.units is empty for %r"
+                % data.name
+            )
+
+        factor = nm_math.si_scale_factor(from_units, self._to_units)
+        data.nparray = data.nparray.astype(float) * factor
+        data.yscale.units = self._to_units
+        self._add_note(
+            data,
+            "NMRescale(from=%s,to=%s,factor=%.6g)" % (from_units, self._to_units, factor),
+        )
+
+
+# =========================================================================
 # Accumulate (base for Average, Sum, SumSqr, Min, Max)
 # =========================================================================
 
@@ -2463,6 +2553,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "normalize": NMMainOpNormalize,
     "redimension": NMMainOpRedimension,
     "replace_values": NMMainOpReplaceValues,
+    "rescale": NMMainOpRescale,
     "reverse": NMMainOpReverse,
     "rotate": NMMainOpRotate,
     "sum": NMMainOpSum,

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -257,6 +257,94 @@ def apply_dfof(arr: np.ndarray, f0: float) -> np.ndarray:
 
 
 # =========================================================================
+# SI unit helpers
+# =========================================================================
+
+# SI prefix → base-10 exponent
+_SI_PREFIX_EXPONENTS: dict[str, int] = {
+    "f": -15,       # femto
+    "p": -12,       # pico
+    "n": -9,        # nano
+    "u": -6,        # micro (ASCII)
+    "\u00b5": -6,   # µ (U+00B5 micro sign)
+    "\u03bc": -6,   # μ (U+03BC Greek mu)
+    "m": -3,        # milli
+    "":   0,        # (no prefix — base unit)
+    "k":  3,        # kilo
+    "M":  6,        # mega
+    "G":  9,        # giga
+    "T": 12,        # tera
+}
+
+
+def parse_si_units(units: str) -> tuple[str, str]:
+    """Split an SI-prefixed units string into ``(prefix, base_unit)``.
+
+    The first character is treated as a prefix if it is a known SI prefix
+    AND the string is longer than one character.
+
+    Examples::
+
+        parse_si_units("pA")  → ("p",  "A")
+        parse_si_units("mV")  → ("m",  "V")
+        parse_si_units("V")   → ("",   "V")
+        parse_si_units("ms")  → ("m",  "s")
+        parse_si_units("kHz") → ("k",  "Hz")
+
+    Args:
+        units: Non-empty units string (e.g. ``"pA"``, ``"mV"``).
+
+    Returns:
+        Tuple ``(prefix, base_unit)`` where *prefix* is ``""`` when no
+        recognised SI prefix is present.
+
+    Raises:
+        ValueError: If *units* is empty.
+    """
+    if not units:
+        raise ValueError("units string is empty")
+    first = units[0]
+    if len(units) > 1 and first in _SI_PREFIX_EXPONENTS:
+        return (first, units[1:])
+    return ("", units)
+
+
+def si_scale_factor(from_units: str, to_units: str) -> float:
+    """Return the multiplicative factor to convert *from_units* → *to_units*.
+
+    Both strings must share the same base unit (e.g. ``"A"``).
+
+    Examples::
+
+        si_scale_factor("pA", "nA") → 1e-3   (1 pA = 0.001 nA)
+        si_scale_factor("mV", "V")  → 1e-3
+        si_scale_factor("V",  "mV") → 1e3
+
+    Supported base units include ``"V"`` (volts), ``"A"`` (amperes),
+    ``"Ohm"`` or ``"Ω"`` (ohms), and ``"s"`` (seconds).
+
+    Args:
+        from_units: Source units string (e.g. ``"pA"``).
+        to_units:   Target units string (e.g. ``"nA"``).
+
+    Returns:
+        Float scale factor.
+
+    Raises:
+        ValueError: If base units differ, or either prefix is unrecognised.
+    """
+    from_prefix, from_base = parse_si_units(from_units)
+    to_prefix, to_base = parse_si_units(to_units)
+    if from_base != to_base:
+        raise ValueError(
+            "base units must match: %r (from %r) vs %r (from %r)"
+            % (from_base, from_units, to_base, to_units)
+        )
+    exp_diff = _SI_PREFIX_EXPONENTS[from_prefix] - _SI_PREFIX_EXPONENTS[to_prefix]
+    return 10.0 ** exp_diff
+
+
+# =========================================================================
 # Array statistics
 # =========================================================================
 

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -34,6 +34,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpNormalize,
     NMMainOpRedimension,
     NMMainOpReplaceValues,
+    NMMainOpRescale,
     NMMainOpReverse,
     NMMainOpRotate,
     NMMainOpSum,
@@ -2784,6 +2785,159 @@ class TestNMMainOpDFOF(unittest.TestCase):
     def test_dfof_by_name(self):
         op = op_from_name("dfof")
         self.assertIsInstance(op, NMMainOpDFOF)
+
+
+# ---------------------------------------------------------------------------
+# TestNMMainOpRescale
+# ---------------------------------------------------------------------------
+
+
+class TestNMMainOpRescale(unittest.TestCase):
+    """Tests for NMMainOpRescale."""
+
+    # ------------------------------------------------------------------
+    # Basic rescaling
+
+    def test_basic_rescale(self):
+        d = _make_data("RecordA0", [1.0, 2.0])
+        d.yscale.units = "pA"
+        op = NMMainOpRescale(to_units="nA")
+        op.run_init()
+        op.run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [1e-3, 2e-3])
+
+    def test_scale_factor_up(self):
+        d = _make_data("RecordA0", [1.0, 2.0])
+        d.yscale.units = "V"
+        op = NMMainOpRescale(to_units="mV")
+        op.run_init()
+        op.run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [1e3, 2e3])
+
+    def test_same_units_factor_one(self):
+        d = _make_data("RecordA0", [1.0, 2.0])
+        d.yscale.units = "pA"
+        op = NMMainOpRescale(to_units="pA")
+        op.run_init()
+        op.run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [1.0, 2.0])
+
+    # ------------------------------------------------------------------
+    # yscale update
+
+    def test_yscale_units_updated(self):
+        d = _make_data("RecordA0", [1.0])
+        d.yscale.units = "pA"
+        op = NMMainOpRescale(to_units="nA")
+        op.run_init()
+        op.run(d)
+        self.assertEqual(d.yscale.units, "nA")
+
+    # ------------------------------------------------------------------
+    # from_units
+
+    def test_from_units_auto_detected(self):
+        d = _make_data("RecordA0", [1.0, 2.0])
+        d.yscale.units = "mV"
+        op = NMMainOpRescale(to_units="V")
+        op.run_init()
+        op.run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [1e-3, 2e-3])
+
+    def test_from_units_explicit(self):
+        d = _make_data("RecordA0", [1.0, 2.0])
+        d.yscale.units = ""   # yscale empty — explicit from_units overrides
+        op = NMMainOpRescale(to_units="nA", from_units="pA")
+        op.run_init()
+        op.run(d)
+        np.testing.assert_array_almost_equal(d.nparray, [1e-3, 2e-3])
+
+    def test_from_units_empty_raises(self):
+        d = _make_data("RecordA0", [1.0])
+        d.yscale.units = ""
+        op = NMMainOpRescale(to_units="nA")  # from_units=None, yscale empty
+        op.run_init()
+        with self.assertRaises(ValueError):
+            op.run(d)
+
+    # ------------------------------------------------------------------
+    # Validation
+
+    def test_to_units_empty_raises(self):
+        op = NMMainOpRescale(to_units="")
+        with self.assertRaises(ValueError):
+            op.run_init()
+
+    def test_base_mismatch_raises(self):
+        d = _make_data("RecordA0", [1.0])
+        d.yscale.units = "pA"
+        op = NMMainOpRescale(to_units="mV")
+        op.run_init()
+        with self.assertRaises(ValueError):
+            op.run(d)
+
+    def test_to_units_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            NMMainOpRescale(to_units=123)
+
+    def test_from_units_rejects_non_string_non_none(self):
+        with self.assertRaises(TypeError):
+            NMMainOpRescale(to_units="nA", from_units=123)
+
+    # ------------------------------------------------------------------
+    # Notes
+
+    def test_note_written(self):
+        d = _make_data("RecordA0", [1.0])
+        d.yscale.units = "pA"
+        op = NMMainOpRescale(to_units="nA")
+        op.run_init()
+        op.run(d)
+        self.assertGreater(len(d.notes), 0)
+        note = d.notes[0]["note"]
+        self.assertIn("NMRescale", note)
+
+    def test_note_contains_factor(self):
+        d = _make_data("RecordA0", [1.0])
+        d.yscale.units = "pA"
+        op = NMMainOpRescale(to_units="nA")
+        op.run_init()
+        op.run(d)
+        note = d.notes[0]["note"]
+        self.assertIn("factor=", note)
+
+    # ------------------------------------------------------------------
+    # Edge cases
+
+    def test_skips_non_ndarray(self):
+        d = _make_data("RecordA0", [1.0])
+        d.yscale.units = "pA"
+        d.nparray = None   # not an ndarray
+        op = NMMainOpRescale(to_units="nA")
+        op.run_init()
+        op.run(d)   # should not raise
+
+    def test_multiple_waves(self):
+        waves = [
+            _make_data("RecordA0", [1.0, 2.0]),
+            _make_data("RecordA1", [3.0, 4.0]),
+            _make_data("RecordA2", [5.0, 6.0]),
+        ]
+        for w in waves:
+            w.yscale.units = "mV"
+        op = NMMainOpRescale(to_units="V")
+        op.run_init()
+        for w in waves:
+            op.run(w)
+        np.testing.assert_array_almost_equal(waves[0].nparray, [1e-3, 2e-3])
+        np.testing.assert_array_almost_equal(waves[1].nparray, [3e-3, 4e-3])
+        np.testing.assert_array_almost_equal(waves[2].nparray, [5e-3, 6e-3])
+        for w in waves:
+            self.assertEqual(w.yscale.units, "V")
+
+    def test_rescale_by_name(self):
+        op = op_from_name("rescale")
+        self.assertIsInstance(op, NMMainOpRescale)
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -20,6 +20,8 @@ from pyneuromatic.core.nm_math import (
     inequality_mask,
     interp_x,
     linear_regression,
+    parse_si_units,
+    si_scale_factor,
     time_window_to_slice,
 )
 
@@ -452,3 +454,79 @@ class TestApplyDFOF:
         assert np.isnan(result[1])
         assert not np.isnan(result[0])
         assert not np.isnan(result[2])
+
+
+# ---------------------------------------------------------------------------
+# TestParseSiUnits
+# ---------------------------------------------------------------------------
+
+
+class TestParseSiUnits:
+    def test_prefix_and_base(self):
+        assert parse_si_units("pA") == ("p", "A")
+
+    def test_milli(self):
+        assert parse_si_units("mV") == ("m", "V")
+
+    def test_no_prefix(self):
+        assert parse_si_units("V") == ("", "V")
+
+    def test_single_char_no_prefix(self):
+        assert parse_si_units("A") == ("", "A")
+
+    def test_kilo(self):
+        assert parse_si_units("kHz") == ("k", "Hz")
+
+    def test_micro_ascii(self):
+        assert parse_si_units("uV") == ("u", "V")
+
+    def test_micro_unicode_b5(self):
+        assert parse_si_units("\u00b5V") == ("\u00b5", "V")
+
+    def test_multi_char_base(self):
+        assert parse_si_units("MOhm") == ("M", "Ohm")
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError):
+            parse_si_units("")
+
+
+# ---------------------------------------------------------------------------
+# TestSiScaleFactor
+# ---------------------------------------------------------------------------
+
+
+class TestSiScaleFactor:
+    def test_pA_to_nA(self):
+        assert si_scale_factor("pA", "nA") == pytest.approx(1e-3)
+
+    def test_nA_to_pA(self):
+        assert si_scale_factor("nA", "pA") == pytest.approx(1e3)
+
+    def test_mV_to_V(self):
+        assert si_scale_factor("mV", "V") == pytest.approx(1e-3)
+
+    def test_V_to_mV(self):
+        assert si_scale_factor("V", "mV") == pytest.approx(1e3)
+
+    def test_same_units(self):
+        assert si_scale_factor("mV", "mV") == pytest.approx(1.0)
+
+    def test_base_mismatch_raises(self):
+        with pytest.raises(ValueError, match="base units must match"):
+            si_scale_factor("pA", "mV")
+
+    def test_unknown_prefix_raises(self):
+        # "x" is not a recognised SI prefix, so parse_si_units treats "xA"
+        # as a bare base unit — base mismatch with "A" still raises ValueError
+        with pytest.raises(ValueError):
+            si_scale_factor("xA", "nA")
+
+    def test_no_prefix_to_prefix(self):
+        assert si_scale_factor("V", "mV") == pytest.approx(1e3)
+
+    def test_ohm_units(self):
+        assert si_scale_factor("MOhm", "kOhm") == pytest.approx(1e3)
+
+    def test_femto_to_base(self):
+        assert si_scale_factor("fA", "A") == pytest.approx(1e-15)


### PR DESCRIPTION
## Summary
- Add `NMMainOpRescale` to rescale data arrays between SI-prefixed unit variants (e.g. pA → nA, mV → V) in-place
- Add `parse_si_units()` and `si_scale_factor()` helpers to `nm_math.py` with a complete SI prefix table (femto → tera)
- Source units auto-detected from `data.yscale.units` when `from_units=None`; base-unit mismatch raises `ValueError`

## Test plan
- [ ] `python3 -m pytest tests/test_core/test_nm_math.py::TestParseSiUnits -v`
- [ ] `python3 -m pytest tests/test_core/test_nm_math.py::TestSiScaleFactor -v`
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py::TestNMMainOpRescale -v`
- [ ] `python3 -m pytest tests/ -x -q` — all 1974 tests pass

Closes #205 