### PR TITLE
feat: add NMMainOpRescaleX for x-axis SI unit rescaling

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -1773,6 +1773,94 @@ class NMMainOpRescale(NMMainOp):
 
 
 # =========================================================================
+# RescaleX
+# =========================================================================
+
+
+class NMMainOpRescaleX(NMMainOp):
+    """Rescale the x-axis between SI-prefixed unit variants in-place.
+
+    Multiplies ``xscale.start`` and ``xscale.delta`` by the power-of-10
+    factor implied by the unit conversion and updates ``xscale.units``.
+
+    Supported base units include ``"s"`` (seconds), ``"m"`` (metres),
+    ``"V"`` (volts), ``"A"`` (amperes), and ``"Hz"`` (hertz).
+
+    Parameters:
+        to_units:   Target units string (e.g. ``"s"``).  Required; must
+                    not be empty at run time.
+        from_units: Source units string.  Defaults to ``None``, which
+                    means the source units are read from
+                    ``data.xscale.units`` at runtime.  Raises
+                    ``ValueError`` if that field is also empty.
+    """
+
+    name = "rescale_x"
+
+    def __init__(
+        self,
+        to_units: str = "",
+        from_units: str | None = None,
+    ) -> None:
+        self.to_units = to_units
+        self.from_units = from_units
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def to_units(self) -> str:
+        return self._to_units
+
+    @to_units.setter
+    def to_units(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "to_units", "string"))
+        self._to_units = value
+
+    @property
+    def from_units(self) -> str | None:
+        return self._from_units
+
+    @from_units.setter
+    def from_units(self, value: str | None) -> None:
+        if value is not None and not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "from_units", "string or None"))
+        self._from_units = value
+
+    # ------------------------------------------------------------------
+    # Validation
+
+    def _validate(self) -> None:
+        if not self._to_units:
+            raise ValueError("to_units must not be empty")
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run_init(self) -> None:
+        self._validate()
+
+    def run(self, data: NMData, channel_name: str | None = None) -> None:
+        from_units = self._from_units if self._from_units is not None \
+            else data.xscale.units
+        if not from_units:
+            raise ValueError(
+                "from_units not set and data.xscale.units is empty for %r"
+                % data.name
+            )
+
+        factor = nm_math.si_scale_factor(from_units, self._to_units)
+        data.xscale.start = data.xscale.start * factor
+        data.xscale.delta = data.xscale.delta * factor
+        data.xscale.units = self._to_units
+        self._add_note(
+            data,
+            "NMRescaleX(from=%s,to=%s,factor=%.6g)" % (from_units, self._to_units, factor),
+        )
+
+
+# =========================================================================
 # Accumulate (base for Average, Sum, SumSqr, Min, Max)
 # =========================================================================
 
@@ -2554,6 +2642,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "redimension": NMMainOpRedimension,
     "replace_values": NMMainOpReplaceValues,
     "rescale": NMMainOpRescale,
+    "rescale_x": NMMainOpRescaleX,
     "reverse": NMMainOpReverse,
     "rotate": NMMainOpRotate,
     "sum": NMMainOpSum,

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -35,6 +35,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpRedimension,
     NMMainOpReplaceValues,
     NMMainOpRescale,
+    NMMainOpRescaleX,
     NMMainOpReverse,
     NMMainOpRotate,
     NMMainOpSum,
@@ -2938,6 +2939,171 @@ class TestNMMainOpRescale(unittest.TestCase):
     def test_rescale_by_name(self):
         op = op_from_name("rescale")
         self.assertIsInstance(op, NMMainOpRescale)
+
+
+# ---------------------------------------------------------------------------
+# TestNMMainOpRescaleX
+# ---------------------------------------------------------------------------
+
+
+class TestNMMainOpRescaleX(unittest.TestCase):
+    """Tests for NMMainOpRescaleX."""
+
+    # ------------------------------------------------------------------
+    # Basic rescaling
+
+    def test_basic_rescale(self):
+        d = _make_data("RecordA0", [1.0, 2.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="s")
+        op.run_init()
+        op.run(d)
+        self.assertAlmostEqual(d.xscale.start, 0.0)
+        self.assertAlmostEqual(d.xscale.delta, 1e-3)
+
+    def test_scale_factor_up(self):
+        d = _make_data("RecordA0", [1.0, 2.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = "s"
+        op = NMMainOpRescaleX(to_units="ms")
+        op.run_init()
+        op.run(d)
+        self.assertAlmostEqual(d.xscale.start, 0.0)
+        self.assertAlmostEqual(d.xscale.delta, 1e3)
+
+    def test_same_units_factor_one(self):
+        d = _make_data("RecordA0", [1.0, 2.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="ms")
+        op.run_init()
+        op.run(d)
+        self.assertAlmostEqual(d.xscale.start, 0.0)
+        self.assertAlmostEqual(d.xscale.delta, 1.0)
+
+    # ------------------------------------------------------------------
+    # xscale field updates
+
+    def test_xscale_start_updated(self):
+        d = _make_data("RecordA0", [1.0], xstart=10.0, xdelta=1.0)
+        d.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="s")
+        op.run_init()
+        op.run(d)
+        self.assertAlmostEqual(d.xscale.start, 10e-3)
+
+    def test_xscale_delta_updated(self):
+        d = _make_data("RecordA0", [1.0], xstart=0.0, xdelta=0.1)
+        d.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="s")
+        op.run_init()
+        op.run(d)
+        self.assertAlmostEqual(d.xscale.delta, 0.1e-3)
+
+    def test_xscale_units_updated(self):
+        d = _make_data("RecordA0", [1.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="s")
+        op.run_init()
+        op.run(d)
+        self.assertEqual(d.xscale.units, "s")
+
+    # ------------------------------------------------------------------
+    # from_units
+
+    def test_from_units_auto_detected(self):
+        d = _make_data("RecordA0", [1.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="s")
+        op.run_init()
+        op.run(d)
+        self.assertAlmostEqual(d.xscale.delta, 1e-3)
+
+    def test_from_units_explicit(self):
+        d = _make_data("RecordA0", [1.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = ""   # empty — explicit from_units overrides
+        op = NMMainOpRescaleX(to_units="s", from_units="ms")
+        op.run_init()
+        op.run(d)
+        self.assertAlmostEqual(d.xscale.delta, 1e-3)
+
+    def test_from_units_empty_raises(self):
+        d = _make_data("RecordA0", [1.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = ""
+        op = NMMainOpRescaleX(to_units="s")
+        op.run_init()
+        with self.assertRaises(ValueError):
+            op.run(d)
+
+    # ------------------------------------------------------------------
+    # Validation
+
+    def test_to_units_empty_raises(self):
+        op = NMMainOpRescaleX(to_units="")
+        with self.assertRaises(ValueError):
+            op.run_init()
+
+    def test_base_mismatch_raises(self):
+        d = _make_data("RecordA0", [1.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="V")
+        op.run_init()
+        with self.assertRaises(ValueError):
+            op.run(d)
+
+    def test_to_units_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            NMMainOpRescaleX(to_units=123)
+
+    def test_from_units_rejects_non_string_non_none(self):
+        with self.assertRaises(TypeError):
+            NMMainOpRescaleX(to_units="s", from_units=123)
+
+    # ------------------------------------------------------------------
+    # Notes
+
+    def test_note_written(self):
+        d = _make_data("RecordA0", [1.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="s")
+        op.run_init()
+        op.run(d)
+        self.assertGreater(len(d.notes), 0)
+        note = d.notes[0]["note"]
+        self.assertIn("NMRescaleX", note)
+
+    def test_note_contains_factor(self):
+        d = _make_data("RecordA0", [1.0], xstart=0.0, xdelta=1.0)
+        d.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="s")
+        op.run_init()
+        op.run(d)
+        note = d.notes[0]["note"]
+        self.assertIn("factor=", note)
+
+    # ------------------------------------------------------------------
+    # Other
+
+    def test_multiple_waves(self):
+        waves = [
+            _make_data("RecordA0", [1.0], xstart=0.0, xdelta=1.0),
+            _make_data("RecordA1", [2.0], xstart=0.0, xdelta=2.0),
+            _make_data("RecordA2", [3.0], xstart=10.0, xdelta=0.5),
+        ]
+        for w in waves:
+            w.xscale.units = "ms"
+        op = NMMainOpRescaleX(to_units="s")
+        op.run_init()
+        for w in waves:
+            op.run(w)
+        self.assertAlmostEqual(waves[0].xscale.delta, 1e-3)
+        self.assertAlmostEqual(waves[1].xscale.delta, 2e-3)
+        self.assertAlmostEqual(waves[2].xscale.start, 10e-3)
+        self.assertAlmostEqual(waves[2].xscale.delta, 0.5e-3)
+        for w in waves:
+            self.assertEqual(w.xscale.units, "s")
+
+    def test_rescale_x_by_name(self):
+        op = op_from_name("rescale_x")
+        self.assertIsInstance(op, NMMainOpRescaleX)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `NMMainOpRescaleX` to rescale the x-axis between SI-prefixed unit variants (e.g. ms → s, µm → mm) in-place
- Multiplies `xscale.start` and `xscale.delta` by the scale factor and updates `xscale.units`
- Source units auto-detected from `data.xscale.units` when `from_units=None`; base-unit mismatch raises `ValueError`
- Reuses existing `si_scale_factor()` helper from `nm_math.py` — no new math code needed

## Test plan
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py::TestNMMainOpRescaleX -v`
- [ ] `python3 -m pytest tests/ -x -q` — all 1991 tests pass

Closes #207