### PR TITLE
feat(analysis): add NMMainOpConcatenate op

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -2265,6 +2265,92 @@ class NMMainOpMax(NMMainOpAccumulate):
 
 
 # =========================================================================
+# Concatenate
+# =========================================================================
+
+
+class NMMainOpConcatenate(NMMainOpAccumulate):
+    """Concatenate selected data arrays per channel into a single output array.
+
+    In ``"1d"`` mode arrays are joined end-to-end (``np.concatenate``);
+    unequal lengths are allowed.  In ``"2d"`` mode arrays are stacked as
+    rows (``np.stack``); shorter arrays are padded with NaN to ``max_len``
+    so no data is lost from longer waves.
+
+    Output array is written to the destination folder as
+    ``Cat_{prefix}{channel}`` (e.g. ``Cat_RecordA``).
+
+    Parameters:
+        mode:        ``"1d"`` (default) or ``"2d"``.
+        ignore_nans: Passed to the accumulate base (unused by concatenate
+                     itself, kept for API consistency).
+    """
+
+    name = "concatenate"
+    _output_prefix = "Cat_"
+    _note_name = "NMConcatenate"
+    _VALID_MODES: frozenset[str] = frozenset({"1d", "2d"})
+
+    def __init__(self, mode: str = "1d", ignore_nans: bool = True) -> None:
+        super().__init__(ignore_nans)
+        self.mode = mode
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @mode.setter
+    def mode(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "mode", "string"))
+        if value not in self._VALID_MODES:
+            raise ValueError(
+                "mode must be one of %s, got %r" % (sorted(self._VALID_MODES), value)
+            )
+        self._mode = value
+
+    # ------------------------------------------------------------------
+    # Subclass contract
+
+    def _reduce(self, stack: np.ndarray) -> np.ndarray:
+        # Not called — _process_channel is fully overridden.
+        return stack  # pragma: no cover
+
+    def _process_channel(
+        self,
+        folder: NMFolder,
+        pfx: str,
+        cname: str,
+        arrays: list[np.ndarray],
+    ) -> None:
+        if self._mode == "1d":
+            arr = np.concatenate(arrays)
+        else:  # "2d"
+            max_len = max(len(a) for a in arrays)
+            padded = []
+            for a in arrays:
+                deficit = max_len - len(a)
+                if deficit:
+                    a = np.concatenate([a, np.full(deficit, np.nan)])
+                padded.append(a)
+            arr = np.stack(padded)
+
+        n = len(arrays)
+        epoch_str = self._epoch_str(cname)
+        base_name = self._out_prefix + pfx + cname
+        out_name = self._make_out_name(folder, base_name)
+        note_name = "NMConcatenate_%s" % self._mode
+        self._write_output_array(
+            folder, out_name, arr, note_name,
+            folder.name, pfx, cname, epoch_str, n,
+        )
+        self._results[cname] = out_name
+
+
+# =========================================================================
 # NMMainOpInequality
 # =========================================================================
 
@@ -2627,6 +2713,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "arithmetic": NMMainOpArithmetic,
     "arithmetic_by_array": NMMainOpArithmeticByArray,
     "average": NMMainOpAverage,
+    "concatenate": NMMainOpConcatenate,
     "baseline": NMMainOpBaseline,
     "delete_nans": NMMainOpDeleteNaNs,
     "dfof": NMMainOpDFOF,

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -34,6 +34,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpNormalize,
     NMMainOpRedimension,
     NMMainOpReplaceValues,
+    NMMainOpConcatenate,
     NMMainOpRescale,
     NMMainOpRescaleX,
     NMMainOpReverse,
@@ -3104,6 +3105,176 @@ class TestNMMainOpRescaleX(unittest.TestCase):
     def test_rescale_x_by_name(self):
         op = op_from_name("rescale_x")
         self.assertIsInstance(op, NMMainOpRescaleX)
+
+
+# ---------------------------------------------------------------------------
+# TestNMMainOpConcatenate
+# ---------------------------------------------------------------------------
+
+
+class TestNMMainOpConcatenate(unittest.TestCase):
+    """Tests for NMMainOpConcatenate (1d and 2d modes)."""
+
+    def setUp(self):
+        self.op = NMMainOpConcatenate()
+        self.arrays = {
+            "RecordA0": [1.0, 2.0, 3.0],
+            "RecordA1": [4.0, 5.0, 6.0],
+        }
+
+    def _run(self, arrays=None, op=None):
+        if arrays is None:
+            arrays = self.arrays
+        if op is None:
+            op = self.op
+        return _run_op_directly(op, arrays)
+
+    # ------------------------------------------------------------------
+    # 1D mode — basic
+
+    def test_1d_values(self):
+        folder = self._run()
+        out = folder.data.get("Cat_RecordA")
+        self.assertIsNotNone(out)
+        np.testing.assert_array_almost_equal(out.nparray, [1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+
+    def test_1d_unequal_lengths(self):
+        arrays = {"RecordA0": [1.0, 2.0, 3.0], "RecordA1": [4.0, 5.0]}
+        folder = self._run(arrays)
+        out = folder.data.get("Cat_RecordA")
+        np.testing.assert_array_almost_equal(out.nparray, [1.0, 2.0, 3.0, 4.0, 5.0])
+
+    def test_1d_output_length(self):
+        folder = self._run()
+        out = folder.data.get("Cat_RecordA")
+        self.assertEqual(len(out.nparray), 6)  # 3 + 3
+
+    # ------------------------------------------------------------------
+    # 2D mode — basic
+
+    def test_2d_shape(self):
+        op = NMMainOpConcatenate(mode="2d")
+        arrays = {
+            "RecordA0": [1.0, 2.0, 3.0, 4.0],
+            "RecordA1": [5.0, 6.0, 7.0, 8.0],
+            "RecordA2": [9.0, 10.0, 11.0, 12.0],
+        }
+        folder = self._run(arrays, op)
+        out = folder.data.get("Cat_RecordA")
+        self.assertIsNotNone(out)
+        self.assertEqual(out.nparray.shape, (3, 4))
+
+    def test_2d_values(self):
+        op = NMMainOpConcatenate(mode="2d")
+        arrays = {"RecordA0": [1.0, 2.0], "RecordA1": [3.0, 4.0]}
+        folder = self._run(arrays, op)
+        out = folder.data.get("Cat_RecordA")
+        np.testing.assert_array_almost_equal(out.nparray[0], [1.0, 2.0])
+        np.testing.assert_array_almost_equal(out.nparray[1], [3.0, 4.0])
+
+    def test_2d_unequal_lengths_pads_nan(self):
+        op = NMMainOpConcatenate(mode="2d")
+        arrays = {"RecordA0": [1.0, 2.0, 3.0], "RecordA1": [4.0, 5.0]}
+        folder = self._run(arrays, op)
+        out = folder.data.get("Cat_RecordA")
+        self.assertEqual(out.nparray.shape, (2, 3))
+        np.testing.assert_array_almost_equal(out.nparray[0], [1.0, 2.0, 3.0])
+        self.assertAlmostEqual(out.nparray[1, 0], 4.0)
+        self.assertAlmostEqual(out.nparray[1, 1], 5.0)
+        self.assertTrue(np.isnan(out.nparray[1, 2]))
+
+    def test_2d_equal_lengths_no_nan(self):
+        op = NMMainOpConcatenate(mode="2d")
+        arrays = {"RecordA0": [1.0, 2.0], "RecordA1": [3.0, 4.0]}
+        folder = self._run(arrays, op)
+        out = folder.data.get("Cat_RecordA")
+        self.assertFalse(np.any(np.isnan(out.nparray)))
+
+    # ------------------------------------------------------------------
+    # Output naming and metadata
+
+    def test_output_name(self):
+        folder = self._run()
+        self.assertIsNotNone(folder.data.get("Cat_RecordA"))
+
+    def test_output_name_in_results(self):
+        self._run()
+        self.assertIn("A", self.op.results)
+        self.assertEqual(self.op.results["A"], "Cat_RecordA")
+
+    def test_yscale_copied_from_first(self):
+        folder = self._run()
+        out = folder.data.get("Cat_RecordA")
+        self.assertIsNotNone(out.yscale)
+
+    def test_xscale_copied_from_first(self):
+        folder = self._run()
+        out = folder.data.get("Cat_RecordA")
+        self.assertIsNotNone(out.xscale)
+
+    # ------------------------------------------------------------------
+    # Multi-channel
+
+    def test_two_channels(self):
+        arrays = {
+            "RecordA0": [1.0, 2.0],
+            "RecordA1": [3.0, 4.0],
+            "RecordB0": [5.0, 6.0],
+            "RecordB1": [7.0, 8.0],
+        }
+        folder = self._run(arrays)
+        self.assertIsNotNone(folder.data.get("Cat_RecordA"))
+        self.assertIsNotNone(folder.data.get("Cat_RecordB"))
+
+    # ------------------------------------------------------------------
+    # Notes
+
+    def test_note_written_1d(self):
+        folder = self._run()
+        out = folder.data.get("Cat_RecordA")
+        note = out.notes[0]["note"]
+        self.assertIn("NMConcatenate_1d", note)
+
+    def test_note_written_2d(self):
+        op = NMMainOpConcatenate(mode="2d")
+        folder = self._run(op=op)
+        out = folder.data.get("Cat_RecordA")
+        note = out.notes[0]["note"]
+        self.assertIn("NMConcatenate_2d", note)
+
+    # ------------------------------------------------------------------
+    # Validation
+
+    def test_mode_rejects_invalid(self):
+        with self.assertRaises(ValueError):
+            NMMainOpConcatenate(mode="3d")
+
+    def test_mode_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            NMMainOpConcatenate(mode=1)
+
+    def test_default_mode_is_1d(self):
+        self.assertEqual(NMMainOpConcatenate().mode, "1d")
+
+    # ------------------------------------------------------------------
+    # Registry
+
+    def test_concatenate_by_name(self):
+        op = op_from_name("concatenate")
+        self.assertIsInstance(op, NMMainOpConcatenate)
+
+    # ------------------------------------------------------------------
+    # Overwrite
+
+    def test_overwrite_false_creates_new(self):
+        op = NMMainOpConcatenate(mode="1d")
+        op.overwrite = False
+        _run_op_directly(op, self.arrays)   # creates Cat_RecordA_0
+        _run_op_directly(op, self.arrays)   # creates Cat_RecordA_1
+        # Both _0 and _1 must exist (fresh folder each call, but op tracks state)
+        # Verify second run produced a _0-suffixed name
+        self.assertIn("A", op.results)
+        self.assertTrue(op.results["A"].startswith("Cat_RecordA"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `NMMainOpConcatenate` to concatenate selected waves per channel into a single output array
- `"1d"` mode: waves joined end-to-end (`np.concatenate`); unequal lengths allowed
- `"2d"` mode: waves stacked as rows (`np.stack`); shorter waves padded with NaN to `max_len`
- Output named `Cat_{prefix}{channel}` (e.g. `Cat_RecordA`); note records folder, dataseries, channel, epochs, and count
- Inherits from `NMMainOpAccumulate` to reuse buffering, output-naming, overwrite, and note infrastructure

## Test plan
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_main.py::TestNMMainOpConcatenate -v`
- [ ] `python3 -m pytest tests/ -x -q` — all 2010 tests pass

Closes #209
