### PR TITLE
feat(core): add command history logging to NMManager

### DIFF
--- a/pyneuromatic/core/nm_manager.py
+++ b/pyneuromatic/core/nm_manager.py
@@ -344,6 +344,8 @@ class NMManager:
                 raise KeyError(f"'{tier}' is not a valid selection tier. "
                                f"Valid tiers: {HIERARCHY_SELECT_KEYS}")
 
+        nmch.add_command("nm.select_keys = %r" % (select,))
+
         # Traverse hierarchy, setting values as we go so subsequent tiers
         # use the newly selected parent
         folders = self.__project.folders

--- a/tests/test_core/test_nm_manager.py
+++ b/tests/test_core/test_nm_manager.py
@@ -696,6 +696,46 @@ class TestNMManagerCommandHistory(NMManagerTestBase):
             self.nm.run_keys_set({"folder": "folder0"})  # missing data/dataseries
         self.assertEqual(len(self.nm.command_history.buffer), 0)
 
+    def test_select_keys_set_logs_command(self):
+        self.nm.command_history.clear()
+        self.nm._select_keys_set({"folder": "folder0"})
+        buf = self.nm.command_history.buffer
+        self.assertEqual(len(buf), 1)
+        self.assertIn("nm.select_keys =", buf[0]["command"])
+        self.assertIn("folder0", buf[0]["command"])
+
+    def test_select_keys_set_logs_normalised_keys(self):
+        self.nm.command_history.clear()
+        self.nm._select_keys_set({"Folder": "folder0"})
+        cmd = self.nm.command_history.buffer[0]["command"]
+        self.assertIn("'folder'", cmd)
+        self.assertNotIn("'Folder'", cmd)
+
+    def test_select_keys_set_invalid_does_not_log(self):
+        self.nm.command_history.clear()
+        with self.assertRaises(KeyError):
+            self.nm._select_keys_set({"invalid_tier": "folder0"})
+        self.assertEqual(len(self.nm.command_history.buffer), 0)
+
+    def test_select_value_set_logs_via_select_keys(self):
+        self.nm.command_history.clear()
+        folder = self.nm.project.folders["folder0"]
+        self.nm.select_value_set(folder)
+        buf = self.nm.command_history.buffer
+        self.assertEqual(len(buf), 1)
+        cmd = buf[0]["command"]
+        self.assertIn("nm.select_keys =", cmd)
+        self.assertIn("folder0", cmd)
+
+    def test_select_value_set_epoch_logs_full_chain(self):
+        self.nm.command_history.clear()
+        epoch = self.select_values["epoch"]
+        self.nm.select_value_set(epoch)
+        cmd = self.nm.command_history.buffer[0]["command"]
+        self.assertIn("folder", cmd)
+        self.assertIn("dataseries", cmd)
+        self.assertIn("epoch", cmd)
+
     def test_run_reset_all_logs_command(self):
         self.nm.command_history.clear()
         self.nm.run_reset_all()


### PR DESCRIPTION
## Summary

Instruments NMManager so that key user actions are automatically recorded
in the session-wide `NMCommandHistory`, building on the NMMainOp command
history from #212.

- `NMManager.__init__`: logs `nm = NMManager()` as the first entry;
  workspace `tool_add()` calls follow immediately after
- `nm.command_history` property: mirrors the existing `nm.history` property
- **Tool management**: `tool_add()`, `tool_remove()`, `tool_select` setter
- **Run management**: `run_keys_set()`, `run_reset_all()`, `run_tool()`
  (always logs the resolved tool name, not `"selected"`)
- **Selection**: `select_keys` setter and `select_value_set()` — both log
  `nm.select_keys = {...}` using the public property form; failed validation
  never logs

A typical session now produces a complete, reproducible command history:

```python
nm = NMManager()
nm.tool_add('main')
nm.select_keys = {'folder': 'folder0', 'dataseries': 'data', 'channel': 'A', 'epoch': 'E0'}
nm.run_keys_set({'folder': 'folder0', 'dataseries': 'data', 'channel': 'all', 'epoch': 'Set1'})
nm.run_tool('main')

Closes #214
