### PR TITLE
feat(core): add nm_name parameter to NMCommandHistory and log tool_main.op

### DIFF
--- a/pyneuromatic/analysis/nm_tool_main.py
+++ b/pyneuromatic/analysis/nm_tool_main.py
@@ -76,6 +76,11 @@ class NMToolMain(NMTool):
             raise TypeError(
                 nmu.type_error_str(value, "op", "NMMainOp or string")
             )
+        from pyneuromatic.core.nm_command_history import add_nm_command
+        params = self._op._op_params_str()
+        if params is None:
+            params = ""
+        add_nm_command("tool_main.op = %s(%s)" % (type(self._op).__name__, params))
 
     # ------------------------------------------------------------------
     # Lifecycle hooks

--- a/pyneuromatic/core/nm_command_history.py
+++ b/pyneuromatic/core/nm_command_history.py
@@ -115,6 +115,7 @@ class NMCommandHistory:
         enabled: bool = True,
         quiet: bool = False,
         log_to_nm_history: bool = True,
+        nm_name: str = "nm",
     ) -> None:
         if not isinstance(enabled, bool):
             raise TypeError("enabled must be a bool, got %r" % type(enabled).__name__)
@@ -125,9 +126,12 @@ class NMCommandHistory:
                 "log_to_nm_history must be a bool, got %r"
                 % type(log_to_nm_history).__name__
             )
+        if not isinstance(nm_name, str) or not nm_name:
+            raise TypeError("nm_name must be a non-empty string")
         self._enabled: bool = enabled
         self._quiet: bool = quiet
         self._log_to_nm_history: bool = log_to_nm_history
+        self._nm_name: str = nm_name
         self._buffer: list[dict] = []  # [{"date": ISO_str, "command": str}, ...]
 
     # ------------------------------------------------------------------
@@ -177,6 +181,22 @@ class NMCommandHistory:
         """
         return list(self._buffer)
 
+    @property
+    def nm_name(self) -> str:
+        """Variable name used for the NMManager instance (default ``"nm"``).
+
+        Used by :meth:`add_nm` to prefix commands with ``nm_name + suffix``.
+        Change this if your script uses a different variable name, e.g.
+        ``manager`` or ``my_nm``.
+        """
+        return self._nm_name
+
+    @nm_name.setter
+    def nm_name(self, value: str) -> None:
+        if not isinstance(value, str) or not value:
+            raise TypeError("nm_name must be a non-empty string")
+        self._nm_name = value
+
     # ------------------------------------------------------------------
     # Core
 
@@ -209,6 +229,18 @@ class NMCommandHistory:
             _nmh.history(command_str, path="NONE")
         elif not self._quiet:
             print(command_str)
+
+    def add_nm(self, suffix: str) -> None:
+        """Log a command prefixed with :attr:`nm_name` and a dot.
+
+        Equivalent to ``self.add(self.nm_name + "." + suffix)``.  Use this
+        for all NMManager attribute/method calls so the variable name is kept
+        in one place::
+
+            history.add_nm("tool_add('main')")     # → "nm.tool_add('main')"
+            history.add_nm("tool_select = 'main'") # → "nm.tool_select = 'main'"
+        """
+        self.add(self._nm_name + "." + suffix)
 
     def clear(self) -> None:
         """Remove all entries from the buffer."""
@@ -318,6 +350,11 @@ _nm_command_history: NMCommandHistory = NMCommandHistory(quiet=True, log_to_nm_h
 def add_command(command_str: str) -> None:
     """Log *command_str* to the global :class:`NMCommandHistory` instance."""
     _nm_command_history.add(command_str)
+
+
+def add_nm_command(suffix: str) -> None:
+    """Log a command prefixed with the global instance's :attr:`~NMCommandHistory.nm_name`."""
+    _nm_command_history.add_nm(suffix)
 
 
 def enable_command_history() -> None:

--- a/pyneuromatic/core/nm_manager.py
+++ b/pyneuromatic/core/nm_manager.py
@@ -96,15 +96,16 @@ class NMManager:
         quiet: bool = False,
         workspace: str | None = None,
         config_dir: str | Path | None = None,
+        nm_name: str = "nm",
     ) -> None:
         # Initialize centralized history logging
         self.__history = nmh.NMHistory(quiet=quiet)
         nmh.set_history(self.__history)
 
         # Initialize centralized command history
-        self.__command_history = nmch.NMCommandHistory(quiet=quiet)
+        self.__command_history = nmch.NMCommandHistory(quiet=quiet, nm_name=nm_name)
         nmch.set_command_history(self.__command_history)
-        nmch.add_command("nm = NMManager()")
+        nmch.add_command(nm_name + " = NMManager()")
 
         # Create project (root)
         self.__project = NMProject(parent=self, name="root")
@@ -200,9 +201,9 @@ class NMManager:
         if select:
             self.__toolselect = tname
         if select:
-            nmch.add_command("nm.tool_add(%r, select=True)" % tname)
+            nmch.add_nm_command("tool_add(%r, select=True)" % tname)
         else:
-            nmch.add_command("nm.tool_add(%r)" % tname)
+            nmch.add_nm_command("tool_add(%r)" % tname)
 
     def tool_remove(self, toolname: str) -> bool:
         """
@@ -223,7 +224,7 @@ class NMManager:
                     self.__toolselect = next(iter(self.__toolkit.keys()))
                 else:
                     self.__toolselect = None
-            nmch.add_command("nm.tool_remove(%r)" % tname)
+            nmch.add_nm_command("tool_remove(%r)" % tname)
             return True
         return False
 
@@ -239,7 +240,7 @@ class NMManager:
         tname = toolname.lower()
         if tname in self.__toolkit:
             self.__toolselect = tname
-            nmch.add_command("nm.tool_select = %r" % tname)
+            nmch.add_nm_command("tool_select = %r" % tname)
         else:
             raise KeyError("NM tool key '%s' does not exist" % tname)
 
@@ -344,7 +345,7 @@ class NMManager:
                 raise KeyError(f"'{tier}' is not a valid selection tier. "
                                f"Valid tiers: {HIERARCHY_SELECT_KEYS}")
 
-        nmch.add_command("nm.select_keys = %r" % (select,))
+        nmch.add_nm_command("select_keys = %r" % (select,))
 
         # Traverse hierarchy, setting values as we go so subsequent tiers
         # use the newly selected parent
@@ -592,7 +593,7 @@ class NMManager:
             result = self.run_keys(dataseries_priority=False)
             self._run_check_max_targets(result, max_targets)
             self.__run_config = dict(run)
-            nmch.add_command("nm.run_keys_set(%r)" % (run,))
+            nmch.add_nm_command("run_keys_set(%r)" % (run,))
             return result
 
         # Dataseries mode - requires dataseries, channel, epoch
@@ -616,7 +617,7 @@ class NMManager:
         result = self.run_keys(dataseries_priority=True)
         self._run_check_max_targets(result, max_targets)
         self.__run_config = dict(run)
-        nmch.add_command("nm.run_keys_set(%r)" % (run,))
+        nmch.add_nm_command("run_keys_set(%r)" % (run,))
         return result
 
     def _run_check_max_targets(
@@ -650,7 +651,7 @@ class NMManager:
                 ds.channels.run_target = RUN_SELECTED
                 ds.epochs.run_target = RUN_SELECTED
         self.__run_config = None
-        nmch.add_command("nm.run_reset_all()")
+        nmch.add_nm_command("run_reset_all()")
         return None
 
     def run_tool(
@@ -696,7 +697,7 @@ class NMManager:
         if not targets:
             print("nothing to run")
         result = tool.run_all(targets, run_keys=self.__run_config)
-        nmch.add_command("nm.run_tool(%r)" % tname)
+        nmch.add_nm_command("run_tool(%r)" % tname)
         return result
 
     # Workspace methods

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -3557,5 +3557,45 @@ class TestCommandHistory(unittest.TestCase):
         self.assertEqual(len(self._cmd_history), 2)
 
 
+# ===========================================================================
+# TestToolMainOpLogging
+# ===========================================================================
+
+class TestToolMainOpLogging(unittest.TestCase):
+    """Tests for command history logging of NMToolMain.op setter."""
+
+    def setUp(self):
+        from pyneuromatic.core.nm_command_history import (
+            NMCommandHistory, set_command_history, get_command_history,
+        )
+        self._ch = NMCommandHistory(quiet=True, log_to_nm_history=False)
+        set_command_history(self._ch)
+
+    def test_op_setter_logs_command(self):
+        tool = NMToolMain()
+        self._ch.clear()
+        tool.op = NMMainOpBaseline(x0=0.0, x1=10.0)
+        buf = self._ch.buffer
+        self.assertEqual(len(buf), 1)
+        self.assertIn("NMMainOpBaseline", buf[0]["command"])
+        self.assertIn("tool_main.op", buf[0]["command"])
+
+    def test_op_setter_includes_params(self):
+        tool = NMToolMain()
+        self._ch.clear()
+        tool.op = NMMainOpBaseline(x0=0.0, x1=10.0, mode='per_array')
+        cmd = self._ch.buffer[0]["command"]
+        self.assertIn("x0=0.0", cmd)
+        self.assertIn("x1=10.0", cmd)
+        self.assertIn("mode='per_array'", cmd)
+
+    def test_op_setter_string_name_logs_resolved_class(self):
+        tool = NMToolMain()
+        self._ch.clear()
+        tool.op = "average"
+        cmd = self._ch.buffer[0]["command"]
+        self.assertIn("NMMainOpAverage", cmd)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_core/test_nm_command_history.py
+++ b/tests/test_core/test_nm_command_history.py
@@ -10,6 +10,7 @@ import pytest
 from pyneuromatic.core.nm_command_history import (
     NMCommandHistory,
     add_command,
+    add_nm_command,
     disable_command_history,
     enable_command_history,
     get_command_history,
@@ -143,7 +144,7 @@ class TestNMCommandHistoryAdd:
 
 class TestNMCommandHistoryQuiet:
     def test_quiet_suppresses_print(self, capsys):
-        h = NMCommandHistory(quiet=True)
+        h = NMCommandHistory(quiet=True, log_to_nm_history=False)
         h.add("silent_cmd")
         captured = capsys.readouterr()
         assert "silent_cmd" not in captured.out
@@ -490,3 +491,48 @@ class TestLogToNMHistory:
             assert "no_direct_print" not in captured.out
         finally:
             nmh.history = original
+
+
+# ---------------------------------------------------------------------------
+# nm_name and add_nm
+# ---------------------------------------------------------------------------
+
+
+class TestNMName:
+    def test_default_nm_name(self):
+        h = _fresh()
+        assert h.nm_name == "nm"
+
+    def test_custom_nm_name_constructor(self):
+        h = NMCommandHistory(quiet=True, log_to_nm_history=False, nm_name="manager")
+        assert h.nm_name == "manager"
+
+    def test_nm_name_setter(self):
+        h = _fresh()
+        h.nm_name = "my_nm"
+        assert h.nm_name == "my_nm"
+
+    def test_nm_name_rejects_empty(self):
+        with pytest.raises(TypeError):
+            NMCommandHistory(quiet=True, log_to_nm_history=False, nm_name="")
+
+    def test_nm_name_rejects_non_string(self):
+        with pytest.raises(TypeError):
+            NMCommandHistory(quiet=True, log_to_nm_history=False, nm_name=42)
+
+    def test_add_nm_prepends_nm_name_and_dot(self):
+        h = _fresh()
+        h.add_nm("tool_add('main')")
+        assert h.buffer[0]["command"] == "nm.tool_add('main')"
+
+    def test_add_nm_custom_name(self):
+        h = NMCommandHistory(quiet=True, log_to_nm_history=False, nm_name="manager")
+        h.add_nm("run_tool('main')")
+        assert h.buffer[0]["command"] == "manager.run_tool('main')"
+
+    def test_add_nm_command_module_level(self):
+        set_command_history(NMCommandHistory(quiet=True, log_to_nm_history=False))
+        add_nm_command("run_reset_all()")
+        assert get_command_history().buffer[0]["command"] == "nm.run_reset_all()"
+
+

--- a/tests/test_core/test_nm_manager.py
+++ b/tests/test_core/test_nm_manager.py
@@ -613,6 +613,16 @@ class TestNMManagerCommandHistory(NMManagerTestBase):
         self.assertGreaterEqual(len(buf), 1)
         self.assertEqual(buf[0]["command"], "nm = NMManager()")
 
+    def test_nm_name_default(self):
+        fresh = NMManager(quiet=True)
+        self.assertEqual(fresh.command_history.nm_name, "nm")
+
+    def test_nm_name_custom(self):
+        fresh = NMManager(quiet=True, nm_name="manager")
+        buf = fresh.command_history.buffer
+        self.assertEqual(fresh.command_history.nm_name, "manager")
+        self.assertEqual(buf[0]["command"], "manager = NMManager()")
+
     def test_tool_add_logs_command(self):
         self.nm.command_history.clear()
         self.nm.tool_add("main")


### PR DESCRIPTION
## Summary

- `NMCommandHistory` gains `nm_name: str = "nm"` — the variable name
  prepended to all logged commands. Change to `"manager"` if your script
  uses a different variable name.
- `add_nm(suffix)` / `add_nm_command(suffix)` prepend `nm_name + "."` 
  automatically — call sites pass `"tool_add('main')"` not `"nm.tool_add('main')"`
- `NMManager.__init__` accepts `nm_name` and passes it through
- `NMToolMain.op` setter now logs `nm.tool_main.op = NMMainOpBaseline(...)`
  using `_op_params_str()` already on every op subclass

A complete reproducible session now looks like:
```python
nm = NMManager()
nm.tool_add('main')
nm.run_keys_set({'folder': 'folder0', 'dataseries': 'Record', 'channel': 'all', 'epoch': 'Set1'})
nm.tool_main.op = NMMainOpBaseline(x0=0.0, x1=10.0, mode='per_array', ignore_nans=True)
nm.run_tool('main')

Closes #216