### PR TITLE
feat: command history for stats tool (issue #224)

### DIFF
--- a/pyneuromatic/analysis/nm_stat_func.py
+++ b/pyneuromatic/analysis/nm_stat_func.py
@@ -168,6 +168,17 @@ class NMStatFunc:
             r["Δs"] = ds
         return ds
 
+    def _params_str(self) -> str:
+        """Return constructor args as a string for command history logging.
+
+        The name is always the first positional arg.  Subclasses append
+        keyword args for any non-default parameters, e.g.::
+
+            NMStatFuncBasic('mean')          → "'mean'"
+            NMStatFuncMaxMin('max', n_mean=3) → "'max', n_mean=3"
+        """
+        return "%r" % self._name
+
     def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
                 bsln_result):
         """Execute the stat computation, appending results via run_stat.
@@ -258,6 +269,12 @@ class NMStatFuncMaxMin(NMStatFunc):
             d["n_mean"] = self._n_mean
         return d
 
+    def _params_str(self) -> str:
+        s = "%r" % self._name
+        if self._n_mean is not None:
+            s += ", n_mean=%r" % self._n_mean
+        return s
+
     def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
                 bsln_result):
         """Run the max/min stat; warn if n_mean <= 1 for mean@ variants."""
@@ -304,6 +321,9 @@ class NMStatFuncLevel(NMStatFunc):
     def to_dict(self) -> dict:
         return {"name": self._name, "ylevel": self._ylevel}
 
+    def _params_str(self) -> str:
+        return "%r, ylevel=%r" % (self._name, self._ylevel)
+
     def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
                 bsln_result):
         """Find the level crossing at ylevel and optionally add baseline delta."""
@@ -345,6 +365,9 @@ class NMStatFuncLevelNstd(NMStatFunc):
 
     def to_dict(self) -> dict:
         return {"name": self._name, "n_std": self._n_std}
+
+    def _params_str(self) -> str:
+        return "%r, n_std=%r" % (self._name, self._n_std)
 
     @property
     def needs_baseline(self) -> bool:
@@ -423,6 +446,9 @@ class NMStatFuncRiseTime(NMStatFunc):
 
     def to_dict(self) -> dict:
         return {"name": self._name, "p0": self._p0, "p1": self._p1}
+
+    def _params_str(self) -> str:
+        return "%r, p0=%r, p1=%r" % (self._name, self._p0, self._p1)
 
     @property
     def needs_baseline(self) -> bool:
@@ -545,6 +571,9 @@ class NMStatFuncFallTime(NMStatFunc):
     def to_dict(self) -> dict:
         return {"name": self._name, "p0": self._p0, "p1": self._p1}
 
+    def _params_str(self) -> str:
+        return "%r, p0=%r, p1=%r" % (self._name, self._p0, self._p1)
+
     @property
     def needs_baseline(self) -> bool:
         return True
@@ -644,6 +673,9 @@ class NMStatFuncDecayTime(NMStatFunc):
     def to_dict(self) -> dict:
         return {"name": self._name, "p0": self._p0}
 
+    def _params_str(self) -> str:
+        return "%r, p0=%r" % (self._name, self._p0)
+
     @property
     def needs_baseline(self) -> bool:
         return True
@@ -741,6 +773,9 @@ class NMStatFuncFWHM(NMStatFunc):
 
     def to_dict(self) -> dict:
         return {"name": self._name, "p0": self._p0, "p1": self._p1}
+
+    def _params_str(self) -> str:
+        return "%r, p0=%r, p1=%r" % (self._name, self._p0, self._p1)
 
     @property
     def needs_baseline(self) -> bool:

--- a/pyneuromatic/analysis/nm_stat_win.py
+++ b/pyneuromatic/analysis/nm_stat_win.py
@@ -43,6 +43,7 @@ from pyneuromatic.analysis.nm_stat_func import (
     FUNC_NAMES_BSLN,
     _stat_func_from_dict,
 )
+from pyneuromatic.core.nm_command_history import add_nm_command
 from pyneuromatic.analysis.nm_stat_utilities import stat
 from pyneuromatic.core.nm_data import NMData
 import pyneuromatic.core.nm_history as nmh
@@ -82,12 +83,14 @@ class NMStatWin:
         self,
         name: str = "NMStatWin0",
         win: dict[str, object] | None = None,
+        nm_path: str = "stats.windows",
     ) -> None:
         if not isinstance(name, str):
             raise TypeError(nmu.type_error_str(name, "name", "string"))
         if not name or not nmu.name_ok(name):
             raise ValueError("name: %s" % name)
         self._name = name
+        self._nm_path = nm_path
 
         self.__on = True
         self.__func: NMStatFunc | None = None
@@ -191,7 +194,9 @@ class NMStatWin:
 
     @on.setter
     def on(self, on: bool) -> None:
-        return self._on_set(on)
+        self._on_set(on)
+        add_nm_command("%s[%r].on = %r" % (self._nm_path, self._name, self.__on))
+        return None
 
     def _on_set(self, on: bool, quiet: bool = nmc.QUIET) -> None:
         """Set the on flag; raises TypeError if not bool."""
@@ -210,6 +215,12 @@ class NMStatWin:
     @func.setter
     def func(self, func: dict | str) -> None:
         self._func_set(func)
+        if self.__func is not None:
+            params = self.__func._params_str()
+            add_nm_command(
+                "%s[%r].func = %s(%s)"
+                % (self._nm_path, self._name, type(self.__func).__name__, params)
+            )
         return None
 
     def _func_set(
@@ -248,7 +259,9 @@ class NMStatWin:
 
     @x0.setter
     def x0(self, x0: float) -> None:
-        return self._x_set("x0", x0)
+        self._x_set("x0", x0)
+        add_nm_command("%s[%r].x0 = %r" % (self._nm_path, self._name, self.__x0))
+        return None
 
     def _x_set(
         self,
@@ -289,7 +302,9 @@ class NMStatWin:
 
     @x1.setter
     def x1(self, x1: float) -> None:
-        return self._x_set("x1", x1)
+        self._x_set("x1", x1)
+        add_nm_command("%s[%r].x1 = %r" % (self._nm_path, self._name, self.__x1))
+        return None
 
     @property
     def transform(self) -> list[NMTransform] | None:
@@ -339,7 +354,9 @@ class NMStatWin:
 
     @bsln_on.setter
     def bsln_on(self, on: bool) -> None:
-        return self._bsln_on_set(on)
+        self._bsln_on_set(on)
+        add_nm_command("%s[%r].bsln_on = %r" % (self._nm_path, self._name, self.__bsln_on))
+        return None
 
     def _bsln_on_set(self, on: bool, quiet: bool = nmc.QUIET) -> None:
         """Set the bsln_on flag; raises TypeError if not bool."""
@@ -358,6 +375,10 @@ class NMStatWin:
     @bsln_func.setter
     def bsln_func(self, func: dict | str) -> None:
         self._bsln_func_set(func)
+        if self.__bsln_func:
+            add_nm_command(
+                "%s[%r].bsln_func = %r" % (self._nm_path, self._name, self.__bsln_func)
+            )
         return None
 
     def _bsln_func_set(
@@ -418,7 +439,9 @@ class NMStatWin:
 
     @bsln_x0.setter
     def bsln_x0(self, x0: float) -> None:
-        return self._x_set("bsln_x0", x0)
+        self._x_set("bsln_x0", x0)
+        add_nm_command("%s[%r].bsln_x0 = %r" % (self._nm_path, self._name, self.__bsln_x0))
+        return None
 
     @property
     def bsln_x1(self) -> float:
@@ -427,7 +450,9 @@ class NMStatWin:
 
     @bsln_x1.setter
     def bsln_x1(self, x1: float) -> None:
-        return self._x_set("bsln_x1", x1)
+        self._x_set("bsln_x1", x1)
+        add_nm_command("%s[%r].bsln_x1 = %r" % (self._nm_path, self._name, self.__bsln_x1))
+        return None
 
     @property
     def results(self) -> list[dict]:
@@ -552,8 +577,10 @@ class NMStatWinContainer:
     def __init__(
         self,
         name_prefix: str = "w",
+        nm_path: str = "stats.windows",
     ) -> None:
         self._prefix = name_prefix
+        self._nm_path = nm_path
         self._windows: dict[str, NMStatWin] = {}
         self._count = 0
         self.selected_name: str | None = None
@@ -562,11 +589,12 @@ class NMStatWinContainer:
         """Create, register, and return a new NMStatWin with an auto-name."""
         name = "%s%d" % (self._prefix, self._count)
         self._count += 1
-        w = NMStatWin(name=name)
+        w = NMStatWin(name=name, nm_path=self._nm_path)
         self._windows[name] = w
         if self.selected_name is None:
             self.selected_name = name
         nmh.history("new NMStatWin=%s" % name, quiet=quiet)
+        add_nm_command("%s.new(%r)" % (self._nm_path, name))
         return w
 
     def __iter__(self):

--- a/pyneuromatic/analysis/nm_tool.py
+++ b/pyneuromatic/analysis/nm_tool.py
@@ -51,12 +51,18 @@ class NMTool:
                 return True
     """
 
-    def __init__(self) -> None:
+    def __init__(self, name: str = "") -> None:
+        self._name = name
         self._select: dict[str, NMObject | None] = {
             tier: None for tier in HIERARCHY_SELECT_KEYS
         }
         self._run_meta: dict = {}
         self._config: NMToolConfig | None = None
+
+    @property
+    def name(self) -> str:
+        """Tool name used in command history (e.g. ``'stats'``, ``'tool_main'``)."""
+        return self._name
 
     @property
     def config(self) -> NMToolConfig | None:

--- a/pyneuromatic/analysis/nm_tool_main.py
+++ b/pyneuromatic/analysis/nm_tool_main.py
@@ -45,7 +45,7 @@ class NMToolMain(NMTool):
     """
 
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(name="tool_main")
         self._op: NMMainOp = NMMainOpAverage()
 
     # ------------------------------------------------------------------
@@ -80,7 +80,7 @@ class NMToolMain(NMTool):
         params = self._op._op_params_str()
         if params is None:
             params = ""
-        add_nm_command("tool_main.op = %s(%s)" % (type(self._op).__name__, params))
+        add_nm_command("%s.op = %s(%s)" % (self._name, type(self._op).__name__, params))
 
     # ------------------------------------------------------------------
     # Lifecycle hooks

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -33,6 +33,7 @@ from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_dataseries import NMDataSeries
 from pyneuromatic.core.nm_epoch import NMEpoch
 from pyneuromatic.core.nm_folder import NMFolder
+import pyneuromatic.core.nm_command_history as nmch
 import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_configurations as nmc
 import pyneuromatic.core.nm_math as nm_math
@@ -85,10 +86,10 @@ class NMToolStats(NMTool):
     """
 
     def __init__(self) -> None:
-        super().__init__()
+        super().__init__(name="stats")
         self._config = NMToolStatsConfig()
 
-        self.__win_container = NMStatWinContainer()
+        self.__win_container = NMStatWinContainer(nm_path="%s.windows" % self._name)
         self.__win_container.new()
 
         self.__xclip = True
@@ -147,6 +148,7 @@ class NMToolStats(NMTool):
             e = nmu.type_error_str(xclip, "xclip", "boolean")
             raise TypeError(e)
         nmh.history("set xclip=%s" % xclip, quiet=quiet)
+        nmch.add_nm_command("%s.xclip = %r" % (self._name, self.__xclip))
 
     @property
     def ignore_nans(self) -> bool:
@@ -175,6 +177,7 @@ class NMToolStats(NMTool):
             e = nmu.type_error_str(ignore_nans, "ignore_nans", "boolean")
             raise TypeError(e)
         nmh.history("set ignore_nans=%s" % ignore_nans, quiet=quiet)
+        nmch.add_nm_command("%s.ignore_nans = %r" % (self._name, self.__ignore_nans))
 
     @property
     def results_to_history(self) -> bool:
@@ -200,6 +203,7 @@ class NMToolStats(NMTool):
             raise TypeError(nmu.type_error_str(value, "results_to_history", "boolean"))
         self.__results_to_history = value
         nmh.history("set results_to_history=%s" % value, quiet=quiet)
+        nmch.add_nm_command("%s.results_to_history = %r" % (self._name, self.__results_to_history))
 
     @property
     def results_to_cache(self) -> bool:
@@ -226,6 +230,7 @@ class NMToolStats(NMTool):
             raise TypeError(nmu.type_error_str(value, "results_to_cache", "boolean"))
         self.__results_to_cache = value
         nmh.history("set results_to_cache=%s" % value, quiet=quiet)
+        nmch.add_nm_command("%s.results_to_cache = %r" % (self._name, self.__results_to_cache))
 
     @property
     def results_to_numpy(self) -> bool:
@@ -252,6 +257,7 @@ class NMToolStats(NMTool):
             raise TypeError(nmu.type_error_str(value, "results_to_numpy", "boolean"))
         self.__results_to_numpy = value
         nmh.history("set results_to_numpy=%s" % value, quiet=quiet)
+        nmch.add_nm_command("%s.results_to_numpy = %r" % (self._name, self.__results_to_numpy))
 
     # override, no super
     def run_init(self) -> bool:

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -1263,5 +1263,210 @@ class TestNMToolStatsConfig(unittest.TestCase):
         self.assertTrue(t.config.xclip)
 
 
+class TestNMToolStatsCommandHistory(unittest.TestCase):
+    """Tests for command history logging of NMToolStats, NMStatWin, NMStatWinContainer."""
+
+    def setUp(self):
+        from pyneuromatic.core.nm_command_history import (
+            NMCommandHistory, set_command_history,
+        )
+        self._ch = NMCommandHistory(enabled=True, quiet=True, log_to_nm_history=False)
+        set_command_history(self._ch)
+        self.tool = nms.NMToolStats()
+        self.w0 = self.tool.windows['w0']
+
+    # ------------------------------------------------------------------
+    # NMStatWin.func setter
+
+    def test_func_setter_logs_basic(self):
+        self._ch.clear()
+        self.w0.func = 'mean'
+        self.assertEqual(len(self._ch.buffer), 1)
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.windows['w0'].func", cmd)
+        self.assertIn("NMStatFuncBasic", cmd)
+        self.assertIn("'mean'", cmd)
+
+    def test_func_setter_logs_maxmin_no_n_mean(self):
+        self._ch.clear()
+        self.w0.func = 'max'
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("NMStatFuncMaxMin", cmd)
+        self.assertIn("'max'", cmd)
+        self.assertNotIn("n_mean", cmd)
+
+    def test_func_setter_logs_maxmin_with_n_mean(self):
+        self._ch.clear()
+        self.w0.func = {'name': 'mean@max', 'n_mean': 3}
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("NMStatFuncMaxMin", cmd)
+        self.assertIn("'mean@max'", cmd)
+        self.assertIn("n_mean=3", cmd)
+
+    def test_func_setter_logs_level(self):
+        self._ch.clear()
+        self.w0.func = {'name': 'level', 'ylevel': 10.0}
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("NMStatFuncLevel", cmd)
+        self.assertIn("ylevel=10.0", cmd)
+
+    def test_func_setter_logs_levelnstd(self):
+        self._ch.clear()
+        self.w0.func = {'name': 'level', 'n_std': 2.0}
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("NMStatFuncLevelNstd", cmd)
+        self.assertIn("n_std=2.0", cmd)
+
+    def test_func_setter_logs_risetime(self):
+        self._ch.clear()
+        self.w0.func = {'name': 'risetime+', 'p0': 10.0, 'p1': 90.0}
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("NMStatFuncRiseTime", cmd)
+        self.assertIn("p0=10.0", cmd)
+        self.assertIn("p1=90.0", cmd)
+
+    def test_func_setter_logs_decaytime_default_p0(self):
+        self._ch.clear()
+        self.w0.func = 'decaytime+'
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("NMStatFuncDecayTime", cmd)
+        self.assertIn("p0=", cmd)
+
+    def test_func_setter_logs_decaytime_custom_p0(self):
+        self._ch.clear()
+        self.w0.func = {'name': 'decaytime+', 'p0': 50.0}
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("NMStatFuncDecayTime", cmd)
+        self.assertIn("p0=50.0", cmd)
+
+    def test_func_setter_logs_fwhm_default_p0_p1(self):
+        self._ch.clear()
+        self.w0.func = 'fwhm+'
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("NMStatFuncFWHM", cmd)
+        self.assertIn("p0=", cmd)
+        self.assertIn("p1=", cmd)
+
+    def test_func_setter_logs_fwhm_custom_p0_p1(self):
+        self._ch.clear()
+        self.w0.func = {'name': 'fwhm+', 'p0': 30.0, 'p1': 70.0}
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("NMStatFuncFWHM", cmd)
+        self.assertIn("p0=30.0", cmd)
+        self.assertIn("p1=70.0", cmd)
+
+    def test_func_setter_none_does_not_log(self):
+        self._ch.clear()
+        self.w0.func = None
+        self.assertEqual(len(self._ch.buffer), 0)
+
+    # ------------------------------------------------------------------
+    # NMStatWin scalar setters
+
+    def test_x0_setter_logs(self):
+        self._ch.clear()
+        self.w0.x0 = 100.0
+        self.assertEqual(len(self._ch.buffer), 1)
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.windows['w0'].x0", cmd)
+        self.assertIn("100.0", cmd)
+
+    def test_x1_setter_logs(self):
+        self._ch.clear()
+        self.w0.x1 = 200.0
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.windows['w0'].x1", cmd)
+        self.assertIn("200.0", cmd)
+
+    def test_on_setter_logs_false(self):
+        self._ch.clear()
+        self.w0.on = False
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.windows['w0'].on", cmd)
+        self.assertIn("False", cmd)
+
+    def test_bsln_on_setter_logs_true(self):
+        self._ch.clear()
+        self.w0.bsln_on = True
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.windows['w0'].bsln_on", cmd)
+        self.assertIn("True", cmd)
+
+    def test_bsln_x0_setter_logs(self):
+        self._ch.clear()
+        self.w0.bsln_x0 = -10.0
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.windows['w0'].bsln_x0", cmd)
+        self.assertIn("-10.0", cmd)
+
+    def test_bsln_x1_setter_logs(self):
+        self._ch.clear()
+        self.w0.bsln_x1 = 0.0
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.windows['w0'].bsln_x1", cmd)
+        self.assertIn("0.0", cmd)
+
+    def test_bsln_func_setter_logs(self):
+        self._ch.clear()
+        self.w0.bsln_func = 'mean'
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.windows['w0'].bsln_func", cmd)
+        self.assertIn("'mean'", cmd)
+
+    def test_bsln_func_setter_none_does_not_log(self):
+        self._ch.clear()
+        self.w0.bsln_func = None
+        self.assertEqual(len(self._ch.buffer), 0)
+
+    # ------------------------------------------------------------------
+    # NMStatWinContainer.new()
+
+    def test_windows_new_logs(self):
+        self._ch.clear()
+        self.tool.windows.new()
+        self.assertEqual(len(self._ch.buffer), 1)
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.windows.new(", cmd)
+        self.assertIn("'w1'", cmd)
+
+    # ------------------------------------------------------------------
+    # NMToolStats tool-level flag setters
+
+    def test_xclip_setter_logs(self):
+        self._ch.clear()
+        self.tool.xclip = True
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.xclip", cmd)
+        self.assertIn("True", cmd)
+
+    def test_ignore_nans_setter_logs(self):
+        self._ch.clear()
+        self.tool.ignore_nans = True
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.ignore_nans", cmd)
+        self.assertIn("True", cmd)
+
+    def test_results_to_history_setter_logs(self):
+        self._ch.clear()
+        self.tool.results_to_history = True
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.results_to_history", cmd)
+        self.assertIn("True", cmd)
+
+    def test_results_to_cache_setter_logs_false(self):
+        self._ch.clear()
+        self.tool.results_to_cache = False
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.results_to_cache", cmd)
+        self.assertIn("False", cmd)
+
+    def test_results_to_numpy_setter_logs(self):
+        self._ch.clear()
+        self.tool.results_to_numpy = True
+        cmd = self._ch.buffer[0]['command']
+        self.assertIn("stats.results_to_numpy", cmd)
+        self.assertIn("True", cmd)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- Add `_params_str()` to all `NMStatFunc` subclasses (parallel to
  `NMMainOp._op_params_str()`), returning constructor args as a string
  for command history logging
- Log all user-facing configuration changes on `NMToolStats` (xclip,
  ignore_nans, results_to_*) and `NMStatWin` (func, x0, x1, bsln_*)
  via `add_nm_command()`; `NMStatWinContainer.new()` also logs window
  creation
- Add `name` parameter to `NMTool.__init__` so subclasses use
  `self._name` in command strings rather than hardcoded literals;
  `NMToolMain` uses `"tool_main"`, `NMToolStats` uses `"stats"`
- `NMStatWinContainer` / `NMStatWin` accept an `nm_path` parameter
  (e.g. `"stats.windows"`) so the container property name is defined
  once in `NMToolStats.__init__` and not duplicated inside
  `nm_stat_win.py`

## Example output

```python
nm = NMManager(command_history=True)
nm.stats.windows['w0'].func = 'max'
nm.stats.windows['w0'].x0 = 100.0
nm.stats.xclip = True
nm.command_history.print_all()
# nm.stats.windows.new('w0')
# nm.stats.windows['w0'].func = NMStatFuncMaxMin('max')
# nm.stats.windows['w0'].x0 = 100.0
# nm.stats.xclip = True

Closes #224 