### PR TITLE
feat: NMFolder.new_dataseries() — create synthetic NMDataSeries (issue #226)

### DIFF
--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -296,121 +296,250 @@ class NMFolder(NMObject):
                 prefixes.add(prefix)
         return sorted(prefixes)
 
-    def make_dataseries(
+    def new_dataseries(
+        self,
+        prefix: str,
+        n_channels: int = 1,
+        n_epochs: int = 1,
+        n_points: int = 100,
+        dx: float = 1.0,
+        x_start: float = 0.0,
+        x_label: str = "",
+        x_units: str = "",
+        y_label: str = "",
+        y_units: str = "",
+        fill=0.0,
+        ch_start: int = 0,
+        ep_start: int = 0,
+        select: bool = False,
+        quiet: bool = nmc.QUIET,
+    ) -> NMDataSeries | None:
+        """Create or extend an NMDataSeries with synthetic NumPy arrays.
+
+        Generates ``n_channels * n_epochs`` NMData objects named
+        ``{prefix}{chan}{epoch}`` (e.g. RecordA0, RecordA1, RecordB0 ...),
+        fills each array according to ``fill``, then calls
+        :meth:`assemble_dataseries` which creates the dataseries if it does not
+        yet exist, or extends it with any new channels and epochs if it does.
+
+        Use ``ch_start`` and ``ep_start`` to append to an existing dataseries::
+
+            folder.new_dataseries("Record", n_channels=2, n_epochs=5)
+            # Later, append 3 more epochs to both channels:
+            folder.new_dataseries("Record", n_channels=2, n_epochs=3, ep_start=5)
+
+        Args:
+            prefix: Wave prefix (e.g. ``"Record"``). Must satisfy
+                ``nmu.name_ok()``.
+            n_channels: Number of channels to generate.
+            n_epochs: Number of epochs to generate.
+            n_points: Number of samples per array (0 creates empty arrays).
+            dx: X-axis sample interval.
+            x_start: X-axis start value (default ``0.0``).
+            x_label: X-axis label (e.g. ``"Time"``).
+            x_units: X-axis units (e.g. ``"ms"``).
+            y_label: Y-axis label (e.g. ``"Voltage"``).
+            y_units: Y-axis units (e.g. ``"mV"``).
+            fill: How to populate each array.  Two forms are accepted:
+
+                - **Scalar** (``int``, ``float``, or ``numpy.nan``) — passed
+                  to ``numpy.full(n_points, fill)``.  Examples::
+
+                      fill=0.0        # zeros (default)
+                      fill=numpy.nan  # NaN
+                      fill=1.0        # ones
+                      fill=-9999.0    # sentinel value
+
+                - **Callable** ``f(n_points) -> numpy.ndarray`` — called once
+                  per array.  Any NumPy factory or custom function works::
+
+                      fill=numpy.zeros
+                      fill=numpy.ones
+                      fill=numpy.random.random          # uniform [0, 1)
+                      fill=lambda n: numpy.random.normal(0, 2.0, n)
+
+            ch_start: Index of the first channel to generate (0 = A, 1 = B,
+                ...). Default ``0``.
+            ep_start: Index of the first epoch to generate. Default ``0``.
+            select: Whether to select the dataseries after creation/update.
+            quiet: If True, suppress history output.
+
+        Returns:
+            The NMDataSeries (new or updated), or None on failure.
+
+        Raises:
+            TypeError: If ``prefix`` is not a string, numeric args have wrong
+                type, or ``fill`` is neither a scalar nor a callable.
+            ValueError: If ``prefix`` fails name validation,
+                ``n_channels`` / ``n_epochs`` > 0 violated,
+                ``n_points`` / ``ch_start`` / ``ep_start`` < 0 violated, or
+                any generated data name already exists.
+        """
+        import numpy as np
+
+        if not isinstance(prefix, str):
+            raise TypeError(nmu.type_error_str(prefix, "prefix", "string"))
+        if not prefix or not nmu.name_ok(prefix):
+            raise ValueError("prefix: %r" % prefix)
+        for arg_name, arg_val, min_val in (
+            ("n_channels", n_channels, 1),
+            ("n_epochs",   n_epochs,   1),
+            ("n_points",   n_points,   0),
+            ("ch_start",   ch_start,   0),
+            ("ep_start",   ep_start,   0),
+        ):
+            if isinstance(arg_val, bool) or not isinstance(arg_val, int):
+                raise TypeError(nmu.type_error_str(arg_val, arg_name, "int"))
+            if arg_val < min_val:
+                raise ValueError(
+                    "%s must be >= %d, got %d" % (arg_name, min_val, arg_val)
+                )
+        if not callable(fill) and not isinstance(fill, (int, float)):
+            raise TypeError(
+                "fill must be a numeric scalar or callable, got %r" % type(fill).__name__
+            )
+
+        # Pre-flight: check data names don't conflict before touching any state
+        for ch_i in range(ch_start, ch_start + n_channels):
+            ch_char = nmu.channel_char(ch_i)
+            for ep in range(ep_start, ep_start + n_epochs):
+                name = "%s%s%d" % (prefix, ch_char, ep)
+                if name in self.data:
+                    raise ValueError("data %r already exists" % name)
+
+        xscale = {
+            "start": x_start, "delta": dx, "label": x_label, "units": x_units,
+        }
+        yscale = {"label": y_label, "units": y_units}
+
+        for ch_i in range(ch_start, ch_start + n_channels):
+            ch_char = nmu.channel_char(ch_i)
+            for ep in range(ep_start, ep_start + n_epochs):
+                name = "%s%s%d" % (prefix, ch_char, ep)
+                arr = fill(n_points) if callable(fill) else np.full(n_points, fill)
+                self.data.new(
+                    name=name, nparray=arr, xscale=xscale, yscale=yscale,
+                    quiet=True,
+                )
+
+        return self.assemble_dataseries(prefix, select=select, quiet=quiet)
+
+    def assemble_dataseries(
         self,
         prefix: str,
         select: bool = False,
         quiet: bool = nmc.QUIET,
     ) -> NMDataSeries | None:
-        """Create a dataseries from data matching a prefix pattern.
+        """Create or update a dataseries from data in the folder matching a prefix.
 
         Scans the data container for names matching the NeuroMatic pattern
-        {prefix}{channel}{epoch} and creates a dataseries with appropriate
-        channels and epochs, linking the NMData objects.
+        ``{prefix}{channel}{epoch}`` and creates or extends the dataseries:
 
-        The prefix can be partial - for example, "Rec" will match "RecordA0".
-        The full detected prefix (e.g., "Record") becomes the dataseries name.
+        - If the dataseries does not yet exist, creates it with the matched
+          channels and epochs.
+        - If it already exists, adds any channels and epochs not already
+          present; data already linked to existing channels/epochs is skipped.
+
+        The prefix can be partial — ``"Rec"`` will match ``"RecordA0"``.
+        The full detected prefix (e.g. ``"Record"``) becomes the dataseries name.
 
         Args:
             prefix: Prefix to match (case-insensitive). Can be partial.
-            select: Whether to select the new dataseries.
+            select: Whether to select the dataseries after creation/update.
             quiet: If True, suppress history output.
 
         Returns:
-            The created NMDataSeries, or None if no matching data found.
+            The NMDataSeries (new or updated), or None if no matching data found.
 
         Example:
-            >>> folder.make_dataseries("Record")
-            # Creates dataseries "Record" with channels A, B and epochs E0, E1
-            # if folder contains RecordA0, RecordA1, RecordB0, RecordB1
+            >>> folder.assemble_dataseries("Record")
+            # Creates or updates dataseries "Record" from RecordA0, RecordB0 …
         """
         from pyneuromatic.core.nm_data import NMData
-        from pyneuromatic.core.nm_dataseries import NMDataSeries
 
         if not prefix or not isinstance(prefix, str):
             return None
 
-        # Find all data matching the prefix pattern
+        # Find ALL data in the folder matching the prefix pattern.
         # Key: (channel_char, epoch_num), Value: NMData
         matches: dict[tuple[str, int], NMData] = {}
         actual_prefix: str | None = None
 
         for name, data in self.data.items():
-            # Check if name starts with user's prefix (case-insensitive)
             if not name.lower().startswith(prefix.lower()):
                 continue
-
-            # Parse the name from the end to find channel and epoch
             parsed = nmu.parse_data_name(name)
             if parsed is None:
                 continue
-
             detected_prefix, channel_char, epoch_num = parsed
-
-            # Verify detected prefix starts with user's prefix
             if not detected_prefix.lower().startswith(prefix.lower()):
                 continue
-
-            # Use first detected prefix as the actual prefix for dataseries name
             if actual_prefix is None:
                 actual_prefix = detected_prefix
             elif actual_prefix != detected_prefix:
-                # Different prefix detected, skip this data
                 continue
-
             matches[(channel_char, epoch_num)] = data
 
         if not matches or actual_prefix is None:
             return None
 
-        # Check if dataseries already exists
-        if actual_prefix in self.dataseries:
-            return None  # Could also raise an error or return existing
+        # Get or create the dataseries
+        is_new = actual_prefix not in self.dataseries
+        if is_new:
+            ds = self.dataseries.new(name=actual_prefix, select=select, quiet=True)
+            if ds is None:
+                return None
+            channel_map: dict[str, object] = {}
+            epoch_map: dict[int, object] = {}
+        else:
+            ds = self.dataseries.get(actual_prefix)
+            if select:
+                self.dataseries.selected_name = actual_prefix
+            # Pre-populate maps from existing channels and epochs so we can
+            # detect what is new vs already present
+            channel_map = {
+                ch_name: ds.channels.get(ch_name) for ch_name in ds.channels
+            }
+            epoch_map = {}
+            for ep_name in ds.epochs:
+                try:
+                    epoch_map[int(ep_name[1:])] = ds.epochs.get(ep_name)
+                except (ValueError, IndexError):
+                    pass
 
-        # Create the dataseries, channels, and epochs with quiet=True
-        # to suppress individual history entries; log a summary below
-        ds = self.dataseries.new(name=actual_prefix, select=select, quiet=True)
-        if ds is None:
-            return None
-
-        # Determine unique channels and epochs
+        # Determine which channels/epochs appear in the matches
         channel_chars = sorted(set(ch for ch, _ in matches.keys()))
         epoch_nums = sorted(set(ep for _, ep in matches.keys()))
 
-        # Create channels (NMChannelContainer auto-names A, B, C...)
-        # We need to create channels in order, so if data has A, B, C, we create 3
-        channel_map: dict[str, object] = {}  # channel_char -> NMChannel
+        # Create only channels/epochs not already in the dataseries
         for ch_char in channel_chars:
-            channel = ds.channels.new(quiet=True)
-            if channel is not None:
-                channel_map[ch_char] = channel
+            if ch_char not in channel_map:
+                channel = ds.channels.new(quiet=True)
+                if channel is not None:
+                    channel_map[ch_char] = channel
 
-        # Create epochs (NMEpochContainer auto-names E0, E1, E2...)
-        epoch_map: dict[int, object] = {}  # epoch_num -> NMEpoch
         for ep_num in epoch_nums:
-            epoch = ds.epochs.new(quiet=True)
-            if epoch is not None:
-                epoch_map[ep_num] = epoch
+            if ep_num not in epoch_map:
+                epoch = ds.epochs.new(quiet=True)
+                if epoch is not None:
+                    epoch_map[ep_num] = epoch
 
-        # Link data to channels and epochs
+        # Link data to channels and epochs; skip if already linked
         for (ch_char, ep_num), data in matches.items():
             channel = channel_map.get(ch_char)
             epoch = epoch_map.get(ep_num)
-
-            if channel is not None:
+            if channel is not None and data not in channel.data:
                 channel.data.append(data)
-            if epoch is not None:
+            if epoch is not None and data not in epoch.data:
                 epoch.data.append(data)
 
         # Log summary
         ch_str = ", ".join(channel_chars)
-        if epoch_nums:
-            ep_str = "E%d..E%d" % (epoch_nums[0], epoch_nums[-1])
-        else:
-            ep_str = ""
+        ep_str = ("E%d..E%d" % (epoch_nums[0], epoch_nums[-1])) if epoch_nums else ""
+        action = "new" if is_new else "updated"
         nmh.history(
-            "new dataseries '%s': channels %s; epochs %s"
-            % (actual_prefix, ch_str, ep_str),
+            "%s dataseries '%s': channels %s; epochs %s"
+            % (action, actual_prefix, ch_str, ep_str),
             path=self.path_str,
             quiet=quiet,
         )

--- a/pyneuromatic/io/abf.py
+++ b/pyneuromatic/io/abf.py
@@ -123,6 +123,6 @@ def read_abf(
     if make_dataseries:
         prefixes = folder.detect_prefixes()
         for p in prefixes:
-            folder.make_dataseries(p)
+            folder.assemble_dataseries(p)
 
     return folder

--- a/pyneuromatic/io/axograph.py
+++ b/pyneuromatic/io/axograph.py
@@ -132,7 +132,7 @@ def read_axograph(
     if make_dataseries:
         prefixes = folder.detect_prefixes()
         for p in prefixes:
-            folder.make_dataseries(p)
+            folder.assemble_dataseries(p)
 
     return folder
 

--- a/pyneuromatic/io/pxp.py
+++ b/pyneuromatic/io/pxp.py
@@ -173,7 +173,7 @@ def read_pxp(
     if make_dataseries:
         prefixes = folder.detect_prefixes()
         for p in prefixes:
-            folder.make_dataseries(p)
+            folder.assemble_dataseries(p)
 
     return folder
 

--- a/tests/test_core/test_nm_folder.py
+++ b/tests/test_core/test_nm_folder.py
@@ -233,7 +233,7 @@ class TestNMFolderContainer(unittest.TestCase):
 # Tests for detect_prefixes method
 # =============================================================================
 
-class TestDetectPrefixes(NMFolderTestBase):
+class TestNMFolderDetectPrefixes(NMFolderTestBase):
     """Tests for NMFolder.detect_prefixes() method."""
 
     def test_empty_folder(self):
@@ -261,11 +261,11 @@ class TestDetectPrefixes(NMFolderTestBase):
 
 
 # =============================================================================
-# Tests for make_dataseries method
+# Tests for assemble_dataseries method
 # =============================================================================
 
-class TestMakeDataSeries(NMFolderTestBase):
-    """Tests for NMFolder.make_dataseries() method."""
+class TestNMFolderAssembleDataSeries(NMFolderTestBase):
+    """Tests for NMFolder.assemble_dataseries() method."""
 
     def setUp(self):
         super().setUp()
@@ -276,25 +276,25 @@ class TestMakeDataSeries(NMFolderTestBase):
                 self.folder.data.new(name)
 
     def test_creates_dataseries(self):
-        ds = self.folder.make_dataseries("Record")
+        ds = self.folder.assemble_dataseries("Record")
         self.assertIsNotNone(ds)
         self.assertEqual(ds.name, "Record")
 
     def test_creates_channels(self):
-        ds = self.folder.make_dataseries("Record")
+        ds = self.folder.assemble_dataseries("Record")
         self.assertEqual(len(ds.channels), 2)
         self.assertIn("A", ds.channels)
         self.assertIn("B", ds.channels)
 
     def test_creates_epochs(self):
-        ds = self.folder.make_dataseries("Record")
+        ds = self.folder.assemble_dataseries("Record")
         self.assertEqual(len(ds.epochs), 3)
         self.assertIn("E0", ds.epochs)
         self.assertIn("E1", ds.epochs)
         self.assertIn("E2", ds.epochs)
 
     def test_links_data_to_channels(self):
-        ds = self.folder.make_dataseries("Record")
+        ds = self.folder.assemble_dataseries("Record")
         chan_a = ds.channels.get("A")
         self.assertEqual(len(chan_a.data), 3)
         data_names = [d.name for d in chan_a.data]
@@ -303,7 +303,7 @@ class TestMakeDataSeries(NMFolderTestBase):
         self.assertIn("RecordA2", data_names)
 
     def test_links_data_to_epochs(self):
-        ds = self.folder.make_dataseries("Record")
+        ds = self.folder.assemble_dataseries("Record")
         epoch_0 = ds.epochs.get("E0")
         self.assertEqual(len(epoch_0.data), 2)
         data_names = [d.name for d in epoch_0.data]
@@ -312,43 +312,43 @@ class TestMakeDataSeries(NMFolderTestBase):
 
     def test_partial_prefix_match(self):
         # User enters "Rec" but full prefix is "Record"
-        ds = self.folder.make_dataseries("Rec")
+        ds = self.folder.assemble_dataseries("Rec")
         self.assertIsNotNone(ds)
         self.assertEqual(ds.name, "Record")
 
     def test_case_insensitive_prefix(self):
-        ds = self.folder.make_dataseries("record")
+        ds = self.folder.assemble_dataseries("record")
         self.assertIsNotNone(ds)
         self.assertEqual(ds.name, "Record")
 
     def test_no_match_returns_none(self):
-        ds = self.folder.make_dataseries("NoMatch")
+        ds = self.folder.assemble_dataseries("NoMatch")
         self.assertIsNone(ds)
 
     def test_empty_prefix_returns_none(self):
-        ds = self.folder.make_dataseries("")
+        ds = self.folder.assemble_dataseries("")
         self.assertIsNone(ds)
 
     def test_none_prefix_returns_none(self):
-        ds = self.folder.make_dataseries(None)
+        ds = self.folder.assemble_dataseries(None)
         self.assertIsNone(ds)
 
     def test_select_parameter(self):
-        self.folder.make_dataseries("Record", select=True)
+        self.folder.assemble_dataseries("Record", select=True)
         self.assertEqual(self.folder.dataseries.selected_name, "Record")
 
     def test_adds_to_dataseries_container(self):
-        self.folder.make_dataseries("Record")
+        self.folder.assemble_dataseries("Record")
         self.assertIn("Record", self.folder.dataseries)
 
-    def test_does_not_duplicate_dataseries(self):
-        ds1 = self.folder.make_dataseries("Record")
-        ds2 = self.folder.make_dataseries("Record")
+    def test_returns_existing_dataseries_on_second_call(self):
+        ds1 = self.folder.assemble_dataseries("Record")
+        ds2 = self.folder.assemble_dataseries("Record")
         self.assertIsNotNone(ds1)
-        self.assertIsNone(ds2)  # Already exists
+        self.assertIs(ds1, ds2)  # Same object, not duplicated
 
     def test_get_data_works_after_make(self):
-        ds = self.folder.make_dataseries("Record")
+        ds = self.folder.assemble_dataseries("Record")
         ds.channels.selected_name = "A"
         ds.epochs.selected_name = "E1"
         data = ds.get_data()
@@ -356,8 +356,8 @@ class TestMakeDataSeries(NMFolderTestBase):
         self.assertEqual(data.name, "RecordA1")
 
 
-class TestMakeDataSeriesMultiplePrefixes(NMFolderTestBase):
-    """Tests for make_dataseries with multiple prefixes in folder."""
+class TestNMFolderAssembleDataSeriesMultiplePrefixes(NMFolderTestBase):
+    """Tests for assemble_dataseries with multiple prefixes in folder."""
 
     def setUp(self):
         super().setUp()
@@ -368,15 +368,15 @@ class TestMakeDataSeriesMultiplePrefixes(NMFolderTestBase):
                 self.folder.data.new(f"avg{ch}{ep}")
 
     def test_creates_correct_dataseries(self):
-        ds_record = self.folder.make_dataseries("Record")
-        ds_avg = self.folder.make_dataseries("avg")
+        ds_record = self.folder.assemble_dataseries("Record")
+        ds_avg = self.folder.assemble_dataseries("avg")
 
         self.assertEqual(ds_record.name, "Record")
         self.assertEqual(ds_avg.name, "avg")
 
     def test_dataseries_have_correct_data(self):
-        ds_record = self.folder.make_dataseries("Record")
-        ds_avg = self.folder.make_dataseries("avg")
+        ds_record = self.folder.assemble_dataseries("Record")
+        ds_avg = self.folder.assemble_dataseries("avg")
 
         # Check Record dataseries
         chan_a = ds_record.channels.get("A")
@@ -389,6 +389,222 @@ class TestMakeDataSeriesMultiplePrefixes(NMFolderTestBase):
         data_names = [d.name for d in chan_a.data]
         self.assertIn("avgA0", data_names)
         self.assertNotIn("RecordA0", data_names)
+
+    def test_record_and_avg_record_prefixes(self):
+        """Avg_Record prefix must not cross-contaminate Record dataseries.
+
+        NMMainOpAverage produces output named Avg_{prefix}, e.g. Avg_RecordA0.
+        When the folder contains both RecordA0 and Avg_RecordA0, assembling
+        "Record" should include only Record* data and assembling "Avg_Record"
+        should include only Avg_Record* data.
+
+        setUp already creates RecordA0/A1/B0/B1; we add Avg_Record* here.
+        """
+        # setUp created RecordA0, RecordA1, RecordB0, RecordB1
+        # Add the averaged output that NMMainOpAverage would produce
+        for ch in ["A", "B"]:
+            for ep in range(2):
+                self.folder.data.new("Avg_Record%s%d" % (ch, ep))
+
+        ds_rec = self.folder.assemble_dataseries("Record")
+        ds_avg = self.folder.assemble_dataseries("Avg_Record")
+
+        self.assertEqual(ds_rec.name, "Record")
+        self.assertEqual(ds_avg.name, "Avg_Record")
+
+        # Record dataseries contains only Record* data
+        rec_chan_a = ds_rec.channels.get("A")
+        rec_names = [d.name for d in rec_chan_a.data]
+        self.assertIn("RecordA0", rec_names)
+        self.assertNotIn("Avg_RecordA0", rec_names)
+        self.assertEqual(len(rec_chan_a.data), 2)  # A0, A1
+
+        # Avg_Record dataseries contains only Avg_Record* data
+        avg_chan_a = ds_avg.channels.get("A")
+        avg_names = [d.name for d in avg_chan_a.data]
+        self.assertIn("Avg_RecordA0", avg_names)
+        self.assertNotIn("RecordA0", avg_names)
+        self.assertEqual(len(avg_chan_a.data), 2)  # Avg_RecordA0, Avg_RecordA1
+
+
+# =============================================================================
+# Tests for new_dataseries method
+# =============================================================================
+
+class TestNMFolderNewDataseries(NMFolderTestBase):
+    """Tests for NMFolder.new_dataseries()."""
+
+    def test_returns_dataseries(self):
+        ds = self.folder.new_dataseries("Record")
+        self.assertIsNotNone(ds)
+        self.assertEqual(ds.name, "Record")
+
+    def test_default_single_channel_single_epoch(self):
+        ds = self.folder.new_dataseries("Record")
+        self.assertEqual(len(ds.channels), 1)
+        self.assertEqual(len(ds.epochs), 1)
+
+    def test_n_channels_and_n_epochs(self):
+        ds = self.folder.new_dataseries("Record", n_channels=3, n_epochs=5)
+        self.assertEqual(len(ds.channels), 3)
+        self.assertEqual(len(ds.epochs), 5)
+        self.assertIn("A", ds.channels)
+        self.assertIn("B", ds.channels)
+        self.assertIn("C", ds.channels)
+
+    def test_data_objects_created_in_folder(self):
+        self.folder.new_dataseries("Record", n_channels=2, n_epochs=3)
+        for ch in ["A", "B"]:
+            for ep in range(3):
+                self.assertIn("Record%s%d" % (ch, ep), self.folder.data)
+
+    def test_fill_default_zeros(self):
+        import numpy as np
+        ds = self.folder.new_dataseries("Record", n_points=50)
+        data = self.folder.data.get("RecordA0")
+        self.assertTrue(np.all(data.nparray == 0.0))
+        self.assertEqual(len(data.nparray), 50)
+
+    def test_fill_scalar_zero(self):
+        import numpy as np
+        ds = self.folder.new_dataseries("Record", n_points=50, fill=0.0)
+        data = self.folder.data.get("RecordA0")
+        self.assertTrue(np.all(data.nparray == 0.0))
+
+    def test_fill_scalar_nan(self):
+        import numpy as np
+        ds = self.folder.new_dataseries("Record", n_points=50, fill=np.nan)
+        data = self.folder.data.get("RecordA0")
+        self.assertTrue(np.all(np.isnan(data.nparray)))
+
+    def test_fill_scalar_sentinel(self):
+        import numpy as np
+        ds = self.folder.new_dataseries("Record", n_points=10, fill=-9999.0)
+        data = self.folder.data.get("RecordA0")
+        self.assertTrue(np.all(data.nparray == -9999.0))
+
+    def test_fill_callable_numpy_ones(self):
+        import numpy as np
+        ds = self.folder.new_dataseries("Record", n_points=50, fill=np.ones)
+        data = self.folder.data.get("RecordA0")
+        self.assertTrue(np.all(data.nparray == 1.0))
+
+    def test_fill_callable_numpy_random(self):
+        import numpy as np
+        ds = self.folder.new_dataseries("Record", n_points=50, fill=np.random.random)
+        data = self.folder.data.get("RecordA0")
+        self.assertEqual(len(data.nparray), 50)
+        self.assertFalse(np.all(data.nparray == 0.0))
+
+    def test_fill_callable_lambda_noise(self):
+        import numpy as np
+        noise_std = 2.0
+        ds = self.folder.new_dataseries(
+            "Record", n_points=500,
+            fill=lambda n: np.random.normal(0, noise_std, n),
+        )
+        data = self.folder.data.get("RecordA0")
+        self.assertEqual(len(data.nparray), 500)
+        # SE of sample std ≈ sigma/sqrt(2*n) ≈ 0.063 for n=500;
+        # delta=0.3 covers > 99.9 % of random draws without a fixed seed.
+        self.assertAlmostEqual(np.std(data.nparray), noise_std, delta=0.3)
+
+    def test_xscale(self):
+        self.folder.new_dataseries(
+            "Record", n_points=100, dx=0.1, x_start=5.0,
+            x_label="Time", x_units="ms",
+        )
+        data = self.folder.data.get("RecordA0")
+        self.assertAlmostEqual(data.xscale.delta, 0.1)
+        self.assertAlmostEqual(data.xscale.start, 5.0)
+        self.assertEqual(data.xscale.label, "Time")
+        self.assertEqual(data.xscale.units, "ms")
+
+    def test_yscale(self):
+        self.folder.new_dataseries("Record", y_label="Voltage", y_units="mV")
+        data = self.folder.data.get("RecordA0")
+        self.assertEqual(data.yscale.label, "Voltage")
+        self.assertEqual(data.yscale.units, "mV")
+
+    def test_select_parameter(self):
+        self.folder.new_dataseries("Record", select=True)
+        self.assertEqual(self.folder.dataseries.selected_name, "Record")
+
+    def test_invalid_prefix_type(self):
+        with self.assertRaises(TypeError):
+            self.folder.new_dataseries(123)
+
+    def test_invalid_prefix_value(self):
+        with self.assertRaises(ValueError):
+            self.folder.new_dataseries("")
+        with self.assertRaises(ValueError):
+            self.folder.new_dataseries("bad name!")
+
+    def test_invalid_n_channels_type(self):
+        with self.assertRaises(TypeError):
+            self.folder.new_dataseries("Record", n_channels=1.0)
+
+    def test_invalid_n_channels_zero(self):
+        with self.assertRaises(ValueError):
+            self.folder.new_dataseries("Record", n_channels=0)
+
+    def test_invalid_n_epochs_zero(self):
+        with self.assertRaises(ValueError):
+            self.folder.new_dataseries("Record", n_epochs=0)
+
+    def test_invalid_n_points_negative(self):
+        with self.assertRaises(ValueError):
+            self.folder.new_dataseries("Record", n_points=-1)
+
+    def test_n_points_zero_creates_empty_arrays(self):
+        ds = self.folder.new_dataseries("Record", n_points=0)
+        self.assertIsNotNone(ds)
+        data = self.folder.data.get("RecordA0")
+        self.assertIsNotNone(data)
+        self.assertEqual(len(data.nparray), 0)
+
+    def test_invalid_fill_type(self):
+        with self.assertRaises(TypeError):
+            self.folder.new_dataseries("Record", fill="zeros")
+
+    def test_append_epochs(self):
+        self.folder.new_dataseries("Record", n_channels=2, n_epochs=3)
+        ds = self.folder.new_dataseries("Record", n_channels=2, n_epochs=2, ep_start=3)
+        self.assertIsNotNone(ds)
+        self.assertEqual(len(ds.epochs), 5)
+        self.assertEqual(len(ds.channels), 2)
+        chan_a = ds.channels.get("A")
+        self.assertEqual(len(chan_a.data), 5)
+
+    def test_append_channel(self):
+        self.folder.new_dataseries("Record", n_channels=1, n_epochs=3)
+        ds = self.folder.new_dataseries("Record", n_channels=1, n_epochs=3, ch_start=1)
+        self.assertIsNotNone(ds)
+        self.assertEqual(len(ds.channels), 2)
+        self.assertIn("A", ds.channels)
+        self.assertIn("B", ds.channels)
+
+    def test_append_does_not_duplicate_existing_data_links(self):
+        self.folder.new_dataseries("Record", n_channels=2, n_epochs=3)
+        self.folder.new_dataseries("Record", n_channels=2, n_epochs=2, ep_start=3)
+        ds = self.folder.dataseries.get("Record")
+        chan_a = ds.channels.get("A")
+        # RecordA0..RecordA4 — each should appear exactly once
+        names = [d.name for d in chan_a.data]
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_raises_if_data_name_collision(self):
+        self.folder.data.new("RecordA0")
+        with self.assertRaises(ValueError):
+            self.folder.new_dataseries("Record")
+
+    def test_no_partial_state_on_data_collision(self):
+        # RecordA1 exists but RecordA0 does not — collision on second iteration
+        self.folder.data.new("RecordA1")
+        with self.assertRaises(ValueError):
+            self.folder.new_dataseries("Record", n_epochs=3)
+        # RecordA0 should NOT have been created
+        self.assertNotIn("RecordA0", self.folder.data)
 
 
 class TestNMFolderToolResults(NMFolderTestBase):


### PR DESCRIPTION
## Summary

- Rename `NMFolder.make_dataseries()` → `assemble_dataseries()` to
  clarify that it assembles a dataseries from data already in the folder;
  updated all IO readers (axograph, pxp, abf) accordingly
- `assemble_dataseries()` now updates an existing dataseries rather than
  returning `None` — new channels and epochs are added, existing data links
  are preserved (no duplicates)
- Add `NMFolder.new_dataseries()` — creates synthetic NMData arrays and
  assembles them into an NMDataSeries in one call; supports:
  - `fill`: scalar (e.g. `0.0`, `np.nan`, sentinel) or callable
    (e.g. `np.ones`, `lambda n: np.random.normal(0, 2, n)`)
  - `n_points=0` for empty arrays (useful for later appending)
  - `ch_start` / `ep_start` to append channels or epochs to an existing
    dataseries
  - Pre-flight name conflict checks — no partial state on failure

## Test plan

- [x] `TestNMFolderAssembleDataSeries` — assemble from existing data,
  partial prefix, case-insensitive, select, idempotent second call
- [x] `TestNMFolderAssembleDataSeriesMultiplePrefixes` — independent
  dataseries from `Record` and `Avg_Record` in the same folder
- [x] `TestNMFolderNewDataseries` — fill modes (scalar, `np.nan`,
  sentinel, `np.ones`, `np.random.random`, lambda noise), xscale/yscale,
  empty arrays, append epochs/channels, duplicate-link guard, all error
  cases
- [x] All existing tests pass (`pytest tests/`)

Closes #226 