### PR TITLE
feat(core): add remove_dataseries/channel/epoch methods to NMFolder

### DIFF
--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -275,7 +275,7 @@ class NMFolder(NMObject):
 
     # DataSeries creation from data names
 
-    def detect_prefixes(self) -> list[str]:
+    def detect_data_prefixes(self) -> list[str]:
         """Detect unique data prefixes in this folder's data container.
 
         Scans all data names and parses them to find NeuroMatic naming patterns
@@ -545,6 +545,222 @@ class NMFolder(NMObject):
         )
 
         return ds
+
+    # ------------------------------------------------------------------
+    # Private helpers for dataseries remove_* methods
+    # ------------------------------------------------------------------
+
+    def _get_dataseries(self, prefix: str):
+        """Return the NMDataSeries for *prefix*, or raise ValueError."""
+        ds = self.dataseries.get(prefix)
+        if ds is None:
+            raise ValueError("dataseries %r not found" % prefix)
+        return ds
+
+    def _resolve_channel_names(self, ds, channel) -> list[str]:
+        """Resolve *channel* (str | int | list | range) to a list of channel chars.
+
+        Raises TypeError for unsupported types, ValueError for chars not in *ds*.
+        """
+        if isinstance(channel, range):
+            items = list(channel)
+        elif isinstance(channel, list):
+            items = channel
+        else:
+            items = [channel]
+
+        names: list[str] = []
+        for item in items:
+            if isinstance(item, bool):
+                raise TypeError(
+                    "channel must be str or int, got bool"
+                )
+            if isinstance(item, int):
+                ch_name = nmu.channel_char(item)
+                if not ch_name:
+                    raise ValueError("invalid channel number: %d" % item)
+            elif isinstance(item, str):
+                ch_name = item.upper()
+            else:
+                raise TypeError(
+                    "channel must be str or int, got %s" % type(item).__name__
+                )
+            if ds.channels.get(ch_name) is None:
+                raise ValueError(
+                    "channel %r not found in dataseries %r" % (ch_name, ds.name)
+                )
+            names.append(ch_name)
+        return names
+
+    def _resolve_epoch_names(self, ds, epoch) -> list[str]:
+        """Resolve *epoch* (str | int | list | range) to a list of epoch names.
+
+        Epoch names are stored as 'E0', 'E1', etc.
+        Raises TypeError for unsupported types, ValueError for names not in *ds*.
+        """
+        if isinstance(epoch, range):
+            items = list(epoch)
+        elif isinstance(epoch, list):
+            items = epoch
+        else:
+            items = [epoch]
+
+        names: list[str] = []
+        for item in items:
+            if isinstance(item, bool):
+                raise TypeError(
+                    "epoch must be str or int, got bool"
+                )
+            if isinstance(item, int):
+                ep_name = "E%d" % item
+            elif isinstance(item, str):
+                ep_name = item
+            else:
+                raise TypeError(
+                    "epoch must be str or int, got %s" % type(item).__name__
+                )
+            if ds.epochs.get(ep_name) is None:
+                raise ValueError(
+                    "epoch %r not found in dataseries %r" % (ep_name, ds.name)
+                )
+            names.append(ep_name)
+        return names
+
+    # ------------------------------------------------------------------
+    # Public dataseries remove methods
+    # ------------------------------------------------------------------
+
+    def remove_dataseries(
+        self,
+        prefix: str,
+        delete_data: bool = False,
+        quiet: bool = nmc.QUIET,
+    ) -> None:
+        """Remove a dataseries from this folder.
+
+        Args:
+            prefix: Name of the dataseries to remove.
+            delete_data: If True, also delete all NMData objects that belong
+                to this dataseries from the folder's data container.
+            quiet: Suppress history messages.
+
+        Raises:
+            ValueError: If no dataseries with *prefix* exists.
+        """
+        ds = self._get_dataseries(prefix)
+
+        if delete_data:
+            # Collect unique data names across all channels
+            data_names: set[str] = set()
+            for ch_name in ds.channels:
+                ch = ds.channels.get(ch_name)
+                for d in list(ch.data):
+                    data_names.add(d.name)
+            for name in data_names:
+                self.data.pop(name, default=None, quiet=True)
+
+        self.dataseries.pop(prefix, quiet=True)
+        msg = "removed dataseries '%s'" % prefix
+        if delete_data:
+            msg += " (and %d data objects)" % len(data_names)
+        nmh.history(msg, path=self.path_str, quiet=quiet)
+
+    def remove_dataseries_channel(
+        self,
+        prefix: str,
+        channel,
+        delete_data: bool = False,
+        quiet: bool = nmc.QUIET,
+    ) -> None:
+        """Remove one or more channels from a dataseries.
+
+        Args:
+            prefix: Name of the dataseries.
+            channel: Channel(s) to remove — str ('A'), int (0), list, or range.
+            delete_data: If True, delete the associated NMData from the folder.
+            quiet: Suppress history messages.
+
+        Raises:
+            ValueError: If dataseries or channel not found.
+            TypeError: If *channel* has an unsupported type.
+        """
+        ds = self._get_dataseries(prefix)
+        ch_names = self._resolve_channel_names(ds, channel)
+        n_deleted = 0
+
+        for ch_name in ch_names:
+            ch = ds.channels.get(ch_name)
+            data_list = list(ch.data)
+
+            if delete_data:
+                for d in data_list:
+                    self.data.pop(d.name, default=None, quiet=True)
+                n_deleted += len(data_list)
+
+            # Remove data refs from all epochs
+            for ep_name in ds.epochs:
+                ep = ds.epochs.get(ep_name)
+                for d in data_list:
+                    if d in ep.data:
+                        ep.data.remove(d)
+
+            ds.channels.pop(ch_name, quiet=True)
+
+        ch_str = ", ".join(ch_names)
+        msg = "removed channel(s) [%s] from dataseries '%s'" % (ch_str, prefix)
+        if delete_data:
+            msg += " (and %d data objects)" % n_deleted
+        nmh.history(msg, path=self.path_str, quiet=quiet)
+
+    def remove_dataseries_epoch(
+        self,
+        prefix: str,
+        epoch,
+        delete_data: bool = False,
+        quiet: bool = nmc.QUIET,
+    ) -> None:
+        """Remove one or more epochs from a dataseries.
+
+        Args:
+            prefix: Name of the dataseries.
+            epoch: Epoch(s) to remove — str ('E0'), int (0), list, or range.
+            delete_data: If True, delete the associated NMData from the folder.
+            quiet: Suppress history messages.
+
+        Raises:
+            ValueError: If dataseries or epoch not found.
+            TypeError: If *epoch* has an unsupported type.
+        """
+        ds = self._get_dataseries(prefix)
+        ep_names = self._resolve_epoch_names(ds, epoch)
+        n_deleted = 0
+
+        for ep_name in ep_names:
+            ep = ds.epochs.get(ep_name)
+            data_list = list(ep.data)
+
+            if delete_data:
+                for d in data_list:
+                    self.data.pop(d.name, default=None, quiet=True)
+                n_deleted += len(data_list)
+
+            # Remove data refs from all channels
+            for ch_name in ds.channels:
+                ch = ds.channels.get(ch_name)
+                for d in data_list:
+                    if d in ch.data:
+                        ch.data.remove(d)
+
+            ds.epochs.pop(ep_name, quiet=True)
+
+        if len(ep_names) == 1:
+            ep_str = ep_names[0]
+        else:
+            ep_str = "%s..%s (%d epochs)" % (ep_names[0], ep_names[-1], len(ep_names))
+        msg = "removed epoch(s) [%s] from dataseries '%s'" % (ep_str, prefix)
+        if delete_data:
+            msg += " (and %d data objects)" % n_deleted
+        nmh.history(msg, path=self.path_str, quiet=quiet)
 
 
 class NMFolderContainer(NMObjectContainer):

--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -464,7 +464,7 @@ class NMObjectContainer(NMObject, MutableMapping):
             return default  # type: ignore
         if isinstance(self.selected_name, str):
             if self.selected_name.lower() == actual_key.lower():
-                self.selected_name = None
+                self._selected_name_set(None, quiet=quiet)
         self.sets.remove_from_all(actual_key)
         o = self.__map.pop(actual_key)
         o._container = None

--- a/pyneuromatic/io/abf.py
+++ b/pyneuromatic/io/abf.py
@@ -121,7 +121,7 @@ def read_abf(
 
     # Optionally create dataseries
     if make_dataseries:
-        prefixes = folder.detect_prefixes()
+        prefixes = folder.detect_data_prefixes()
         for p in prefixes:
             folder.assemble_dataseries(p)
 

--- a/pyneuromatic/io/axograph.py
+++ b/pyneuromatic/io/axograph.py
@@ -130,7 +130,7 @@ def read_axograph(
 
     # Optionally create dataseries
     if make_dataseries:
-        prefixes = folder.detect_prefixes()
+        prefixes = folder.detect_data_prefixes()
         for p in prefixes:
             folder.assemble_dataseries(p)
 

--- a/pyneuromatic/io/pxp.py
+++ b/pyneuromatic/io/pxp.py
@@ -171,7 +171,7 @@ def read_pxp(
 
     # Optionally create dataseries
     if make_dataseries:
-        prefixes = folder.detect_prefixes()
+        prefixes = folder.detect_data_prefixes()
         for p in prefixes:
             folder.assemble_dataseries(p)
 

--- a/tests/test_core/test_nm_folder.py
+++ b/tests/test_core/test_nm_folder.py
@@ -230,33 +230,33 @@ class TestNMFolderContainer(unittest.TestCase):
 
 
 # =============================================================================
-# Tests for detect_prefixes method
+# Tests for detect_data_prefixes method
 # =============================================================================
 
-class TestNMFolderDetectPrefixes(NMFolderTestBase):
-    """Tests for NMFolder.detect_prefixes() method."""
+class TestNMFolderDetectDataPrefixes(NMFolderTestBase):
+    """Tests for NMFolder.detect_data_prefixes() method."""
 
     def test_empty_folder(self):
-        result = self.folder.detect_prefixes()
+        result = self.folder.detect_data_prefixes()
         self.assertEqual(result, [])
 
     def test_single_prefix(self):
         for name in ["RecordA0", "RecordA1", "RecordB0", "RecordB1"]:
             self.folder.data.new(name)
-        result = self.folder.detect_prefixes()
+        result = self.folder.detect_data_prefixes()
         self.assertEqual(result, ["Record"])
 
     def test_multiple_prefixes(self):
         for name in ["RecordA0", "RecordB0", "avgA0", "avgB0"]:
             self.folder.data.new(name)
-        result = self.folder.detect_prefixes()
+        result = self.folder.detect_data_prefixes()
         self.assertEqual(result, ["Record", "avg"])
 
     def test_ignores_non_matching_names(self):
         self.folder.data.new("RecordA0")
         self.folder.data.new("SomeOtherData")  # no channel/epoch pattern
         self.folder.data.new("avgB1")
-        result = self.folder.detect_prefixes()
+        result = self.folder.detect_data_prefixes()
         self.assertEqual(result, ["Record", "avg"])
 
 
@@ -605,6 +605,179 @@ class TestNMFolderNewDataseries(NMFolderTestBase):
             self.folder.new_dataseries("Record", n_epochs=3)
         # RecordA0 should NOT have been created
         self.assertNotIn("RecordA0", self.folder.data)
+
+
+class TestNMFolderRemoveDataseries(NMFolderTestBase):
+    """Tests for NMFolder.remove_dataseries()."""
+
+    def setUp(self):
+        super().setUp()
+        self.folder.new_dataseries(
+            "Record", n_channels=2, n_epochs=3, quiet=True
+        )
+
+    def test_removes_dataseries(self):
+        self.folder.remove_dataseries("Record", quiet=True)
+        self.assertIsNone(self.folder.dataseries.get("Record"))
+
+    def test_data_not_deleted_by_default(self):
+        self.folder.remove_dataseries("Record", quiet=True)
+        self.assertIn("RecordA0", self.folder.data)
+
+    def test_delete_data_true_removes_data(self):
+        self.folder.remove_dataseries("Record", delete_data=True, quiet=True)
+        self.assertNotIn("RecordA0", self.folder.data)
+        self.assertNotIn("RecordB2", self.folder.data)
+
+    def test_raises_for_unknown_prefix(self):
+        with self.assertRaises(ValueError):
+            self.folder.remove_dataseries("NoSuch", quiet=True)
+
+    def test_folder_data_unaffected_after_removal_without_delete(self):
+        # 2 channels × 3 epochs = 6 NMData objects
+        self.folder.remove_dataseries("Record", quiet=True)
+        self.assertEqual(len(self.folder.data), 6)
+
+
+class TestNMFolderRemoveDataseriesChannel(NMFolderTestBase):
+    """Tests for NMFolder.remove_dataseries_channel()."""
+
+    def setUp(self):
+        super().setUp()
+        self.folder.new_dataseries(
+            "Record", n_channels=3, n_epochs=2, quiet=True
+        )
+        self.ds = self.folder.dataseries.get("Record")
+
+    def test_remove_dataseries_channel_by_char(self):
+        self.folder.remove_dataseries_channel("Record", "B", quiet=True)
+        self.assertIsNone(self.ds.channels.get("B"))
+
+    def test_remove_dataseries_channel_by_int(self):
+        self.folder.remove_dataseries_channel("Record", 0, quiet=True)
+        self.assertIsNone(self.ds.channels.get("A"))
+
+    def test_remove_dataseries_channel_list(self):
+        self.folder.remove_dataseries_channel("Record", ["A", "C"], quiet=True)
+        self.assertIsNone(self.ds.channels.get("A"))
+        self.assertIsNone(self.ds.channels.get("C"))
+        self.assertIsNotNone(self.ds.channels.get("B"))
+
+    def test_remove_dataseries_channel_range(self):
+        self.folder.remove_dataseries_channel("Record", range(2), quiet=True)
+        self.assertIsNone(self.ds.channels.get("A"))
+        self.assertIsNone(self.ds.channels.get("B"))
+        self.assertIsNotNone(self.ds.channels.get("C"))
+
+    def test_data_not_deleted_by_default(self):
+        self.folder.remove_dataseries_channel("Record", "A", quiet=True)
+        self.assertIn("RecordA0", self.folder.data)
+        self.assertIn("RecordA1", self.folder.data)
+
+    def test_delete_data_true_removes_data(self):
+        self.folder.remove_dataseries_channel("Record", "A", delete_data=True, quiet=True)
+        self.assertNotIn("RecordA0", self.folder.data)
+        self.assertNotIn("RecordA1", self.folder.data)
+        self.assertIn("RecordB0", self.folder.data)
+
+    def test_removed_channel_data_no_longer_in_epochs(self):
+        ch_a_data = list(self.ds.channels.get("A").data)
+        self.folder.remove_dataseries_channel("Record", "A", quiet=True)
+        for ep_name in self.ds.epochs:
+            ep = self.ds.epochs.get(ep_name)
+            for d in ch_a_data:
+                self.assertNotIn(d, ep.data)
+
+    def test_raises_for_unknown_channel(self):
+        with self.assertRaises(ValueError):
+            self.folder.remove_dataseries_channel("Record", "Z", quiet=True)
+
+    def test_raises_for_unknown_prefix(self):
+        with self.assertRaises(ValueError):
+            self.folder.remove_dataseries_channel("NoSuch", "A", quiet=True)
+
+    def test_raises_for_bool_channel(self):
+        with self.assertRaises(TypeError):
+            self.folder.remove_dataseries_channel("Record", True, quiet=True)
+
+
+class TestNMFolderRemoveDataseriesEpoch(NMFolderTestBase):
+    """Tests for NMFolder.remove_dataseries_epoch()."""
+
+    def setUp(self):
+        super().setUp()
+        self.folder.new_dataseries(
+            "Record", n_channels=2, n_epochs=4, quiet=True
+        )
+        self.ds = self.folder.dataseries.get("Record")
+
+    def test_remove_dataseries_epoch_by_int(self):
+        self.folder.remove_dataseries_epoch("Record", 0, quiet=True)
+        self.assertIsNone(self.ds.epochs.get("E0"))
+
+    def test_remove_dataseries_epoch_by_str(self):
+        self.folder.remove_dataseries_epoch("Record", "E1", quiet=True)
+        self.assertIsNone(self.ds.epochs.get("E1"))
+
+    def test_remove_dataseries_epoch_list(self):
+        self.folder.remove_dataseries_epoch("Record", [0, 2], quiet=True)
+        self.assertIsNone(self.ds.epochs.get("E0"))
+        self.assertIsNone(self.ds.epochs.get("E2"))
+        self.assertIsNotNone(self.ds.epochs.get("E1"))
+        self.assertIsNotNone(self.ds.epochs.get("E3"))
+
+    def test_remove_dataseries_epoch_range(self):
+        self.folder.remove_dataseries_epoch("Record", range(1, 3), quiet=True)
+        self.assertIsNone(self.ds.epochs.get("E1"))
+        self.assertIsNone(self.ds.epochs.get("E2"))
+        self.assertIsNotNone(self.ds.epochs.get("E0"))
+        self.assertIsNotNone(self.ds.epochs.get("E3"))
+
+    def test_data_not_deleted_by_default(self):
+        self.folder.remove_dataseries_epoch("Record", 0, quiet=True)
+        self.assertIn("RecordA0", self.folder.data)
+
+    def test_delete_data_true_removes_data(self):
+        self.folder.remove_dataseries_epoch("Record", 0, delete_data=True, quiet=True)
+        self.assertNotIn("RecordA0", self.folder.data)
+        self.assertNotIn("RecordB0", self.folder.data)
+        self.assertIn("RecordA1", self.folder.data)
+
+    def test_removed_epoch_data_no_longer_in_channels(self):
+        ep0 = self.ds.epochs.get("E0")
+        ep0_data = list(ep0.data)
+        self.folder.remove_dataseries_epoch("Record", 0, quiet=True)
+        for ch_name in self.ds.channels:
+            ch = self.ds.channels.get(ch_name)
+            for d in ep0_data:
+                self.assertNotIn(d, ch.data)
+
+    def test_raises_for_unknown_epoch_int(self):
+        with self.assertRaises(ValueError):
+            self.folder.remove_dataseries_epoch("Record", 99, quiet=True)
+
+    def test_raises_for_unknown_epoch_str(self):
+        with self.assertRaises(ValueError):
+            self.folder.remove_dataseries_epoch("Record", "E99", quiet=True)
+
+    def test_raises_for_unknown_prefix(self):
+        with self.assertRaises(ValueError):
+            self.folder.remove_dataseries_epoch("NoSuch", 0, quiet=True)
+
+    def test_raises_for_bool_epoch(self):
+        with self.assertRaises(TypeError):
+            self.folder.remove_dataseries_epoch("Record", True, quiet=True)
+
+    def test_remove_range_200_epochs(self):
+        # Simulate use-case: 200 epochs, remove the last 100
+        self.folder.new_dataseries(
+            "Big", n_channels=1, n_epochs=200, quiet=True
+        )
+        ds = self.folder.dataseries.get("Big")
+        self.folder.remove_dataseries_epoch("Big", range(100, 200), quiet=True)
+        self.assertEqual(len(list(ds.epochs)), 100)
+        self.assertIsNotNone(ds.epochs.get("E99"))
+        self.assertIsNone(ds.epochs.get("E100"))
 
 
 class TestNMFolderToolResults(NMFolderTestBase):


### PR DESCRIPTION
## Summary
- Add `NMFolder.remove_dataseries()`, `remove_dataseries_channel()`, and
  `remove_dataseries_epoch()` to remove dataseries, channels, and epochs
  from a folder
- All three methods accept `str | int | list | range` inputs, support an
  optional `delete_data=False` flag, and emit a single history entry per call
- Fix `NMObjectContainer.pop()` to honour the `quiet` parameter when
  clearing the selected item, preventing spurious "changed selected" history
  entries

## Test plan
- [ ] `TestNMFolderRemoveDataseries` — removes dataseries, data retention/deletion, unknown prefix error
- [ ] `TestNMFolderRemoveDataseriesChannel` — remove by char/int/list/range, cross-ref cleanup in epochs, data deletion, error cases
- [ ] `TestNMFolderRemoveDataseriesEpoch` — remove by str/int/list/range, cross-ref cleanup in channels, data deletion, 200-epoch range scenario, error cases
- [ ] Full suite: `python3 -m pytest tests/ -q` → 2173 passed

Closes #228 
