### PR TITLE
feat(core): add wildcard support and scan_dataseries() to NMFolder

### DIFF
--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -20,6 +20,7 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 import copy
+import dataclasses
 import datetime
 from typing import Any
 import h5py
@@ -50,6 +51,22 @@ NMManager (NMObject, root)
                         NMEpochContainer
                             NMEpoch (E0, E1, E2...)
 """
+
+
+@dataclasses.dataclass(frozen=True)
+class NMDataSeriesScan:
+    """Result of :meth:`NMFolder.scan_dataseries` — what would be created.
+
+    Attributes:
+        prefix:   Detected dataseries name (e.g. ``"Record"``).
+        channels: Sorted list of channel characters (e.g. ``["A", "B"]``).
+        epochs:   Sorted list of epoch numbers (e.g. ``[0, 1, 2]``).
+        n_data:   Total number of matching data items.
+    """
+    prefix: str
+    channels: list
+    epochs: list
+    n_data: int
 
 
 class NMFolder(NMObject):
@@ -611,6 +628,73 @@ class NMFolder(NMObject):
         )
         return ds
 
+    def _scan_dataseries(
+        self,
+        prefix: str,
+    ) -> tuple[str, dict] | None:
+        """Scan folder data for names matching *prefix* without creating anything.
+
+        Returns:
+            ``(actual_prefix, matches)`` where *matches* maps
+            ``(channel_char, epoch_num)`` to :class:`NMData`, or ``None`` if
+            no matching data is found.
+        """
+        matches: dict[tuple[str, int], NMData] = {}
+        actual_prefix: str | None = None
+
+        for name, data in sorted(self.data.items()):
+            parsed = nmu.parse_data_name(name)
+            if parsed is None:
+                continue
+            detected_prefix, channel_char, epoch_num = parsed
+            if not nmu.match_prefix(prefix, detected_prefix):
+                continue
+            if actual_prefix is None:
+                actual_prefix = detected_prefix
+            elif actual_prefix != detected_prefix:
+                continue
+            matches[(channel_char, epoch_num)] = data
+
+        if not matches or actual_prefix is None:
+            return None
+        return actual_prefix, matches
+
+    def scan_dataseries(self, prefix: str) -> NMDataSeriesScan | None:
+        """Return a preview of what sync_dataseries() would create, without side effects.
+
+        Useful as a first step before committing to dataseries creation — e.g.
+        a GUI can call this, show the user the detected channels and epochs, and
+        only call :meth:`sync_dataseries` on confirmation.
+
+        Args:
+            prefix: Prefix or wildcard pattern (same as :meth:`sync_dataseries`).
+
+        Returns:
+            :class:`NMDataSeriesScan` with detected prefix, channels, epochs and
+            data count, or ``None`` if no matching data is found.
+
+        Example:
+            >>> info = folder.scan_dataseries("Record")
+            >>> info.prefix    # "Record"
+            >>> info.channels  # ["A", "B"]
+            >>> info.epochs    # [0, 1, 2]
+            >>> info.n_data    # 6
+        """
+        if not prefix or not isinstance(prefix, str):
+            return None
+        result = self._scan_dataseries(prefix)
+        if result is None:
+            return None
+        actual_prefix, matches = result
+        channels = sorted(set(ch for ch, _ in matches.keys()))
+        epochs = sorted(set(ep for _, ep in matches.keys()))
+        return NMDataSeriesScan(
+            prefix=actual_prefix,
+            channels=channels,
+            epochs=epochs,
+            n_data=len(matches),
+        )
+
     def sync_dataseries(
         self,
         prefix: str,
@@ -630,8 +714,15 @@ class NMFolder(NMObject):
         The prefix can be partial — ``"Rec"`` will match ``"RecordA0"``.
         The full detected prefix (e.g. ``"Record"``) becomes the dataseries name.
 
+        Wildcard patterns (``*``, ``?``, ``[seq]``) are also supported via
+        :mod:`fnmatch` — e.g. ``"Rec*"`` or ``"Avg_*"``.  When a wildcard
+        matches more than one distinct prefix the alphabetically-first prefix
+        is used.
+
+        For a non-destructive preview use :meth:`scan_dataseries` first.
+
         Args:
-            prefix: Prefix to match (case-insensitive). Can be partial.
+            prefix: Prefix or wildcard pattern to match (case-insensitive).
             select: Whether to select the dataseries after creation/update.
             quiet: If True, suppress history output.
 
@@ -641,32 +732,16 @@ class NMFolder(NMObject):
         Example:
             >>> folder.sync_dataseries("Record")
             # Creates or updates dataseries "Record" from RecordA0, RecordB0 …
+            >>> folder.sync_dataseries("Avg_*")
+            # Matches "Avg_Record", "Avg_Test", etc. (alphabetically first wins)
         """
         if not prefix or not isinstance(prefix, str):
             return None
 
-        # Scan folder: build matches dict from all data whose names fit
-        # the NeuroMatic pattern and start with the requested prefix.
-        matches: dict[tuple[str, int], NMData] = {}
-        actual_prefix: str | None = None
-
-        for name, data in self.data.items():
-            if not name.lower().startswith(prefix.lower()):
-                continue
-            parsed = nmu.parse_data_name(name)
-            if parsed is None:
-                continue
-            detected_prefix, channel_char, epoch_num = parsed
-            if not detected_prefix.lower().startswith(prefix.lower()):
-                continue
-            if actual_prefix is None:
-                actual_prefix = detected_prefix
-            elif actual_prefix != detected_prefix:
-                continue
-            matches[(channel_char, epoch_num)] = data
-
-        if not matches or actual_prefix is None:
+        result = self._scan_dataseries(prefix)
+        if result is None:
             return None
+        actual_prefix, matches = result
 
         is_new = actual_prefix not in self.dataseries
         ds = self.build_dataseries(actual_prefix, matches, select=select, quiet=True)

--- a/pyneuromatic/core/nm_utilities.py
+++ b/pyneuromatic/core/nm_utilities.py
@@ -20,6 +20,7 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 
+import fnmatch
 import inspect
 import math
 from typing import Callable
@@ -559,6 +560,26 @@ def parse_data_name(
         return None
 
     return (prefix, channel_char, epoch_num)
+
+
+def match_prefix(pattern: str, prefix: str) -> bool:
+    """Return True if *pattern* matches *prefix* (case-insensitive).
+
+    If *pattern* contains ``*``, ``?``, or ``[``, uses :mod:`fnmatch`
+    wildcard matching against the full prefix.  Otherwise falls back to
+    a case-insensitive ``startswith`` check so that partial prefixes
+    (e.g. ``"Rec"`` matching ``"Record"``) continue to work as before.
+
+    Args:
+        pattern: User-supplied prefix or wildcard pattern.
+        prefix:  Detected prefix from :func:`parse_data_name`.
+
+    Returns:
+        True if the pattern matches the prefix.
+    """
+    if any(c in pattern for c in ('*', '?', '[')):
+        return fnmatch.fnmatch(prefix.lower(), pattern.lower())
+    return prefix.lower().startswith(pattern.lower())
 
 
 def format_epoch_string(data_names: list[str]) -> str:

--- a/tests/test_core/test_nm_folder.py
+++ b/tests/test_core/test_nm_folder.py
@@ -425,6 +425,60 @@ class TestNMFolderBuildDataseries(NMFolderTestBase):
 
 
 # =============================================================================
+# Tests for scan_dataseries method
+# =============================================================================
+
+class TestNMFolderScanDataseries(NMFolderTestBase):
+    """Tests for NMFolder.scan_dataseries() — preview without side effects."""
+
+    def setUp(self):
+        super().setUp()
+        for ch in ["A", "B"]:
+            for ep in range(3):
+                self.folder.data.new(f"Record{ch}{ep}")
+
+    def test_returns_correct_prefix(self):
+        info = self.folder.scan_dataseries("Record")
+        self.assertIsNotNone(info)
+        self.assertEqual(info.prefix, "Record")
+
+    def test_returns_correct_channels(self):
+        info = self.folder.scan_dataseries("Record")
+        self.assertEqual(info.channels, ["A", "B"])
+
+    def test_returns_correct_epochs(self):
+        info = self.folder.scan_dataseries("Record")
+        self.assertEqual(info.epochs, [0, 1, 2])
+
+    def test_returns_correct_n_data(self):
+        info = self.folder.scan_dataseries("Record")
+        self.assertEqual(info.n_data, 6)
+
+    def test_no_side_effects(self):
+        self.folder.scan_dataseries("Record")
+        self.assertEqual(len(self.folder.dataseries), 0)
+
+    def test_no_match_returns_none(self):
+        self.assertIsNone(self.folder.scan_dataseries("NoMatch"))
+
+    def test_empty_prefix_returns_none(self):
+        self.assertIsNone(self.folder.scan_dataseries(""))
+
+    def test_none_prefix_returns_none(self):
+        self.assertIsNone(self.folder.scan_dataseries(None))
+
+    def test_wildcard_pattern(self):
+        info = self.folder.scan_dataseries("Rec*")
+        self.assertIsNotNone(info)
+        self.assertEqual(info.prefix, "Record")
+
+    def test_partial_prefix(self):
+        info = self.folder.scan_dataseries("Rec")
+        self.assertIsNotNone(info)
+        self.assertEqual(info.prefix, "Record")
+
+
+# =============================================================================
 # Tests for sync_dataseries method
 # =============================================================================
 
@@ -589,6 +643,68 @@ class TestNMFolderSyncDataSeriesMultiplePrefixes(NMFolderTestBase):
         self.assertIn("Avg_RecordA0", avg_names)
         self.assertNotIn("RecordA0", avg_names)
         self.assertEqual(len(avg_chan_a.data), 2)  # Avg_RecordA0, Avg_RecordA1
+
+
+# =============================================================================
+# Tests for sync_dataseries wildcard support
+# =============================================================================
+
+class TestNMFolderSyncDataSeriesWildcard(NMFolderTestBase):
+    """Tests for wildcard pattern support in NMFolder.sync_dataseries()."""
+
+    def setUp(self):
+        super().setUp()
+        # Two prefixes starting with "Rec": "Recent" sorts before "Record"
+        for ch in ["A", "B"]:
+            self.folder.data.new(f"Record{ch}0")
+            self.folder.data.new(f"Recent{ch}0")
+        self.folder.data.new("avgA0")
+
+    def test_star_matches_full_prefix(self):
+        ds = self.folder.sync_dataseries("Record*")
+        self.assertIsNotNone(ds)
+        self.assertEqual(ds.name, "Record")
+
+    def test_star_matches_partial_prefix_alphabetically_first(self):
+        # "Rec*" matches both "Recent" and "Record"; "Recent" < "Record" alphabetically
+        ds = self.folder.sync_dataseries("Rec*")
+        self.assertIsNotNone(ds)
+        self.assertEqual(ds.name, "Recent")
+
+    def test_question_mark_wildcard(self):
+        # "Rec?rd" matches "Record" (? = exactly one character)
+        ds = self.folder.sync_dataseries("Rec?rd")
+        self.assertIsNotNone(ds)
+        self.assertEqual(ds.name, "Record")
+
+    def test_star_only_returns_alphabetically_first(self):
+        # "*" matches all prefixes; "Recent" < "Record" < "avg" alphabetically
+        ds = self.folder.sync_dataseries("*")
+        self.assertIsNotNone(ds)
+        self.assertEqual(ds.name, "Recent")
+
+    def test_wildcard_no_match_returns_none(self):
+        ds = self.folder.sync_dataseries("Xyz*")
+        self.assertIsNone(ds)
+
+    def test_wildcard_case_insensitive(self):
+        ds = self.folder.sync_dataseries("rec*")
+        self.assertIsNotNone(ds)
+        self.assertEqual(ds.name, "Recent")
+
+    def test_non_wildcard_partial_still_alphabetically_first(self):
+        # No wildcard: falls back to startswith — "Rec" matches "Recent" and "Record"
+        ds = self.folder.sync_dataseries("Rec")
+        self.assertIsNotNone(ds)
+        self.assertEqual(ds.name, "Recent")
+
+    def test_wildcard_links_correct_data(self):
+        ds = self.folder.sync_dataseries("Record*")
+        chan_a = ds.channels.get("A")
+        names = [d.name for d in chan_a.data]
+        self.assertIn("RecordA0", names)
+        self.assertNotIn("RecentA0", names)
+        self.assertNotIn("avgA0", names)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary 

- Add nmu.match_prefix(pattern, prefix) — case-insensitive prefix matching with fnmatch wildcard support (*, ?, [seq]); falls back to startswith when no wildcards present
- Add NMDataSeriesScan frozen dataclass (prefix, channels, epochs, n_data)
- Add NMFolder._scan_dataseries(prefix) — private scan loop shared by scan_dataseries() and sync_dataseries()
- Add NMFolder.scan_dataseries(prefix) — public no-side-effect preview, enabling a future two-step confirm-before-create workflow (mirrors Igor NeuroMatic's prefix → confirm → create pattern)
- Update sync_dataseries() to use _scan_dataseries() internally and nmu.match_prefix() for matching; iterates alphabetically for deterministic multi-match behavior

## Test plan

- TestNMFolderScanDataseries (10 tests) — correct fields, no side effects, None cases, wildcard and partial prefix
-  TestNMFolderSyncDataSeriesWildcard (8 tests) — *, ?, case-insensitivity, alphabetical first-match, data linking
-  Full suite passes (163 passed)

Closes #233