### PR TITLE
feat(core): add command history logging to NMFolder dataseries methods

### DIFF
--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -31,6 +31,7 @@ from pyneuromatic.core.nm_notes import NMNotes
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
 from pyneuromatic.analysis.nm_tool_folder import NMToolFolderContainer
+import pyneuromatic.core.nm_command_history as nmch
 import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_configurations as nmc
 import pyneuromatic.core.nm_utilities as nmu
@@ -395,6 +396,19 @@ class NMFolder(NMObject):
     # Dataseries methods (build, new, sync, copy, remove)
     # ------------------------------------------------------------------
 
+    @property
+    def _nm_path(self) -> str:
+        """Command-history path for this folder, derived from parent.
+
+        Returns e.g. ``'folders["TestFolder"]'`` when the parent is an
+        NMManager, so that ``nmch.add_nm_command(_nm_path + ".method()")``
+        produces ``nm.folders["TestFolder"].method()``.
+        """
+        from pyneuromatic.core.nm_manager import NMManager
+        if isinstance(self._parent, NMManager):
+            return 'folders["%s"]' % self.name
+        return self.name
+
     def build_dataseries(
         self,
         prefix: str,
@@ -626,6 +640,15 @@ class NMFolder(NMObject):
             path=self.path_str,
             quiet=quiet,
         )
+        _p = '%s["%s"]' % (self._nm_path, self.name)
+        nmch.add_nm_command(
+            '%s.new_dataseries(%r, n_channels=%r, n_epochs=%r, n_points=%r, '
+            'dx=%r, x_start=%r, x_label=%r, x_units=%r, y_label=%r, y_units=%r, '
+            'fill=%r, ch_start=%r, ep_start=%r)'
+            % (_p, prefix, n_channels, n_epochs, n_points,
+               dx, x_start, x_label, x_units, y_label, y_units,
+               fill, ch_start, ep_start)
+        )
         return ds
 
     def _scan_dataseries(
@@ -759,7 +782,8 @@ class NMFolder(NMObject):
             path=self.path_str,
             quiet=quiet,
         )
-
+        _p = '%s["%s"]' % (self._nm_path, self.name)
+        nmch.add_nm_command('%s.sync_dataseries(%r)' % (_p, actual_prefix))
         return ds
 
     def copy_dataseries(
@@ -905,6 +929,12 @@ class NMFolder(NMObject):
             path=self.path_str,
             quiet=quiet,
         )
+        _p = '%s["%s"]' % (self._nm_path, self.name)
+        folder_str = ('%s["%s"]' % (folder._nm_path, folder.name)) if folder is not None else "None"
+        nmch.add_nm_command(
+            '%s.copy_dataseries(%r, new_prefix=%r, channel=%r, epoch=%r, folder=%s)'
+            % (_p, prefix, new_prefix, channel, epoch, folder_str)
+        )
         return ds
 
     def remove_dataseries(
@@ -941,6 +971,10 @@ class NMFolder(NMObject):
         if delete_data:
             msg += " (and %d data objects)" % len(data_names)
         nmh.history(msg, path=self.path_str, quiet=quiet)
+        _p = '%s["%s"]' % (self._nm_path, self.name)
+        nmch.add_nm_command(
+            '%s.remove_dataseries(%r, delete_data=%r)' % (_p, prefix, delete_data)
+        )
 
     def remove_dataseries_channel(
         self,
@@ -988,6 +1022,11 @@ class NMFolder(NMObject):
         if delete_data:
             msg += " (and %d data objects)" % n_deleted
         nmh.history(msg, path=self.path_str, quiet=quiet)
+        _p = '%s["%s"]' % (self._nm_path, self.name)
+        nmch.add_nm_command(
+            '%s.remove_dataseries_channel(%r, %r, delete_data=%r)'
+            % (_p, prefix, channel, delete_data)
+        )
 
     def remove_dataseries_epoch(
         self,
@@ -1038,6 +1077,11 @@ class NMFolder(NMObject):
         if delete_data:
             msg += " (and %d data objects)" % n_deleted
         nmh.history(msg, path=self.path_str, quiet=quiet)
+        _p = '%s["%s"]' % (self._nm_path, self.name)
+        nmch.add_nm_command(
+            '%s.remove_dataseries_epoch(%r, %r, delete_data=%r)'
+            % (_p, prefix, epoch, delete_data)
+        )
 
 
 class NMFolderContainer(NMObjectContainer):

--- a/tests/test_core/test_nm_folder.py
+++ b/tests/test_core/test_nm_folder.py
@@ -15,6 +15,8 @@ from pyneuromatic.core.nm_folder import NMFolder, NMFolderContainer
 from pyneuromatic.core.nm_notes import NMNotes
 from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.core.nm_object import NMObject
+import pyneuromatic.core.nm_command_history as nmch
+from pyneuromatic.core.nm_command_history import NMCommandHistory
 import pyneuromatic.core.nm_utilities as nmu
 
 
@@ -1171,6 +1173,86 @@ class TestNMFolderRemoveDataseriesEpoch(NMFolderTestBase):
         self.assertEqual(len(list(ds.epochs)), 100)
         self.assertIsNotNone(ds.epochs.get("E99"))
         self.assertIsNone(ds.epochs.get("E100"))
+
+
+# =============================================================================
+# Tests for command history logging
+# =============================================================================
+
+class TestNMFolderCommandHistory(NMFolderTestBase):
+    """Tests that dataseries methods record Python-replayable commands."""
+
+    def setUp(self):
+        super().setUp()
+        self._ch = NMCommandHistory(enabled=True)
+        nmch.set_command_history(self._ch)
+        for ch in ["A", "B"]:
+            for ep in range(2):
+                self.folder.data.new(f"Record{ch}{ep}", quiet=True)
+
+    def tearDown(self):
+        nmch.set_command_history(NMCommandHistory())
+
+    def _last_command(self):
+        return self._ch.buffer[-1]["command"]
+
+    def test_new_dataseries_recorded(self):
+        self.folder.new_dataseries("Wave", n_channels=2, n_epochs=3)
+        cmd = self._last_command()
+        self.assertIn('new_dataseries', cmd)
+        self.assertIn("'Wave'", cmd)
+        self.assertIn('n_channels=2', cmd)
+        self.assertIn('n_epochs=3', cmd)
+
+    def test_new_dataseries_uses_nm_path(self):
+        self.folder.new_dataseries("Wave")
+        cmd = self._last_command()
+        self.assertIn('folders["%s"]' % self.folder.name, cmd)
+
+    def test_sync_dataseries_recorded(self):
+        self.folder.sync_dataseries("Record")
+        cmd = self._last_command()
+        self.assertIn('sync_dataseries', cmd)
+        self.assertIn("'Record'", cmd)
+
+    def test_sync_dataseries_uses_actual_prefix(self):
+        # User passes partial pattern; recorded command uses resolved prefix
+        self.folder.sync_dataseries("Rec")
+        cmd = self._last_command()
+        self.assertIn("'Record'", cmd)
+
+    def test_copy_dataseries_recorded(self):
+        self.folder.sync_dataseries("Record", quiet=True)
+        self.folder.copy_dataseries("Record", new_prefix="avg")
+        cmd = self._last_command()
+        self.assertIn('copy_dataseries', cmd)
+        self.assertIn("'Record'", cmd)
+        self.assertIn("new_prefix='avg'", cmd)
+        self.assertIn('folder=None', cmd)
+
+    def test_remove_dataseries_recorded(self):
+        self.folder.sync_dataseries("Record", quiet=True)
+        self.folder.remove_dataseries("Record")
+        cmd = self._last_command()
+        self.assertIn('remove_dataseries(', cmd)
+        self.assertIn("'Record'", cmd)
+        self.assertIn('delete_data=False', cmd)
+
+    def test_remove_dataseries_channel_recorded(self):
+        self.folder.sync_dataseries("Record", quiet=True)
+        self.folder.remove_dataseries_channel("Record", "B")
+        cmd = self._last_command()
+        self.assertIn('remove_dataseries_channel', cmd)
+        self.assertIn("'B'", cmd)
+        self.assertIn('delete_data=False', cmd)
+
+    def test_remove_dataseries_epoch_recorded(self):
+        self.folder.sync_dataseries("Record", quiet=True)
+        self.folder.remove_dataseries_epoch("Record", 1)
+        cmd = self._last_command()
+        self.assertIn('remove_dataseries_epoch', cmd)
+        self.assertIn('1', cmd)
+        self.assertIn('delete_data=False', cmd)
 
 
 class TestNMFolderToolResults(NMFolderTestBase):


### PR DESCRIPTION
## Summary

- Add _nm_path computed property to NMFolder — derives 'folders["FolderName"]' from self._parent (NMManager type check), same pattern as NMStatWin._nm_path
- Add nmch.add_nm_command() after nmh.history() in all 6 public state-modifying dataseries methods: new_dataseries, sync_dataseries, copy_dataseries, remove_dataseries, remove_dataseries_channel, remove_dataseries_epoch
- sync_dataseries records the resolved actual_prefix (not the user's pattern), so the replayed command is always exact
- copy_dataseries renders the folder param as folders["name"] or None
- Add TestNMFolderCommandHistory (8 tests) with an isolated NMCommandHistory per test

## Test plan 

-  All 8 TestNMFolderCommandHistory tests pass
-  Full suite passes (181 passed)

Closes #236