### PR TITLE
feat(core): add command history logging to NMObjectContainer

### DIFF
--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -499,6 +499,14 @@ class NMDataContainer(NMObjectContainer):
             auto_name_seq_format=name_seq_format,
         )
 
+    # override
+    @property
+    def _nm_cmd_path(self) -> str | None:
+        from pyneuromatic.core.nm_folder import NMFolder
+        if isinstance(self._parent, NMFolder):
+            return '%s.data' % self._parent._nm_cmd_path
+        return None
+
     # override, no super
     def content_type(self) -> str:
         return NMData.__name__

--- a/pyneuromatic/core/nm_dataseries.py
+++ b/pyneuromatic/core/nm_dataseries.py
@@ -573,6 +573,14 @@ class NMDataSeriesContainer(NMObjectContainer):
             auto_name_seq_format="",
         )
 
+    # override
+    @property
+    def _nm_cmd_path(self) -> str | None:
+        from pyneuromatic.core.nm_folder import NMFolder
+        if isinstance(self._parent, NMFolder):
+            return '%s.dataseries' % self._parent._nm_cmd_path
+        return None
+
     # override, no super
     def content_type(self) -> str:
         return NMDataSeries.__name__

--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -397,11 +397,11 @@ class NMFolder(NMObject):
     # ------------------------------------------------------------------
 
     @property
-    def _nm_path(self) -> str:
+    def _nm_cmd_path(self) -> str:
         """Command-history path for this folder, derived from parent.
 
         Returns e.g. ``'folders["TestFolder"]'`` when the parent is an
-        NMManager, so that ``nmch.add_nm_command(_nm_path + ".method()")``
+        NMManager, so that ``nmch.add_nm_command(_nm_cmd_path + ".method()")``
         produces ``nm.folders["TestFolder"].method()``.
         """
         from pyneuromatic.core.nm_manager import NMManager
@@ -640,7 +640,7 @@ class NMFolder(NMObject):
             path=self.path_str,
             quiet=quiet,
         )
-        _p = '%s["%s"]' % (self._nm_path, self.name)
+        _p = '%s["%s"]' % (self._nm_cmd_path, self.name)
         nmch.add_nm_command(
             '%s.new_dataseries(%r, n_channels=%r, n_epochs=%r, n_points=%r, '
             'dx=%r, x_start=%r, x_label=%r, x_units=%r, y_label=%r, y_units=%r, '
@@ -782,7 +782,7 @@ class NMFolder(NMObject):
             path=self.path_str,
             quiet=quiet,
         )
-        _p = '%s["%s"]' % (self._nm_path, self.name)
+        _p = '%s["%s"]' % (self._nm_cmd_path, self.name)
         nmch.add_nm_command('%s.sync_dataseries(%r)' % (_p, actual_prefix))
         return ds
 
@@ -929,8 +929,8 @@ class NMFolder(NMObject):
             path=self.path_str,
             quiet=quiet,
         )
-        _p = '%s["%s"]' % (self._nm_path, self.name)
-        folder_str = ('%s["%s"]' % (folder._nm_path, folder.name)) if folder is not None else "None"
+        _p = '%s["%s"]' % (self._nm_cmd_path, self.name)
+        folder_str = ('%s["%s"]' % (folder._nm_cmd_path, folder.name)) if folder is not None else "None"
         nmch.add_nm_command(
             '%s.copy_dataseries(%r, new_prefix=%r, channel=%r, epoch=%r, folder=%s)'
             % (_p, prefix, new_prefix, channel, epoch, folder_str)
@@ -971,7 +971,7 @@ class NMFolder(NMObject):
         if delete_data:
             msg += " (and %d data objects)" % len(data_names)
         nmh.history(msg, path=self.path_str, quiet=quiet)
-        _p = '%s["%s"]' % (self._nm_path, self.name)
+        _p = '%s["%s"]' % (self._nm_cmd_path, self.name)
         nmch.add_nm_command(
             '%s.remove_dataseries(%r, delete_data=%r)' % (_p, prefix, delete_data)
         )
@@ -1022,7 +1022,7 @@ class NMFolder(NMObject):
         if delete_data:
             msg += " (and %d data objects)" % n_deleted
         nmh.history(msg, path=self.path_str, quiet=quiet)
-        _p = '%s["%s"]' % (self._nm_path, self.name)
+        _p = '%s["%s"]' % (self._nm_cmd_path, self.name)
         nmch.add_nm_command(
             '%s.remove_dataseries_channel(%r, %r, delete_data=%r)'
             % (_p, prefix, channel, delete_data)
@@ -1077,7 +1077,7 @@ class NMFolder(NMObject):
         if delete_data:
             msg += " (and %d data objects)" % n_deleted
         nmh.history(msg, path=self.path_str, quiet=quiet)
-        _p = '%s["%s"]' % (self._nm_path, self.name)
+        _p = '%s["%s"]' % (self._nm_cmd_path, self.name)
         nmch.add_nm_command(
             '%s.remove_dataseries_epoch(%r, %r, delete_data=%r)'
             % (_p, prefix, epoch, delete_data)
@@ -1104,6 +1104,11 @@ class NMFolderContainer(NMObjectContainer):
             auto_name_prefix=name_prefix,
             auto_name_seq_format=name_seq_format,
         )
+
+    # override
+    @property
+    def _nm_cmd_path(self) -> str:
+        return "folders"
 
     # override, no super
     def content_type(self) -> str:

--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -24,6 +24,7 @@ from collections.abc import MutableMapping
 from enum import Enum, auto
 
 from pyneuromatic.core.nm_object import NMObject
+import pyneuromatic.core.nm_command_history as nmch
 import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_configurations as nmc
 from pyneuromatic.core.nm_sets import NMSets
@@ -449,6 +450,17 @@ class NMObjectContainer(NMObject, MutableMapping):
     # Sentinel value to distinguish "no default provided" from "default is None"
     _POPDEFAULT = object()
 
+    @property
+    def _nm_cmd_path(self) -> str | None:
+        """Command-history path for this container.
+
+        Returns the dotted access path used to build ``nmch.add_nm_command()``
+        strings, e.g. ``"folders"`` or ``'folders["f0"].data'``.
+        Returns ``None`` to opt out of command-history logging (default).
+        Subclasses override this for containers that should be logged.
+        """
+        return None
+
     # override MutableMapping mixin method
     def pop(  # type: ignore[override]
         self,
@@ -469,6 +481,8 @@ class NMObjectContainer(NMObject, MutableMapping):
         o = self.__map.pop(actual_key)
         o._container = None
         nmh.history("removed '%s'" % actual_key, path=self.path_str, quiet=quiet)
+        if self._nm_cmd_path is not None:
+            nmch.add_nm_command('%s.pop(%r)' % (self._nm_cmd_path, actual_key))
         return o
 
     # override MutableMapping mixin method
@@ -502,6 +516,8 @@ class NMObjectContainer(NMObject, MutableMapping):
         self.sets.empty_all()
         self.__map.clear()
         nmh.history("cleared all: %s" % names, path=self.path_str, quiet=quiet)
+        if self._nm_cmd_path is not None:
+            nmch.add_nm_command('%s.clear()' % self._nm_cmd_path)
 
     # override MutableMapping mixin method
     # add/update NMObject to map
@@ -661,6 +677,10 @@ class NMObjectContainer(NMObject, MutableMapping):
             "renamed '%s' as '%s'" % (key, actual_newname),
             path=self.path_str, quiet=quiet,
         )
+        if self._nm_cmd_path is not None:
+            nmch.add_nm_command(
+                '%s.rename(%r, %r)' % (self._nm_cmd_path, key, actual_newname)
+            )
         return True
 
     def reorder(
@@ -721,6 +741,10 @@ class NMObjectContainer(NMObject, MutableMapping):
             "duplicated '%s' as '%s'" % (key, c.name),
             path=self.path_str, quiet=quiet,
         )
+        if self._nm_cmd_path is not None:
+            nmch.add_nm_command(
+                '%s.duplicate(%r, %r)' % (self._nm_cmd_path, key, c.name)
+            )
         return c
 
     # children should override
@@ -756,6 +780,8 @@ class NMObjectContainer(NMObject, MutableMapping):
         if isinstance(select, bool) and select:
             self.__selected_name = newkey
         nmh.history("new '%s'" % newkey, path=self.path_str, quiet=quiet)
+        if self._nm_cmd_path is not None:
+            nmch.add_nm_command('%s.new(%r)' % (self._nm_cmd_path, newkey))
         return True
 
     @property
@@ -924,9 +950,13 @@ class NMObjectContainer(NMObject, MutableMapping):
 
     @selected_name.setter
     def selected_name(
-        self, 
+        self,
         name: str | None
     ) -> None:
+        if self._nm_cmd_path is not None:
+            nmch.add_nm_command(
+                '%s.selected_name = %r' % (self._nm_cmd_path, name)
+            )
         self._selected_name_set(name)
 
     def _selected_name_set(

--- a/tests/test_core/test_nm_folder.py
+++ b/tests/test_core/test_nm_folder.py
@@ -1204,7 +1204,7 @@ class TestNMFolderCommandHistory(NMFolderTestBase):
         self.assertIn('n_channels=2', cmd)
         self.assertIn('n_epochs=3', cmd)
 
-    def test_new_dataseries_uses_nm_path(self):
+    def test_new_dataseries_uses_nm_cmd_path(self):
         self.folder.new_dataseries("Wave")
         cmd = self._last_command()
         self.assertIn('folders["%s"]' % self.folder.name, cmd)
@@ -1253,6 +1253,18 @@ class TestNMFolderCommandHistory(NMFolderTestBase):
         self.assertIn('remove_dataseries_epoch', cmd)
         self.assertIn('1', cmd)
         self.assertIn('delete_data=False', cmd)
+
+    def test_data_container_nm_cmd_path(self):
+        self.assertEqual(
+            self.folder.data._nm_cmd_path,
+            'folders["%s"].data' % self.folder.name,
+        )
+
+    def test_dataseries_container_nm_cmd_path(self):
+        self.assertEqual(
+            self.folder.dataseries._nm_cmd_path,
+            'folders["%s"].dataseries' % self.folder.name,
+        )
 
 
 class TestNMFolderToolResults(NMFolderTestBase):

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -9,6 +9,8 @@ acquiring and simulating electrophysiology data.
 import copy
 import unittest
 
+import pyneuromatic.core.nm_command_history as nmch
+from pyneuromatic.core.nm_command_history import NMCommandHistory
 import pyneuromatic.core.nm_utilities as nmu
 from pyneuromatic.core.nm_manager import NMManager
 from pyneuromatic.core.nm_object import NMObject
@@ -1320,6 +1322,79 @@ class TestNMObjectContainerHistory(unittest.TestCase):
     def test_update_none_no_log(self):
         self.container.update(None, quiet=False)
         self.assertEqual(len(self.nm.history.buffer), 0)
+
+
+class _NMObjectContainerLogged(NMObjectContainer):
+    """NMObjectContainer subclass that opts in to command-history logging."""
+
+    @property
+    def _nm_cmd_path(self) -> str:
+        return "container"
+
+
+class TestNMObjectContainerCommandHistory(unittest.TestCase):
+    """Tests that NMObjectContainer records Python-replayable commands."""
+
+    def setUp(self):
+        self._ch = NMCommandHistory(enabled=True)
+        nmch.set_command_history(self._ch)
+        self.container = _NMObjectContainerLogged(
+            parent=None,
+            name="container",
+            auto_name_prefix="NMObject",
+        )
+        self.container.new(name="NMObject0", quiet=True)
+        self._ch.clear()  # discard setUp actions; tests start with empty buffer
+
+    def tearDown(self):
+        nmch.set_command_history(NMCommandHistory())
+
+    def _last_command(self):
+        return self._ch.buffer[-1]["command"]
+
+    def test_new_recorded(self):
+        self.container.new(name="NMObject1", quiet=True)
+        cmd = self._last_command()
+        self.assertIn('container.new(', cmd)
+        self.assertIn("'NMObject1'", cmd)
+
+    def test_pop_recorded(self):
+        self.container.pop("NMObject0", quiet=True)
+        cmd = self._last_command()
+        self.assertIn('container.pop(', cmd)
+        self.assertIn("'NMObject0'", cmd)
+
+    def test_rename_recorded(self):
+        self.container.rename("NMObject0", "NMObject0renamed", quiet=True)
+        cmd = self._last_command()
+        self.assertIn('container.rename(', cmd)
+        self.assertIn("'NMObject0'", cmd)
+        self.assertIn("'NMObject0renamed'", cmd)
+
+    def test_duplicate_recorded(self):
+        self.container.duplicate("NMObject0", "NMObject0copy", quiet=True)
+        cmd = self._last_command()
+        self.assertIn('container.duplicate(', cmd)
+        self.assertIn("'NMObject0'", cmd)
+
+    def test_selected_name_recorded(self):
+        self.container.new(name="NMObject1", quiet=True)
+        self.container.selected_name = "NMObject1"
+        cmd = self._last_command()
+        self.assertIn('container.selected_name', cmd)
+        self.assertIn("'NMObject1'", cmd)
+
+    def test_clear_recorded(self):
+        self.container.clear(quiet=True)
+        cmd = self._last_command()
+        self.assertIn('container.clear()', cmd)
+
+    def test_no_log_when_nm_cmd_path_none(self):
+        # Plain NMObjectContainer has _nm_cmd_path=None — nothing recorded
+        plain = NMObjectContainer(parent=None, name="plain")
+        count_before = len(self._ch.buffer)
+        plain.new(quiet=True)
+        self.assertEqual(len(self._ch.buffer), count_before)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add _nm_cmd_path property to NMObjectContainer (returns None by default to opt out); subclasses override to enable logging
- Call nmch.add_nm_command() in new, pop, rename, duplicate, clear, and selected_name setter — guarded by if self._nm_cmd_path is not None
- NMFolderContainer._nm_cmd_path → "folders" (static)
- NMDataContainer._nm_cmd_path and NMDataSeriesContainer._nm_cmd_path compose from parent NMFolder._nm_cmd_path at call time (avoids staleness after rename)
- selected_name setter (not _selected_name_set) used to avoid double-recording when pop() internally calls _selected_name_set()

## Test plan

-  TestNMObjectContainerCommandHistory — uses _NMObjectContainerLogged subclass with generic names, no NMManager dependency
-  test_data_container_nm_cmd_path and test_dataseries_container_nm_cmd_path moved to TestNMFolderCommandHistory
-  Run python3 -m pytest tests/test_core/test_nm_object_container.py tests/test_core/test_nm_folder.py -q — all 407 tests pass

Closes #238 