### PR TITLE
refactor(core): simplify NMObjectContainer.update() to single NMObject parameter

### DIFF
--- a/pyneuromatic/core/nm_object_container.py
+++ b/pyneuromatic/core/nm_object_container.py
@@ -262,13 +262,8 @@ class NMObjectContainer(NMObject, MutableMapping):
         key: str,
         nmobject: NMObject  # key is equal to NMObject name
     ) -> None:
-        """
-        called by '=' and update()
-        override below: update()
-        e.g. mymap['recorda0'] = mynmobject
-        """
-        # print('__setitem__, ' + str(key) + ', ' + str(nmobject))
-        self.update({key: nmobject})  # key is not used
+        """e.g. mymap['recorda0'] = mynmobject  (key is not used; name taken from nmobject)"""
+        self.update(nmobject)  # key is not used
 
     # MutableMapping required abstract method
     def __delitem__(
@@ -523,59 +518,20 @@ class NMObjectContainer(NMObject, MutableMapping):
     # add/update NMObject to map
     def update(  # type: ignore[override]
         self,
-        nmobjects: NMObject | list[NMObject] | dict[str, NMObject] | NMObjectContainer | None = None,
+        nmobject: NMObject,
         quiet: bool = nmc.QUIET,
     ) -> None:
-        olist: list[NMObject]
-        if nmobjects is None:
-            nmobjects = []
-        if isinstance(nmobjects, NMObject) and self.content_type_ok(nmobjects):
-            olist = [nmobjects]
-        elif isinstance(nmobjects, list):
-            olist = nmobjects
-        elif isinstance(nmobjects, NMObjectContainer):
-            olist = list(nmobjects.__map.values())
-        elif isinstance(nmobjects, dict):
-            olist = []
-            for k, o in nmobjects.items():
-                # key is not used, key is NMObject name
-                if not self.content_type_ok(o):
-                    e = "nmobjects: '%s' value" % k
-                    e = nmu.type_error_str(o, e, self.content_type())
-                    raise TypeError(e)
-                if k is None:
-                    k = o.name
-                if not isinstance(k, str):
-                    e = nmu.type_error_str(k, "nmobjects: key", "string")
-                    raise TypeError(e)
-                if k.lower() != o.name.lower():
-                    raise KeyError("key and name mismatch: '%s' != '%s'" % (k, o.name))
-                olist.append(o)
-        else:
-            e = (
-                self.content_type()
-                + " or list or dictionary or "
-                + self.__class__.__name__
-            )
-            e = nmu.type_error_str(nmobjects, "nmobjects", e)
+        if not self.content_type_ok(nmobject):
+            e = nmu.type_error_str(nmobject, "nmobject", self.content_type())
             raise TypeError(e)
-        updated: list[str] = []
-        for o in olist:
-            if self.content_type_ok(o):
-                key = self._getkey(o.name)
-                if key is None:
-                    key = self._newkey(o.name)
-                self.__map[key] = o
-                updated.append(key)
-            else:
-                e = "nmobjects: list item"
-                e = nmu.type_error_str(o, e, self.content_type())
-                raise TypeError(e)
-        if updated:
-            self.__update_nmobject_references()
-            nmh.history(
-                "updated %s" % updated, path=self.path_str, quiet=quiet
-            )
+        key = self._getkey(nmobject.name)
+        if key is None:
+            key = self._newkey(nmobject.name)
+        self.__map[key] = nmobject
+        self.__update_nmobject_references()
+        nmh.history("updated '%s'" % key, path=self.path_str, quiet=quiet)
+        if self._nm_cmd_path is not None:
+            nmch.add_nm_command('%s.update(%r)' % (self._nm_cmd_path, nmobject.name))
 
     def __update_nmobject_references(self):
         for o in self.__map.values():

--- a/tests/test_core/test_nm_object_container.py
+++ b/tests/test_core/test_nm_object_container.py
@@ -55,7 +55,8 @@ class NMObjectContainerTestBase(unittest.TestCase):
             auto_name_prefix=OPREFIX0,
             auto_name_seq_format=OSEQFORMAT0,
         )
-        self.map0.update(self.olist0)
+        for o in self.olist0:
+            self.map0.update(o)
 
         self.sets0 = {SETS_NLIST0[0]: [ONLIST0[0], ONLIST0[2], ONLIST0[3]]}
         self.map0.sets.update(self.sets0)
@@ -67,7 +68,8 @@ class NMObjectContainerTestBase(unittest.TestCase):
             auto_name_prefix=OPREFIX1,
             auto_name_seq_format=OSEQFORMAT1,
         )
-        self.map1.update(self.olist1)
+        for o in self.olist1:
+            self.map1.update(o)
         self.map1.selected_name = ONLIST1[2]
 
         self.sets1 = {
@@ -347,25 +349,18 @@ class TestNMObjectContainerGetItem(NMObjectContainerTestBase):
 class TestNMObjectContainerSetItem(NMObjectContainerTestBase):
     """Tests for __setitem__ method."""
 
-    def test_rejects_bad_key_types(self):
-        bad = list(BAD_TYPES)
-        bad.remove("string")
-        bad.remove(None)
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.map0[b] = NMObject(parent=NM0, name="test")
-
     def test_rejects_bad_value_types(self):
         n = ONLIST0[1]
         for b in BAD_TYPES:
-            with self.assertRaises(TypeError):
+            with self.assertRaises((TypeError, ValueError, KeyError)):
                 self.map0[n] = b
 
-    def test_rejects_mismatched_name_and_key(self):
-        n = ONLIST0[1]
-        badname = n + "x"
-        with self.assertRaises(KeyError):
-            self.map0[n] = NMObject(parent=NM0, name=badname)
+    def test_key_is_ignored(self):
+        # __setitem__ delegates to update(nmobject) — key is not used
+        o = NMObject(parent=NM0, name="newobj")
+        self.map0["anykey"] = o
+        self.assertIn("newobj", self.map0)
+        self.assertNotIn("anykey", self.map0)
 
     def test_replaces_existing_object(self):
         n = ONLIST0[1]
@@ -533,7 +528,8 @@ class TestNMObjectContainerEquality(NMObjectContainerTestBase):
         olist0 = []
         for n in ONLIST0:
             olist0.append(NMObject(parent=NM0, name=n))
-        map0.update(olist0)
+        for o in olist0:
+            map0.update(o)
         self.assertFalse(map0 == self.map0)  # sets are not equal
         map0.sets.update(self.sets0)
         self.assertTrue(map0 == self.map0)
@@ -548,7 +544,8 @@ class TestNMObjectContainerEquality(NMObjectContainerTestBase):
         olist0 = []
         for n in ONLIST0:
             olist0.append(NMObject(parent=NM0, name=n))
-        map0.update(olist0)
+        for o in olist0:
+            map0.update(o)
         map0.sets.update(self.sets0)
         map0.sets.new(SETS_NLIST0[1])
         self.assertFalse(map0 == self.map0)
@@ -622,19 +619,9 @@ class TestNMObjectContainerUpdate(NMObjectContainerTestBase):
     """Tests for update() method."""
 
     def test_update_rejects_bad_types(self):
-        bad = list(BAD_TYPES)
-        bad.remove(None)
-        bad.remove([])
-        bad.remove({})
-        for b in bad:
-            with self.assertRaises(TypeError):
-                self.map0.update(b)
-
-    def test_update_rejects_bad_items_in_list(self):
-        o1 = NMObject(parent=NM0, name="test")
         for b in BAD_TYPES:
-            with self.assertRaises(TypeError):
-                self.map0.update([b, o1])
+            with self.assertRaises((TypeError, ValueError, KeyError)):
+                self.map0.update(b)
 
     def test_update_adds_object(self):
         n1 = "test"
@@ -657,18 +644,10 @@ class TestNMObjectContainerUpdate(NMObjectContainerTestBase):
         self.map0.update(o2)
         self.assertTrue(self.map0.get(n1) is o2)
 
-    def test_update_dict_ignores_key(self):
-        n1 = "test"
-        o2 = NMObject(parent=NM0, name=n1.upper())
-        self.map0.update({"test": o2})
-        self.assertTrue(self.map0.get(n1) is o2)
-
-    def test_update_dict_rejects_mismatched_keys(self):
-        n1 = "test"
-        o1 = NMObject(parent=NM0, name=n1)
-        o2 = NMObject(parent=NM0, name=n1.upper())
-        with self.assertRaises(KeyError):
-            self.map0.update({"test1": o1, "test2": o2})
+    def test_update_uses_object_name(self):
+        o = NMObject(parent=NM0, name="newobj")
+        self.map0.update(o)
+        self.assertIn("newobj", self.map0)
 
     def test_update_rejects_wrong_type(self):
         o3 = NMObject2(parent=NM0, name="test3")
@@ -677,7 +656,8 @@ class TestNMObjectContainerUpdate(NMObjectContainerTestBase):
 
     def test_update_from_another_container(self):
         new_len = len(self.map0) + len(self.map1)
-        self.map0.update(self.map1)
+        for o in self.map1.values():
+            self.map0.update(o)
         self.assertEqual(len(self.map0), new_len)
         for n in ONLIST1:
             self.assertTrue(n in self.map0)
@@ -1311,17 +1291,16 @@ class TestNMObjectContainerHistory(unittest.TestCase):
         self.assertIn("itemX", msg)
 
     def test_update_multiple_logs(self):
-        objs = [NMObject(parent=self.nm, name="a%d" % i) for i in range(3)]
-        self.container.update(objs, quiet=False)
-        msg = self._last_message()
-        self.assertIn("updated", msg)
-        self.assertIn("a0", msg)
-        self.assertIn("a1", msg)
-        self.assertIn("a2", msg)
+        for i in range(3):
+            self.container.update(NMObject(parent=self.nm, name="a%d" % i), quiet=False)
+        msgs = self._messages()
+        self.assertTrue(any("a0" in m for m in msgs))
+        self.assertTrue(any("a1" in m for m in msgs))
+        self.assertTrue(any("a2" in m for m in msgs))
 
-    def test_update_none_no_log(self):
-        self.container.update(None, quiet=False)
-        self.assertEqual(len(self.nm.history.buffer), 0)
+    def test_update_rejects_none(self):
+        with self.assertRaises(TypeError):
+            self.container.update(None)
 
 
 class _NMObjectContainerLogged(NMObjectContainer):
@@ -1388,6 +1367,13 @@ class TestNMObjectContainerCommandHistory(unittest.TestCase):
         self.container.clear(quiet=True)
         cmd = self._last_command()
         self.assertIn('container.clear()', cmd)
+
+    def test_update_recorded(self):
+        o = NMObject(parent=None, name="NMObject1")
+        self.container.update(o, quiet=True)
+        cmd = self._last_command()
+        self.assertIn('container.update(', cmd)
+        self.assertIn("'NMObject1'", cmd)
 
     def test_no_log_when_nm_cmd_path_none(self):
         # Plain NMObjectContainer has _nm_cmd_path=None — nothing recorded


### PR DESCRIPTION
## Summary

- Remove multi-type nmobjects overload (NMObject | list | dict | NMObjectContainer) — only production caller was __setitem__ with a single-item dict; all other forms were test-only convenience
- Simplify update(nmobject: NMObject, quiet=...) to a direct single-object upsert, with _getkey() + _newkey() preserving existing replace-by-name behaviour
- Reverse the delegation: __setitem__ now calls update(nmobject) directly (previously backwards — __setitem__ called update({key: obj}))
- Add nmch.add_nm_command('%s.update(%r)' % ...) for command-history logging, consistent with new, pop, rename, duplicate, clear

## Test plan

-  NMObjectContainerTestBase.setUp() loops instead of passing lists
-  test_key_is_ignored — confirms key passed to __setitem__ is not used
-  test_update_uses_object_name — confirms object's own name is used
-  test_update_recorded in TestNMObjectContainerCommandHistory
-  Run python3 -m pytest tests/test_core/test_nm_object_container.py tests/test_core/test_nm_folder.py -q — 405 tests pass

Closes #239