### PR TITLE
feat(core): add smooth operation (boxcar, binomial, Savitzky-Golay)

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_folder import NMFolder
+import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_math as nm_math
 import pyneuromatic.core.nm_utilities as nmu
 
@@ -1263,6 +1264,137 @@ class NMMainOpBaseline(NMMainOp):
     def _op_params_str(self) -> str:
         return "x0=%r, x1=%r, mode=%r, ignore_nans=%r" % (
             self._x0, self._x1, self._mode, self._ignore_nans)
+
+
+# =========================================================================
+# Smooth
+# =========================================================================
+
+_VALID_SMOOTH_METHODS: frozenset[str] = frozenset({"boxcar", "binomial", "savgol"})
+
+
+class NMMainOpSmooth(NMMainOp):
+    """Smooth each selected array in-place: boxcar, binomial, or Savitzky-Golay.
+
+    Uses shared pure functions from :mod:`pyneuromatic.core.nm_math`.
+    Edge effects at both ends of each array (half a window-width of points)
+    are an inherent property of ``np.convolve`` with ``mode='same'``.
+
+    Parameters:
+        method: ``"boxcar"``, ``"binomial"``, or ``"savgol"``. Default ``"boxcar"``.
+        window: Kernel width in points (odd int >= 3). Used by boxcar and savgol.
+            Not used by binomial. Default 5.
+        passes: Number of times to apply the kernel (int >= 1). Default 1.
+            Used by boxcar and binomial; ignored by savgol.
+        polyorder: Polynomial order for savgol (int >= 1, < window). Default 2.
+    """
+
+    name = "smooth"
+
+    def __init__(
+        self,
+        method: str = "boxcar",
+        window: int = 5,
+        passes: int = 1,
+        polyorder: int = 2,
+    ) -> None:
+        self.method = method
+        self.window = window
+        self.passes = passes
+        self.polyorder = polyorder
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def method(self) -> str:
+        """Smooth method: ``'boxcar'``, ``'binomial'``, or ``'savgol'``."""
+        return self._method
+
+    @method.setter
+    def method(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "method", "string"))
+        if value not in _VALID_SMOOTH_METHODS:
+            raise ValueError(
+                "method must be one of %s, got %r"
+                % (sorted(_VALID_SMOOTH_METHODS), value)
+            )
+        self._method = value
+
+    @property
+    def window(self) -> int:
+        """Kernel width in points (odd int >= 3). Used by boxcar and savgol."""
+        return self._window
+
+    @window.setter
+    def window(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "window", "int"))
+        if value < 3:
+            raise ValueError("window must be >= 3, got %d" % value)
+        if value % 2 == 0:
+            raise ValueError("window must be odd, got %d" % value)
+        self._window = value
+
+    @property
+    def passes(self) -> int:
+        """Number of times to apply the kernel (int >= 1). Used by boxcar and binomial."""
+        return self._passes
+
+    @passes.setter
+    def passes(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "passes", "int"))
+        if value < 1:
+            raise ValueError("passes must be >= 1, got %d" % value)
+        self._passes = value
+
+    @property
+    def polyorder(self) -> int:
+        """Polynomial order for savgol (int >= 1, < window)."""
+        return self._polyorder
+
+    @polyorder.setter
+    def polyorder(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "polyorder", "int"))
+        if value < 1:
+            raise ValueError("polyorder must be >= 1, got %d" % value)
+        self._polyorder = value
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Smooth *data* in-place."""
+        import pyneuromatic.core.nm_math as nm_math
+        y = data.nparray
+        if y is None:
+            return
+        if self._method == "savgol" and self._passes > 1:
+            nmh.history(
+                "passes=%d ignored for savgol; savgol is applied once" % self._passes,
+                title="ALERT",
+                red=True,
+            )
+        if self._method == "boxcar":
+            data.nparray = nm_math.smooth_boxcar(y, self._window, self._passes)
+        elif self._method == "binomial":
+            data.nparray = nm_math.smooth_binomial(y, self._passes)
+        else:  # savgol
+            data.nparray = nm_math.smooth_savgol(y, self._window, self._polyorder)
+        self._add_op_note(data)
+
+    def _op_params_str(self) -> str:
+        effective_passes = 1 if self._method == "savgol" else self._passes
+        return "method=%r, window=%r, passes=%r, polyorder=%r" % (
+            self._method, self._window, effective_passes, self._polyorder
+        )
 
 
 # =========================================================================
@@ -2849,6 +2981,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "rescale_x": NMMainOpRescaleX,
     "reverse": NMMainOpReverse,
     "rotate": NMMainOpRotate,
+    "smooth": NMMainOpSmooth,
     "sum": NMMainOpSum,
     "sum_sqr": NMMainOpSumSqr,
 }

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -669,3 +669,124 @@ def linear_regression(
     m, b = np.polyfit(xarray, yarray, deg=1)
 
     return (m, b)
+
+
+# =========================================================================
+# Smooth functions
+# =========================================================================
+
+_VALID_SMOOTH_METHODS: frozenset[str] = frozenset({"boxcar", "binomial", "savgol"})
+
+
+def smooth_boxcar(
+    y: np.ndarray,
+    window: int,
+    passes: int = 1,
+) -> np.ndarray:
+    """Boxcar (moving average) smooth via ``np.convolve``.
+
+    Args:
+        y: 1-D numpy array of y-values.
+        window: Kernel width in points. Must be an odd integer >= 3.
+        passes: Number of times to apply the kernel. Must be >= 1. Default 1.
+
+    Returns:
+        Smoothed copy of *y* with the same length (``mode='same'``).
+
+    Raises:
+        TypeError: If *y* is not a numpy ndarray, or *window*/*passes* are
+            not integers (bool rejected).
+        ValueError: If *window* is not odd, < 3, or *passes* < 1.
+    """
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+    if isinstance(window, bool) or not isinstance(window, int):
+        raise TypeError(nmu.type_error_str(window, "window", "int"))
+    if window < 3:
+        raise ValueError("window must be >= 3, got %d" % window)
+    if window % 2 == 0:
+        raise ValueError("window must be odd, got %d" % window)
+    if isinstance(passes, bool) or not isinstance(passes, int):
+        raise TypeError(nmu.type_error_str(passes, "passes", "int"))
+    if passes < 1:
+        raise ValueError("passes must be >= 1, got %d" % passes)
+    kernel = np.ones(window) / window
+    result = y.copy().astype(float)
+    for _ in range(passes):
+        result = np.convolve(result, kernel, mode='same')
+    return result
+
+
+def smooth_binomial(
+    y: np.ndarray,
+    passes: int = 1,
+) -> np.ndarray:
+    """Binomial smooth: apply 3-point binomial kernel via ``np.convolve``.
+
+    Args:
+        y: 1-D numpy array of y-values.
+        passes: Number of times to apply the 3-point binomial kernel.
+            Must be >= 1. More passes produce a wider effective smooth.
+
+    Returns:
+        Smoothed copy of *y* with the same length (``mode='same'``).
+
+    Raises:
+        TypeError: If *y* is not a numpy ndarray, or *passes* is not an
+            integer (bool rejected).
+        ValueError: If *passes* < 1.
+    """
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+    if isinstance(passes, bool) or not isinstance(passes, int):
+        raise TypeError(nmu.type_error_str(passes, "passes", "int"))
+    if passes < 1:
+        raise ValueError("passes must be >= 1, got %d" % passes)
+    kernel = np.array([0.25, 0.5, 0.25]) # 3-point binomial filter
+    result = y.copy().astype(float)
+    for _ in range(passes):
+        result = np.convolve(result, kernel, mode='same')
+    return result
+
+
+def smooth_savgol(
+    y: np.ndarray,
+    window: int,
+    polyorder: int = 2,
+) -> np.ndarray:
+    """Savitzky-Golay smooth via ``scipy.signal.savgol_filter``.
+
+    Args:
+        y: 1-D numpy array of y-values.
+        window: Kernel width in points. Must be an odd integer and
+            >= *polyorder* + 2.
+        polyorder: Polynomial order. Must be an integer >= 1 and
+            < *window*. Default 2.
+
+    Returns:
+        Smoothed copy of *y* with the same length.
+
+    Raises:
+        TypeError: If *y* is not a numpy ndarray, or any numeric
+            parameter is not an integer (bool rejected).
+        ValueError: If *window* is not odd, too small, or *polyorder* is
+            out of range.
+    """
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+    if isinstance(window, bool) or not isinstance(window, int):
+        raise TypeError(nmu.type_error_str(window, "window", "int"))
+    if window < 3:
+        raise ValueError("window must be >= 3, got %d" % window)
+    if window % 2 == 0:
+        raise ValueError("window must be odd, got %d" % window)
+    if isinstance(polyorder, bool) or not isinstance(polyorder, int):
+        raise TypeError(nmu.type_error_str(polyorder, "polyorder", "int"))
+    if polyorder < 1:
+        raise ValueError("polyorder must be >= 1, got %d" % polyorder)
+    if polyorder >= window:
+        raise ValueError(
+            "polyorder (%d) must be < window (%d)" % (polyorder, window)
+        )
+    from scipy.signal import savgol_filter
+    return savgol_filter(y.copy().astype(float), window, polyorder)

--- a/pyneuromatic/core/nm_transform.py
+++ b/pyneuromatic/core/nm_transform.py
@@ -29,6 +29,7 @@ import copy
 import numpy as np
 
 from pyneuromatic.core.nm_scale import NMScaleX
+import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_utilities as nmu
 
 
@@ -228,6 +229,155 @@ class NMTransformLn(NMTransform):
 
 
 # =========================================================================
+# Smooth transform
+# =========================================================================
+
+_VALID_SMOOTH_METHODS: frozenset[str] = frozenset({"boxcar", "binomial", "savgol"})
+
+
+class NMTransformSmooth(NMTransform):
+    """Smooth transform: boxcar, binomial, or Savitzky-Golay (polynomial).
+
+    Applies the chosen smooth method to y-data via the shared pure functions
+    in :mod:`pyneuromatic.core.nm_math`.
+
+    Args:
+        method: ``"boxcar"``, ``"binomial"``, or ``"savgol"``. Default ``"boxcar"``.
+        window: Kernel width in points (odd int >= 3). Used by boxcar and savgol.
+            Default 5.
+        passes: Number of times to apply the kernel (int >= 1). Default 1.
+            Used by boxcar and binomial; ignored by savgol.
+        polyorder: Polynomial order for savgol (int >= 1, < window). Default 2.
+    """
+
+    def __init__(
+        self,
+        parent: object | None = None,
+        method: str = "boxcar",
+        window: int = 5,
+        passes: int = 1,
+        polyorder: int = 2,
+    ) -> None:
+        super().__init__(parent=parent)
+        self.method = method
+        self.window = window
+        self.passes = passes
+        self.polyorder = polyorder
+
+    def __repr__(self) -> str:
+        return (
+            "%s(method=%r, window=%r, passes=%r, polyorder=%r)"
+            % (self.__class__.__name__, self._method, self._window,
+               self._passes, self._polyorder)
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, NMTransformSmooth):
+            return (
+                self._method == other._method
+                and self._window == other._window
+                and self._passes == other._passes
+                and self._polyorder == other._polyorder
+            )
+        if isinstance(other, dict):
+            return self.to_dict() == other
+        return NotImplemented
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def method(self) -> str:
+        """Smooth method: ``'boxcar'``, ``'binomial'``, or ``'savgol'``."""
+        return self._method
+
+    @method.setter
+    def method(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "method", "string"))
+        if value not in _VALID_SMOOTH_METHODS:
+            raise ValueError(
+                "method must be one of %s, got %r"
+                % (sorted(_VALID_SMOOTH_METHODS), value)
+            )
+        self._method = value
+
+    @property
+    def window(self) -> int:
+        """Kernel width in points (odd int >= 3). Used by boxcar and savgol."""
+        return self._window
+
+    @window.setter
+    def window(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "window", "int"))
+        if value < 3:
+            raise ValueError("window must be >= 3, got %d" % value)
+        if value % 2 == 0:
+            raise ValueError("window must be odd, got %d" % value)
+        self._window = value
+
+    @property
+    def passes(self) -> int:
+        """Number of times to apply the kernel (int >= 1). Used by boxcar and binomial."""
+        return self._passes
+
+    @passes.setter
+    def passes(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "passes", "int"))
+        if value < 1:
+            raise ValueError("passes must be >= 1, got %d" % value)
+        self._passes = value
+
+    @property
+    def polyorder(self) -> int:
+        """Polynomial order for savgol (int >= 1, < window)."""
+        return self._polyorder
+
+    @polyorder.setter
+    def polyorder(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "polyorder", "int"))
+        if value < 1:
+            raise ValueError("polyorder must be >= 1, got %d" % value)
+        self._polyorder = value
+
+    # ------------------------------------------------------------------
+    # Core
+
+    def apply(
+        self,
+        ydata: np.ndarray,
+        xscale: NMScaleX | None = None,
+    ) -> np.ndarray:
+        """Apply the smooth to *ydata* and return the result."""
+        import pyneuromatic.core.nm_math as nm_math
+        if self._method == "savgol" and self._passes > 1:
+            nmh.history(
+                "passes=%d ignored for savgol; savgol is applied once" % self._passes,
+                title="ALERT",
+                red=True,
+            )
+        if self._method == "boxcar":
+            return nm_math.smooth_boxcar(ydata, self._window, self._passes)
+        if self._method == "binomial":
+            return nm_math.smooth_binomial(ydata, self._passes)
+        # savgol
+        return nm_math.smooth_savgol(ydata, self._window, self._polyorder)
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d.update({
+            "method": self._method,
+            "window": self._window,
+            "passes": self._passes,
+            "polyorder": self._polyorder,
+        })
+        return d
+
+
+# =========================================================================
 # Registry and helper functions
 # =========================================================================
 
@@ -239,6 +389,7 @@ _TRANSFORM_REGISTRY: dict[str, type[NMTransform]] = {
     "NMTransformIntegrate": NMTransformIntegrate,
     "NMTransformLog": NMTransformLog,
     "NMTransformLn": NMTransformLn,
+    "NMTransformSmooth": NMTransformSmooth,
 }
 
 
@@ -268,7 +419,8 @@ def _transform_from_dict(
     if type_str not in _TRANSFORM_REGISTRY:
         raise ValueError("unknown transform type: '%s'" % type_str)
     cls = _TRANSFORM_REGISTRY[type_str]
-    return cls(parent=parent)
+    kwargs = {k: v for k, v in d.items() if k != "type"}
+    return cls(parent=parent, **kwargs)
 
 
 def _transforms_from_list(

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -40,6 +40,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpRescaleX,
     NMMainOpReverse,
     NMMainOpRotate,
+    NMMainOpSmooth,
     NMMainOpSum,
     NMMainOpSumSqr,
     op_from_name,
@@ -3354,6 +3355,115 @@ class TestToolMainOpLogging(unittest.TestCase):
         tool.op = "average"
         cmd = self._ch.buffer[0]["command"]
         self.assertIn("NMMainOpAverage", cmd)
+
+
+# =============================================================================
+# NMMainOpSmooth
+# =============================================================================
+
+
+class TestNMMainOpSmooth(unittest.TestCase):
+    """Tests for NMMainOpSmooth."""
+
+    def test_default_params(self):
+        op = NMMainOpSmooth()
+        self.assertEqual(op.method, "boxcar")
+        self.assertEqual(op.window, 5)
+        self.assertEqual(op.passes, 1)
+        self.assertEqual(op.polyorder, 2)
+
+    def test_rejects_invalid_method(self):
+        with self.assertRaises(ValueError):
+            NMMainOpSmooth(method="unknown")
+
+    def test_rejects_even_window(self):
+        with self.assertRaises(ValueError):
+            NMMainOpSmooth(window=4)
+
+    def test_rejects_window_lt3(self):
+        with self.assertRaises(ValueError):
+            NMMainOpSmooth(window=1)
+
+    def test_rejects_passes_zero(self):
+        with self.assertRaises(ValueError):
+            NMMainOpSmooth(passes=0)
+
+    def test_rejects_bool_window(self):
+        with self.assertRaises(TypeError):
+            NMMainOpSmooth(window=True)
+
+    def test_op_params_str(self):
+        op = NMMainOpSmooth(method="savgol", window=7, passes=2, polyorder=3)
+        s = op._op_params_str()
+        self.assertIn("'savgol'", s)
+        self.assertIn("7", s)
+        self.assertIn("3", s)
+        # passes is forced to 1 in the note for savgol
+        self.assertIn("passes=1", s)
+
+    def test_op_params_str_boxcar_passes(self):
+        op = NMMainOpSmooth(method="boxcar", window=5, passes=3)
+        s = op._op_params_str()
+        self.assertIn("passes=3", s)
+
+    def test_savgol_passes_gt1_runs_without_error(self):
+        # passes > 1 is silently ignored for savgol (nmh.history ALERT issued)
+        folder, _ = _make_folder_with_data({"RecordA0": list(np.linspace(0.0, 1.0, 20))})
+        d = folder.data.get("RecordA0")
+        op = NMMainOpSmooth(method="savgol", window=5, passes=3)
+        op.run(d)  # should not raise
+        self.assertEqual(len(d.nparray), 20)
+
+    def test_boxcar_run_modifies_in_place(self):
+        folder, _ = _make_folder_with_data({"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]})
+        d = folder.data.get("RecordA0")
+        original = d.nparray.copy()
+        op = NMMainOpSmooth(method="boxcar", window=3)
+        op.run(d)
+        self.assertEqual(len(d.nparray), len(original))
+        # centre points should be averaged
+        self.assertAlmostEqual(d.nparray[3], np.mean(original[2:5]))
+
+    def test_binomial_run_preserves_length(self):
+        folder, _ = _make_folder_with_data({"RecordA0": list(range(20))})
+        d = folder.data.get("RecordA0")
+        op = NMMainOpSmooth(method="binomial", passes=3)
+        op.run(d)
+        self.assertEqual(len(d.nparray), 20)
+
+    def test_savgol_run_preserves_linear(self):
+        y = list(np.linspace(0.0, 1.0, 20))
+        folder, _ = _make_folder_with_data({"RecordA0": y})
+        d = folder.data.get("RecordA0")
+        op = NMMainOpSmooth(method="savgol", window=5, polyorder=1)
+        op.run(d)
+        np.testing.assert_allclose(d.nparray, np.linspace(0.0, 1.0, 20), atol=1e-10)
+
+    def test_run_skips_none_array(self):
+        d = NMData(NM, name="empty")
+        op = NMMainOpSmooth()
+        op.run(d)  # should not raise
+
+    def test_run_adds_note(self):
+        folder, _ = _make_folder_with_data({"RecordA0": list(range(10))})
+        d = folder.data.get("RecordA0")
+        op = NMMainOpSmooth(method="boxcar", window=3)
+        op.run(d)
+        self.assertTrue(len(d.notes) > 0)
+
+    def test_op_from_name_smooth(self):
+        op = op_from_name("smooth")
+        self.assertIsInstance(op, NMMainOpSmooth)
+
+    def test_run_all_via_op_run_all(self):
+        folder = _op_run_all(
+            NMMainOpSmooth(method="boxcar", window=3),
+            {"RecordA0": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+             "RecordA1": [7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0]},
+        )
+        # index 3: mean([3,4,5]) = 4.0
+        np.testing.assert_allclose(folder.data.get("RecordA0").nparray[3], 4.0)
+        np.testing.assert_allclose(folder.data.get("RecordA1").nparray[3], 4.0)
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -530,3 +530,159 @@ class TestSiScaleFactor:
 
     def test_femto_to_base(self):
         assert si_scale_factor("fA", "A") == pytest.approx(1e-15)
+
+
+# =============================================================================
+# smooth_boxcar
+# =============================================================================
+
+
+class TestSmoothBoxcar:
+    def test_basic_output_length(self):
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = nm_math.smooth_boxcar(y, window=3)
+        assert len(result) == len(y)
+
+    def test_flat_signal_unchanged(self):
+        y = np.ones(10)
+        result = nm_math.smooth_boxcar(y, window=3)
+        np.testing.assert_allclose(result[1:-1], 1.0)
+
+    def test_window5_centre(self):
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+        result = nm_math.smooth_boxcar(y, window=5)
+        # centre point: mean of [2,3,4,5,6] = 4.0
+        assert result[3] == pytest.approx(4.0)
+
+    def test_returns_copy(self):
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = nm_math.smooth_boxcar(y, window=3)
+        result[2] = 999.0
+        assert y[2] == 3.0
+
+    def test_rejects_bool_window(self):
+        with pytest.raises(TypeError):
+            nm_math.smooth_boxcar(np.ones(5), window=True)
+
+    def test_rejects_even_window(self):
+        with pytest.raises(ValueError):
+            nm_math.smooth_boxcar(np.ones(5), window=4)
+
+    def test_rejects_window_lt3(self):
+        with pytest.raises(ValueError):
+            nm_math.smooth_boxcar(np.ones(5), window=1)
+
+    def test_passes_increases_smoothing(self):
+        y = np.zeros(21)
+        y[10] = 1.0
+        r1 = nm_math.smooth_boxcar(y, window=3, passes=1)
+        r3 = nm_math.smooth_boxcar(y, window=3, passes=3)
+        # more passes → more non-zero points around centre
+        assert np.count_nonzero(r3) > np.count_nonzero(r1)
+
+    def test_rejects_passes_zero(self):
+        with pytest.raises(ValueError):
+            nm_math.smooth_boxcar(np.ones(5), window=3, passes=0)
+
+    def test_rejects_non_array(self):
+        with pytest.raises(TypeError):
+            nm_math.smooth_boxcar([1.0, 2.0, 3.0], window=3)
+
+
+# =============================================================================
+# smooth_binomial
+# =============================================================================
+
+
+class TestSmoothBinomial:
+    def test_basic_output_length(self):
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = nm_math.smooth_binomial(y)
+        assert len(result) == len(y)
+
+    def test_flat_signal_unchanged(self):
+        y = np.ones(10)
+        result = nm_math.smooth_binomial(y, passes=1)
+        np.testing.assert_allclose(result[1:-1], 1.0)
+
+    def test_centre_point(self):
+        # [0,0,1,0,0] → after 1 pass centre should be 0.5
+        y = np.array([0.0, 0.0, 1.0, 0.0, 0.0])
+        result = nm_math.smooth_binomial(y, passes=1)
+        assert result[2] == pytest.approx(0.5)
+
+    def test_passes_spreads_impulse(self):
+        # More passes spread a central impulse over more points
+        y = np.zeros(21)
+        y[10] = 1.0
+        r1 = nm_math.smooth_binomial(y, passes=1)
+        r5 = nm_math.smooth_binomial(y, passes=5)
+        # More passes → more non-zero points around centre
+        nonzero1 = np.count_nonzero(r1)
+        nonzero5 = np.count_nonzero(r5)
+        assert nonzero5 > nonzero1
+
+    def test_returns_copy(self):
+        y = np.array([1.0, 2.0, 3.0])
+        result = nm_math.smooth_binomial(y)
+        result[1] = 999.0
+        assert y[1] == 2.0
+
+    def test_rejects_bool_passes(self):
+        with pytest.raises(TypeError):
+            nm_math.smooth_binomial(np.ones(5), passes=True)
+
+    def test_rejects_passes_zero(self):
+        with pytest.raises(ValueError):
+            nm_math.smooth_binomial(np.ones(5), passes=0)
+
+    def test_rejects_non_array(self):
+        with pytest.raises(TypeError):
+            nm_math.smooth_binomial([1.0, 2.0, 3.0])
+
+
+# =============================================================================
+# smooth_savgol
+# =============================================================================
+
+
+class TestSmoothSavgol:
+    def test_basic_output_length(self):
+        y = np.linspace(0, 1, 20)
+        result = nm_math.smooth_savgol(y, window=5)
+        assert len(result) == len(y)
+
+    def test_linear_signal_preserved(self):
+        y = np.linspace(0.0, 1.0, 20)
+        result = nm_math.smooth_savgol(y, window=5, polyorder=1)
+        np.testing.assert_allclose(result, y, atol=1e-10)
+
+    def test_returns_copy(self):
+        y = np.linspace(0.0, 1.0, 20)
+        result = nm_math.smooth_savgol(y, window=5)
+        result[5] = 999.0
+        assert y[5] != 999.0
+
+    def test_rejects_even_window(self):
+        with pytest.raises(ValueError):
+            nm_math.smooth_savgol(np.ones(10), window=4)
+
+    def test_rejects_window_lt3(self):
+        with pytest.raises(ValueError):
+            nm_math.smooth_savgol(np.ones(10), window=1)
+
+    def test_rejects_polyorder_gte_window(self):
+        with pytest.raises(ValueError):
+            nm_math.smooth_savgol(np.ones(10), window=5, polyorder=5)
+
+    def test_rejects_polyorder_zero(self):
+        with pytest.raises(ValueError):
+            nm_math.smooth_savgol(np.ones(10), window=5, polyorder=0)
+
+    def test_rejects_bool_window(self):
+        with pytest.raises(TypeError):
+            nm_math.smooth_savgol(np.ones(10), window=True)
+
+    def test_rejects_non_array(self):
+        with pytest.raises(TypeError):
+            nm_math.smooth_savgol([1.0, 2.0, 3.0], window=3)

--- a/tests/test_core/test_nm_transform.py
+++ b/tests/test_core/test_nm_transform.py
@@ -14,6 +14,7 @@ from pyneuromatic.core.nm_transform import (
     NMTransformIntegrate,
     NMTransformLog,
     NMTransformLn,
+    NMTransformSmooth,
     _transform_from_dict,
     _transforms_from_list,
     apply_transforms,
@@ -379,6 +380,86 @@ class TestApplyTransforms(unittest.TestCase):
         result = apply_transforms(y, [NMTransformDifferentiate()], xscale=xs)
         # dy/dx = 1/0.5 = 2.0
         np.testing.assert_allclose(result, 2.0)
+
+
+class TestNMTransformSmooth(unittest.TestCase):
+    """Tests for NMTransformSmooth."""
+
+    def setUp(self):
+        self.y = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0])
+
+    def test_default_params(self):
+        t = NMTransformSmooth()
+        self.assertEqual(t.method, "boxcar")
+        self.assertEqual(t.window, 5)
+        self.assertEqual(t.passes, 1)
+        self.assertEqual(t.polyorder, 2)
+
+    def test_boxcar_output_length(self):
+        t = NMTransformSmooth(method="boxcar", window=3)
+        result = t.apply(self.y)
+        self.assertEqual(len(result), len(self.y))
+
+    def test_binomial_output_length(self):
+        t = NMTransformSmooth(method="binomial")
+        result = t.apply(self.y)
+        self.assertEqual(len(result), len(self.y))
+
+    def test_savgol_output_length(self):
+        t = NMTransformSmooth(method="savgol", window=5, polyorder=2)
+        result = t.apply(self.y)
+        self.assertEqual(len(result), len(self.y))
+
+    def test_flat_signal_boxcar(self):
+        t = NMTransformSmooth(method="boxcar", window=3)
+        y = np.ones(10)
+        result = t.apply(y)
+        np.testing.assert_allclose(result[1:-1], 1.0)
+
+    def test_to_dict(self):
+        t = NMTransformSmooth(method="savgol", window=7, passes=2, polyorder=3)
+        d = t.to_dict()
+        self.assertEqual(d["type"], "NMTransformSmooth")
+        self.assertEqual(d["method"], "savgol")
+        self.assertEqual(d["window"], 7)
+        self.assertEqual(d["passes"], 2)
+        self.assertEqual(d["polyorder"], 3)
+
+    def test_equality(self):
+        t1 = NMTransformSmooth(method="boxcar", window=5)
+        t2 = NMTransformSmooth(method="boxcar", window=5)
+        t3 = NMTransformSmooth(method="binomial")
+        self.assertEqual(t1, t2)
+        self.assertNotEqual(t1, t3)
+
+    def test_from_dict_registered(self):
+        t = NMTransformSmooth(method="binomial", passes=3)
+        d = t.to_dict()
+        t2 = _transform_from_dict(d)
+        self.assertIsInstance(t2, NMTransformSmooth)
+
+    def test_rejects_invalid_method(self):
+        with self.assertRaises(ValueError):
+            NMTransformSmooth(method="unknown")
+
+    def test_rejects_even_window(self):
+        with self.assertRaises(ValueError):
+            NMTransformSmooth(window=4)
+
+    def test_rejects_bool_passes(self):
+        with self.assertRaises(TypeError):
+            NMTransformSmooth(passes=True)
+
+    def test_savgol_passes_gt1_runs_without_error(self):
+        # passes > 1 is silently ignored for savgol (nmh.history ALERT issued)
+        t = NMTransformSmooth(method="savgol", window=5, passes=3)
+        result = t.apply(self.y)
+        self.assertEqual(len(result), len(self.y))
+
+    def test_repr(self):
+        t = NMTransformSmooth(method="boxcar", window=5, passes=1, polyorder=2)
+        self.assertIn("NMTransformSmooth", repr(t))
+        self.assertIn("boxcar", repr(t))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `smooth_boxcar()`, `smooth_binomial()`, `smooth_savgol()` pure functions to `nm_math.py`
- Adds `NMTransformSmooth` for real-time display transforms (consistent with other `NMTransform` subclasses)
- Adds `NMMainOpSmooth` permanent batch operation, registered as `"smooth"` in `_OP_REGISTRY`

## Notes
- `passes` applies to boxcar and binomial (Igor NeuroMatic convention); savgol applies once
- If `passes > 1` with savgol, an ALERT is issued via `nmh.history()` and op note records `passes=1`
- Shared math in `nm_math.py` — both `NMTransformSmooth` and `NMMainOpSmooth` delegate to the same pure functions
- SciPy (`savgol_filter`) is already a core dependency; import is lazy (inside `smooth_savgol`)

## Test plan
- [ ] `tests/test_core/test_nm_math.py` — `TestSmoothBoxcar`, `TestSmoothBinomial`, `TestSmoothSavgol`
- [ ] `tests/test_core/test_nm_transform.py` — `TestNMTransformSmooth`
- [ ] `tests/test_analysis/test_nm_tool_main.py` — `TestNMMainOpSmooth`

Closes #242
