### PR TITLE
feat(core): extract histogram, ks_test, stability_test to nm_math.py

### DIFF
--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -765,19 +765,16 @@ class NMToolStats2:
         if not isinstance(d.nparray, np.ndarray):
             raise ValueError("array has no nparray: %s" % name)
 
-        arr = d.nparray
-        arr = arr[np.isfinite(arr)]  # exclude NaN and Inf
-
-        counts, edges = np.histogram(arr, bins=bins, range=xrange,
-                                     density=density)
+        result = nm_math.histogram(d.nparray, bins=bins, xrange=xrange,
+                                   density=density)
 
         if save_to_numpy:
-            # x-scaling: left edge of first bin, uniform bin width
+            edges = result["edges"]
             xscale = {"start": float(edges[0]),
                       "delta": float(edges[1] - edges[0])}
             toolfolder.data.new(
                 "H_%s_counts" % name,
-                nparray=counts.astype(float),
+                nparray=result["counts"].astype(float),
                 xscale=xscale,
             )
             toolfolder.data.new(
@@ -785,7 +782,7 @@ class NMToolStats2:
                 nparray=edges,
             )
 
-        return {"counts": counts, "edges": edges}
+        return result
 
     @staticmethod
     def inequality(
@@ -1016,8 +1013,6 @@ class NMToolStats2:
             ValueError: If the named array has no nparray data.
             ImportError: If scipy is not installed.
         """
-        from scipy.stats import ks_2samp  # noqa: PLC0415
-
         if not isinstance(toolfolder, NMToolFolder):
             raise TypeError(
                 nmu.type_error_str(toolfolder, "toolfolder", "NMToolFolder")
@@ -1039,36 +1034,17 @@ class NMToolStats2:
         if not isinstance(d2.nparray, np.ndarray):
             raise ValueError("array has no nparray: %s" % name2)
 
-        # Strip NaN/Inf
-        arr1 = d1.nparray.astype(float)
-        arr2 = d2.nparray.astype(float)
-        arr1 = arr1[np.isfinite(arr1)]
-        arr2 = arr2[np.isfinite(arr2)]
-
-        stat, pvalue = ks_2samp(arr1, arr2, method=method)
-
-        significant = bool(pvalue <= alpha)
-        message = "different populations" if significant else "same population"
+        result = nm_math.ks_test(d1.nparray, d2.nparray, alpha=alpha,
+                                 method=method)
 
         if save_to_numpy and toolfolder.data is not None:
-            sort1 = np.sort(arr1)
-            prob1 = np.arange(1, len(sort1) + 1) / len(sort1)
-            sort2 = np.sort(arr2)
-            prob2 = np.arange(1, len(sort2) + 1) / len(sort2)
-            toolfolder.data.new("KS_%s_sort" % name1, nparray=sort1)
-            toolfolder.data.new("KS_%s_ecdf" % name1, nparray=prob1)
-            toolfolder.data.new("KS_%s_sort" % name2, nparray=sort2)
-            toolfolder.data.new("KS_%s_ecdf" % name2, nparray=prob2)
+            toolfolder.data.new("KS_%s_sort" % name1, nparray=result["sort1"])
+            toolfolder.data.new("KS_%s_ecdf" % name1, nparray=result["ecdf1"])
+            toolfolder.data.new("KS_%s_sort" % name2, nparray=result["sort2"])
+            toolfolder.data.new("KS_%s_ecdf" % name2, nparray=result["ecdf2"])
 
-        return {
-            "d":           float(stat),
-            "pvalue":      float(pvalue),
-            "alpha":       float(alpha),
-            "significant": significant,
-            "message":     message,
-            "n1":          int(len(arr1)),
-            "n2":          int(len(arr2)),
-        }
+        return {k: result[k] for k in
+                ("d", "pvalue", "alpha", "significant", "message", "n1", "n2")}
 
     @staticmethod
     def stability_test(
@@ -1129,10 +1105,6 @@ class NMToolStats2:
             ValueError: If the array has no data, or min_window is out of
                 range.
         """
-        import warnings  # noqa: PLC0415
-
-        from scipy.stats import spearmanr  # noqa: PLC0415
-
         if not isinstance(toolfolder, NMToolFolder):
             raise TypeError(
                 nmu.type_error_str(toolfolder, "toolfolder", "NMToolFolder")
@@ -1146,84 +1118,17 @@ class NMToolStats2:
         if not isinstance(d.nparray, np.ndarray):
             raise ValueError("array has no nparray: %s" % name)
 
-        arr = d.nparray.astype(float)
-        finite_mask = np.isfinite(arr)
-        finite_idx = np.where(finite_mask)[0]  # original positions of valid points
-        arr_clean = arr[finite_mask]
-        n = len(arr_clean)
-
-        if min_window < 3:
-            raise ValueError("min_window must be >= 3, got %d" % min_window)
-        if min_window > n:
-            raise ValueError(
-                "min_window (%d) > available data points (%d)" % (min_window, n)
-            )
-
-        # Sliding-window Spearman search: largest window first
-        best_start: int | None = None
-        best_size: int = 0
-        best_rs: float | None = None
-        best_pvalue: float = 0.0
-
-        for w in range(n, min_window - 1, -1):
-            for i in range(n - w + 1):
-                x = np.arange(i, i + w, dtype=float)
-                y = arr_clean[i: i + w]
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore")
-                    rs, pvalue = spearmanr(x, y)
-                # Constant y → spearmanr returns NaN for both rs and pvalue
-                # (ConstantInputWarning); no trend by definition → treat as
-                # perfectly stable.  NaN pvalue with valid rs (e.g. w=2 with
-                # non-constant data) → cannot assess stability → skip.
-                if math.isnan(rs):
-                    rs, pvalue = 0.0, 1.0
-                elif math.isnan(pvalue):
-                    continue
-                if pvalue > alpha and pvalue > best_pvalue:
-                    best_start = i
-                    best_size = w
-                    best_rs = float(rs)
-                    best_pvalue = float(pvalue)
-            if best_start is not None:
-                break  # largest stable window found; stop shrinking
-
-        mask = np.zeros(len(arr), dtype=bool)
-
-        if best_start is None:
-            return {
-                "stable":  False,
-                "start":   None,
-                "end":     None,
-                "n":       None,
-                "rs":      None,
-                "pvalue":  None,
-                "alpha":   float(alpha),
-                "mask":    mask,
-            }
-
-        best_end = best_start + best_size - 1
-        orig_start = int(finite_idx[best_start])
-        orig_end = int(finite_idx[best_end])
-        mask[finite_idx[best_start: best_end + 1]] = True
+        result = nm_math.stability_test(d.nparray, alpha=alpha,
+                                        min_window=min_window)
 
         if save_to_numpy and toolfolder.data is not None:
-            toolfolder.data.new("STAB_%s_mask" % name, nparray=mask.astype(float))
+            toolfolder.data.new("STAB_%s_mask" % name,
+                                nparray=result["mask"].astype(float))
 
-        # Create epoch set if dataseries and set name are given
         if isinstance(dataseries, NMDataSeries) and set_name_stable:
             NMToolStats2._add_epoch_sets_from_mask(
-                toolfolder, name, dataseries, mask,
+                toolfolder, name, dataseries, result["mask"],
                 set_name_true=set_name_stable,
             )
 
-        return {
-            "stable":  True,
-            "start":   orig_start,
-            "end":     orig_end,
-            "n":       best_size,
-            "rs":      best_rs,
-            "pvalue":  best_pvalue,
-            "alpha":   float(alpha),
-            "mask":    mask,
-        }
+        return result

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -790,3 +790,237 @@ def smooth_savgol(
         )
     from scipy.signal import savgol_filter
     return savgol_filter(y.copy().astype(float), window, polyorder)
+
+
+# =========================================================================
+# Stats functions
+# =========================================================================
+
+
+def histogram(
+    y: np.ndarray,
+    bins: int | list = 10,
+    xrange: tuple | None = None,
+    density: bool = False,
+) -> dict:
+    """Compute a histogram of a 1-D array, excluding NaN and Inf values.
+
+    Args:
+        y: 1-D numpy array of values.
+        bins: Number of equal-width bins (int) or explicit bin edges (list).
+            Default 10.
+        xrange: ``(min, max)`` tuple to restrict the data range. Default None
+            (full data range).
+        density: If True, return probability density instead of counts.
+            Default False.
+
+    Returns:
+        Dict with keys:
+
+        - ``"counts"``: bin counts or density values (numpy array).
+        - ``"edges"``: bin edge values, length = bins + 1 (numpy array).
+
+    Raises:
+        TypeError: If *y* is not a numpy ndarray.
+    """
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+    arr = y.astype(float)
+    arr = arr[np.isfinite(arr)]
+    counts, edges = np.histogram(arr, bins=bins, range=xrange, density=density)
+    return {"counts": counts, "edges": edges}
+
+
+def ks_test(
+    y1: np.ndarray,
+    y2: np.ndarray,
+    alpha: float = 0.05,
+    method: str = "auto",
+) -> dict:
+    """Two-sample Kolmogorov-Smirnov test on two 1-D arrays.
+
+    NaN and Inf values are excluded before testing, matching the Igor
+    ``NMKSTest()`` behaviour of removing NaNs before sorting.
+
+    This mirrors the Igor NeuroMatic ``NMKSTest()`` function
+    (``NM_StatsTabKolmogorov.ipf``), originally written by Dr. Angus
+    Silver (UCL) based on *Numerical Recipes*.
+
+    Args:
+        y1: First 1-D numpy array of values.
+        y2: Second 1-D numpy array of values.
+        alpha: Significance level; ``significant`` is True when
+            ``pvalue <= alpha``. Default 0.05.
+        method: P-value calculation method forwarded to
+            ``scipy.stats.ks_2samp``. One of ``"auto"`` (default),
+            ``"exact"``, or ``"asymp"``.
+
+    Returns:
+        Dict with keys:
+
+        - ``"d"``: KS statistic — max |CDF1 - CDF2|.
+        - ``"pvalue"``: p-value.
+        - ``"alpha"``: significance level (echoed from param).
+        - ``"significant"``: True if ``pvalue <= alpha``.
+        - ``"message"``: ``"different populations"`` or ``"same population"``.
+        - ``"n1"``: sample size of y1 after NaN/Inf removal.
+        - ``"n2"``: sample size of y2 after NaN/Inf removal.
+        - ``"sort1"``: sorted finite values of y1 (for empirical CDF).
+        - ``"ecdf1"``: empirical CDF values for y1.
+        - ``"sort2"``: sorted finite values of y2 (for empirical CDF).
+        - ``"ecdf2"``: empirical CDF values for y2.
+
+    Raises:
+        TypeError: If *y1* or *y2* are not numpy ndarrays.
+        ImportError: If scipy is not installed.
+    """
+    from scipy.stats import ks_2samp  # noqa: PLC0415
+
+    if not isinstance(y1, np.ndarray):
+        raise TypeError(nmu.type_error_str(y1, "y1", "numpy.ndarray"))
+    if not isinstance(y2, np.ndarray):
+        raise TypeError(nmu.type_error_str(y2, "y2", "numpy.ndarray"))
+    arr1 = y1.astype(float)
+    arr2 = y2.astype(float)
+    arr1 = arr1[np.isfinite(arr1)]
+    arr2 = arr2[np.isfinite(arr2)]
+    stat, pvalue = ks_2samp(arr1, arr2, method=method)
+    significant = bool(pvalue <= alpha)
+    sort1 = np.sort(arr1)
+    ecdf1 = np.arange(1, len(sort1) + 1) / len(sort1)
+    sort2 = np.sort(arr2)
+    ecdf2 = np.arange(1, len(sort2) + 1) / len(sort2)
+    return {
+        "d":           float(stat),
+        "pvalue":      float(pvalue),
+        "alpha":       float(alpha),
+        "significant": significant,
+        "message":     "different populations" if significant else "same population",
+        "n1":          int(len(arr1)),
+        "n2":          int(len(arr2)),
+        "sort1":       sort1,
+        "ecdf1":       ecdf1,
+        "sort2":       sort2,
+        "ecdf2":       ecdf2,
+    }
+
+
+def stability_test(
+    y: np.ndarray,
+    alpha: float = 0.05,
+    min_window: int = 10,
+) -> dict:
+    """Find the largest stable (trend-free) window in a 1-D array.
+
+    Tests whether consecutive subsets of values have no significant monotonic
+    trend over time using the Spearman rank-order correlation between values
+    and their array indices. Searches from the largest possible window down to
+    ``min_window``, stopping as soon as the largest stable window is found.
+
+    This mirrors the Igor NeuroMatic ``NMStabilityRankOrderTest()`` function
+    (``NM_StatsTabStability.ipf``, pass 1 only), originally written by
+    Dr. Angus Silver and Simon Mitchell (UCL), based on *Numerical Recipes in C*.
+
+    NaN and Inf values are excluded before the search; returned indices
+    (``start``, ``end``) refer to positions in the original array *y*.
+
+    Args:
+        y: 1-D numpy array of values.
+        alpha: Significance level. A window is "stable" when its Spearman
+            p-value exceeds this threshold. Default 0.05.
+        min_window: Minimum window size in data points. Must be >= 3 (scipy
+            requires at least 3 points to compute a p-value for non-constant
+            data). Default 10.
+
+    Returns:
+        Dict with keys:
+
+        - ``"stable"``: True if a stable region was found.
+        - ``"start"``: Index into original *y* of first stable point, or None.
+        - ``"end"``: Index into original *y* of last stable point
+          (inclusive), or None.
+        - ``"n"``: Window size (``end - start + 1``), or None.
+        - ``"rs"``: Spearman rs at best window, or None.
+        - ``"pvalue"``: p-value at best window, or None.
+        - ``"alpha"``: significance level (echoed from param).
+        - ``"mask"``: Boolean numpy array (length = len(y)), True where the
+          stable region falls.
+
+    Raises:
+        TypeError: If *y* is not a numpy ndarray.
+        ValueError: If *min_window* < 3 or > number of finite data points.
+        ImportError: If scipy is not installed.
+    """
+    import warnings  # noqa: PLC0415
+
+    from scipy.stats import spearmanr  # noqa: PLC0415
+
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+
+    arr = y.astype(float)
+    finite_mask = np.isfinite(arr)
+    finite_idx = np.where(finite_mask)[0]
+    arr_clean = arr[finite_mask]
+    n = len(arr_clean)
+
+    if min_window < 3:
+        raise ValueError("min_window must be >= 3, got %d" % min_window)
+    if min_window > n:
+        raise ValueError(
+            "min_window (%d) > available data points (%d)" % (min_window, n)
+        )
+
+    best_start: int | None = None
+    best_size: int = 0
+    best_rs: float | None = None
+    best_pvalue: float = 0.0
+
+    for w in range(n, min_window - 1, -1):
+        for i in range(n - w + 1):
+            x = np.arange(i, i + w, dtype=float)
+            ywin = arr_clean[i: i + w]
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                rs, pvalue = spearmanr(x, ywin)
+            if math.isnan(rs):
+                rs, pvalue = 0.0, 1.0
+            elif math.isnan(pvalue):
+                continue
+            if pvalue > alpha and pvalue > best_pvalue:
+                best_start = i
+                best_size = w
+                best_rs = float(rs)
+                best_pvalue = float(pvalue)
+        if best_start is not None:
+            break
+
+    mask = np.zeros(len(arr), dtype=bool)
+
+    if best_start is None:
+        return {
+            "stable":  False,
+            "start":   None,
+            "end":     None,
+            "n":       None,
+            "rs":      None,
+            "pvalue":  None,
+            "alpha":   float(alpha),
+            "mask":    mask,
+        }
+
+    best_end = best_start + best_size - 1
+    orig_start = int(finite_idx[best_start])
+    orig_end = int(finite_idx[best_end])
+    mask[finite_idx[best_start: best_end + 1]] = True
+
+    return {
+        "stable":  True,
+        "start":   orig_start,
+        "end":     orig_end,
+        "n":       best_size,
+        "rs":      best_rs,
+        "pvalue":  best_pvalue,
+        "alpha":   float(alpha),
+        "mask":    mask,
+    }

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -803,7 +803,7 @@ def histogram(
     xrange: tuple | None = None,
     density: bool = False,
 ) -> dict:
-    """Compute a histogram of a 1-D array, excluding NaN and Inf values.
+    """Thin wrapper around ``np.histogram`` that excludes NaN and Inf values.
 
     Args:
         y: 1-D numpy array of values.
@@ -844,7 +844,8 @@ def ks_test(
 
     This mirrors the Igor NeuroMatic ``NMKSTest()`` function
     (``NM_StatsTabKolmogorov.ipf``), originally written by Dr. Angus
-    Silver (UCL) based on *Numerical Recipes*.
+    Silver (UCL) based on *Numerical Recipes*, but now uses 
+    ``scipy.stats.ks_2samp`` for p-value calculation.
 
     Args:
         y1: First 1-D numpy array of values.
@@ -919,7 +920,8 @@ def stability_test(
 
     This mirrors the Igor NeuroMatic ``NMStabilityRankOrderTest()`` function
     (``NM_StatsTabStability.ipf``, pass 1 only), originally written by
-    Dr. Angus Silver and Simon Mitchell (UCL), based on *Numerical Recipes in C*.
+    Dr. Angus Silver and Simon Mitchell (UCL), based on *Numerical Recipes in C*,
+    but now uses ``scipy.stats.spearmanr`` for p-value calculation.
 
     NaN and Inf values are excluded before the search; returned indices
     (``start``, ``end``) refer to positions in the original array *y*.

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -403,7 +403,9 @@ class TestNMToolStats2(unittest.TestCase):
 
 
 class TestNMToolStats2Histogram(unittest.TestCase):
-    """Tests for NMToolStats2.histogram()."""
+    """Tests for NMToolStats2.histogram() — NM wrapper behaviour only.
+    Pure math tests are in test_nm_math.py::TestHistogram.
+    """
 
     def setUp(self):
         from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
@@ -411,27 +413,7 @@ class TestNMToolStats2Histogram(unittest.TestCase):
         arr = np.array([1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 5.0])
         self.tf.data.new("ST_w0_mean_y", nparray=arr)
 
-    # --- return value ---
-
-    def test_histogram_returns_dict(self):
-        r = nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y")
-        self.assertIsInstance(r, dict)
-        self.assertIn("counts", r)
-        self.assertIn("edges", r)
-
-    def test_histogram_counts_length(self):
-        r = nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4)
-        self.assertEqual(len(r["counts"]), 4)
-
-    def test_histogram_edges_length(self):
-        r = nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4)
-        self.assertEqual(len(r["edges"]), 5)  # bins + 1
-
-    def test_histogram_counts_sum(self):
-        r = nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4)
-        self.assertEqual(sum(r["counts"]), 9)  # all 9 values counted
-
-    # --- saved arrays (save_to_numpy=True, default) ---
+    # --- save_to_numpy ---
 
     def test_histogram_saves_counts_array(self):
         nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4)
@@ -451,34 +433,12 @@ class TestNMToolStats2Histogram(unittest.TestCase):
         d = self.tf.data.get("H_ST_w0_mean_y_counts")
         self.assertAlmostEqual(d.xscale.delta, 1.0)  # (5 - 1) / 4 = 1.0
 
-    # --- save_to_numpy=False ---
-
     def test_histogram_no_save_skips_arrays(self):
         nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4, save_to_numpy=False)
         self.assertNotIn("H_ST_w0_mean_y_counts", self.tf.data)
         self.assertNotIn("H_ST_w0_mean_y_edges", self.tf.data)
 
-    def test_histogram_no_save_still_returns_dict(self):
-        r = nms.NMToolStats2.histogram(self.tf, "ST_w0_mean_y", bins=4,
-                                 save_to_numpy=False)
-        self.assertIn("counts", r)
-        self.assertIn("edges", r)
-
-    # --- NaN/Inf handling ---
-
-    def test_histogram_strips_nans(self):
-        arr_nan = np.array([1.0, 2.0, np.nan, 3.0])
-        self.tf.data.new("ST_w0_nan_s", nparray=arr_nan)
-        r = nms.NMToolStats2.histogram(self.tf, "ST_w0_nan_s", bins=3)
-        self.assertEqual(sum(r["counts"]), 3)  # NaN excluded
-
-    def test_histogram_strips_infs(self):
-        arr_inf = np.array([1.0, 2.0, np.inf, 3.0])
-        self.tf.data.new("ST_w0_inf_s", nparray=arr_inf)
-        r = nms.NMToolStats2.histogram(self.tf, "ST_w0_inf_s", bins=3)
-        self.assertEqual(sum(r["counts"]), 3)  # Inf excluded
-
-    # --- type validation ---
+    # --- type and key validation ---
 
     def test_histogram_rejects_non_toolfolder(self):
         with self.assertRaises(TypeError):
@@ -750,102 +710,19 @@ class TestNMToolStats2Inequality(unittest.TestCase):
 
 
 class TestNMToolStats2KSTest(unittest.TestCase):
-    """Tests for NMToolStats2.ks_test()."""
+    """Tests for NMToolStats2.ks_test() — NM wrapper behaviour only.
+    Pure math tests are in test_nm_math.py::TestKSTest.
+    """
 
     def setUp(self):
         from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
 
         rng = np.random.default_rng(42)
         self.tf = NMToolFolder(name="stats0")
-
-        # Two clearly different distributions (mean 0 vs mean 10, n=50)
         self.pop1 = rng.normal(loc=0, scale=1, size=50)
         self.pop2 = rng.normal(loc=10, scale=1, size=50)
         self.tf.data.new("ST_w0_pop1_y", nparray=self.pop1.copy())
         self.tf.data.new("ST_w0_pop2_y", nparray=self.pop2.copy())
-
-        # Two samples from the same distribution
-        self.same1 = rng.normal(loc=0, scale=1, size=50)
-        self.same2 = rng.normal(loc=0, scale=1, size=50)
-        self.tf.data.new("ST_w0_same1_y", nparray=self.same1.copy())
-        self.tf.data.new("ST_w0_same2_y", nparray=self.same2.copy())
-
-    # --- return value structure ---
-
-    def test_ks_test_returns_dict(self):
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
-        )
-        for key in ("d", "pvalue", "alpha", "significant", "message", "n1", "n2"):
-            self.assertIn(key, r)
-
-    def test_ks_test_d_range(self):
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
-        )
-        self.assertGreaterEqual(r["d"], 0.0)
-        self.assertLessEqual(r["d"], 1.0)
-
-    def test_ks_test_pvalue_range(self):
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
-        )
-        self.assertGreaterEqual(r["pvalue"], 0.0)
-        self.assertLessEqual(r["pvalue"], 1.0)
-
-    # --- significance ---
-
-    def test_ks_test_significant_true(self):
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
-        )
-        self.assertTrue(r["significant"])
-
-    def test_ks_test_significant_false(self):
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_same1_y", "ST_w0_same2_y", save_to_numpy=False
-        )
-        self.assertFalse(r["significant"])
-
-    # --- message ---
-
-    def test_ks_test_message_different(self):
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
-        )
-        self.assertEqual(r["message"], "different populations")
-
-    def test_ks_test_message_same(self):
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_same1_y", "ST_w0_same2_y", save_to_numpy=False
-        )
-        self.assertEqual(r["message"], "same population")
-
-    # --- n1/n2 ---
-
-    def test_ks_test_n1_n2(self):
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
-        )
-        self.assertEqual(r["n1"], 50)
-        self.assertEqual(r["n2"], 50)
-
-    def test_ks_test_strips_nans(self):
-        arr_nan = np.concatenate([self.pop1, [np.nan, np.nan]])
-        self.tf.data.new("ST_w0_nan_y", nparray=arr_nan)
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_nan_y", "ST_w0_pop2_y", save_to_numpy=False
-        )
-        self.assertEqual(r["n1"], 50)  # 2 NaNs removed
-
-    # --- alpha ---
-
-    def test_ks_test_alpha_in_result(self):
-        r = nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y",
-            alpha=0.01, save_to_numpy=False
-        )
-        self.assertAlmostEqual(r["alpha"], 0.01)
 
     # --- save_to_numpy ---
 
@@ -863,28 +740,6 @@ class TestNMToolStats2KSTest(unittest.TestCase):
         self.assertIn("KS_ST_w0_pop1_y_ecdf", self.tf.data)
         self.assertIn("KS_ST_w0_pop2_y_ecdf", self.tf.data)
 
-    def test_ks_test_ecdf_values_in_range(self):
-        nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=True
-        )
-        ecdf = self.tf.data.get("KS_ST_w0_pop1_y_ecdf").nparray
-        self.assertTrue(np.all(ecdf >= 0.0))
-        self.assertTrue(np.all(ecdf <= 1.0))
-
-    def test_ks_test_ecdf_last_value_is_one(self):
-        nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=True
-        )
-        ecdf = self.tf.data.get("KS_ST_w0_pop1_y_ecdf").nparray
-        self.assertAlmostEqual(ecdf[-1], 1.0)
-
-    def test_ks_test_sort_array_is_sorted(self):
-        nms.NMToolStats2.ks_test(
-            self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=True
-        )
-        sort_arr = self.tf.data.get("KS_ST_w0_pop1_y_sort").nparray
-        self.assertTrue(np.all(sort_arr[:-1] <= sort_arr[1:]))
-
     def test_ks_test_no_save(self):
         nms.NMToolStats2.ks_test(
             self.tf, "ST_w0_pop1_y", "ST_w0_pop2_y", save_to_numpy=False
@@ -892,7 +747,7 @@ class TestNMToolStats2KSTest(unittest.TestCase):
         self.assertNotIn("KS_ST_w0_pop1_y_sort", self.tf.data)
         self.assertNotIn("KS_ST_w0_pop1_y_ecdf", self.tf.data)
 
-    # --- type validation ---
+    # --- type and key validation ---
 
     def test_ks_test_rejects_bad_toolfolder(self):
         with self.assertRaises(TypeError):
@@ -916,28 +771,17 @@ class TestNMToolStats2KSTest(unittest.TestCase):
 
 
 class TestNMToolStats2StabilityTest(unittest.TestCase):
-    """Tests for NMToolStats2.stability_test()."""
+    """Tests for NMToolStats2.stability_test() — NM wrapper behaviour only.
+    Pure math tests are in test_nm_math.py::TestStabilityTest.
+    """
 
     def setUp(self):
         from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
 
         self.tf = NMToolFolder(name="stats0")
-
-        # Flat array (constant) — no monotonic trend → always stable
         self.flat = np.full(20, 3.0)
         self.tf.data.new("ST_w0_flat_y", nparray=self.flat.copy())
 
-        # Strictly increasing — perfect monotonic trend → not stable
-        self.trend = np.arange(20, dtype=float)
-        self.tf.data.new("ST_w0_trend_y", nparray=self.trend.copy())
-
-        # Flat array with 2 NaN values
-        nan_arr = np.full(20, 3.0)
-        nan_arr[5] = np.nan
-        nan_arr[15] = np.nan
-        self.tf.data.new("ST_w0_nan_y", nparray=nan_arr)
-
-        # array names and dataseries for epoch-set tests
         array_names = ["RecordA%d" % i for i in range(20)]
         self.tf.data.new(
             "ST_w0_data",
@@ -949,112 +793,6 @@ class TestNMToolStats2StabilityTest(unittest.TestCase):
         self.ds = self.folder.dataseries.new("Record")
         for i in range(20):
             self.ds.epochs.new("E%d" % i)
-
-    # --- stable=True (flat array) ---
-
-    def test_stable_region_found(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5
-        )
-        self.assertTrue(r["stable"])
-
-    def test_returns_dict_keys(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5
-        )
-        for key in ("stable", "start", "end", "n", "rs", "pvalue", "alpha", "mask"):
-            self.assertIn(key, r)
-
-    def test_start_end_not_none_when_stable(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5
-        )
-        self.assertIsNotNone(r["start"])
-        self.assertIsNotNone(r["end"])
-
-    def test_n_matches_window(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5
-        )
-        self.assertEqual(r["n"], r["end"] - r["start"] + 1)
-
-    def test_rs_range(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5
-        )
-        self.assertGreaterEqual(r["rs"], -1.0)
-        self.assertLessEqual(r["rs"], 1.0)
-
-    def test_pvalue_range(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5
-        )
-        self.assertGreaterEqual(r["pvalue"], 0.0)
-        self.assertLessEqual(r["pvalue"], 1.0)
-
-    def test_alpha_echoed(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", alpha=0.01, min_window=5
-        )
-        self.assertAlmostEqual(r["alpha"], 0.01)
-
-    # --- stable=False (trending array) ---
-
-    def test_unstable_region(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_trend_y", alpha=0.05, min_window=5
-        )
-        self.assertFalse(r["stable"])
-
-    def test_start_end_none_when_not_stable(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_trend_y", alpha=0.05, min_window=5
-        )
-        self.assertIsNone(r["start"])
-        self.assertIsNone(r["end"])
-
-    def test_rs_none_when_not_stable(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_trend_y", alpha=0.05, min_window=5
-        )
-        self.assertIsNone(r["rs"])
-
-    # --- mask ---
-
-    def test_mask_length_equals_original_array(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5
-        )
-        self.assertEqual(len(r["mask"]), len(self.flat))
-
-    def test_mask_true_at_stable_region(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5
-        )
-        # Every index in [start, end] should be True in mask
-        self.assertTrue(np.all(r["mask"][r["start"]: r["end"] + 1]))
-
-    def test_mask_all_false_when_not_stable(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_trend_y", alpha=0.05, min_window=5
-        )
-        self.assertFalse(np.any(r["mask"]))
-
-    # --- NaN handling ---
-
-    def test_strips_nans_mask_length_unchanged(self):
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_nan_y", min_window=5
-        )
-        # mask length = length of original array (including NaN positions)
-        self.assertEqual(len(r["mask"]), 20)
-
-    def test_strips_nans_stable_found(self):
-        # Flat array with 2 NaNs removed → remaining 18 values are flat → stable
-        r = nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_nan_y", min_window=5
-        )
-        self.assertTrue(r["stable"])
 
     # --- save_to_numpy ---
 
@@ -1070,19 +808,23 @@ class TestNMToolStats2StabilityTest(unittest.TestCase):
         )
         self.assertNotIn("STAB_ST_w0_flat_y_mask", self.tf.data)
 
-    # --- min_window validation ---
+    # --- epoch sets ---
 
-    def test_min_window_too_large_raises(self):
-        with self.assertRaises(ValueError):
-            nms.NMToolStats2.stability_test(
-                self.tf, "ST_w0_flat_y", min_window=100
-            )
+    def test_set_name_stable_creates_epoch_set(self):
+        nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5,
+            dataseries=self.ds, set_name_stable="Stable",
+        )
+        self.assertIsNotNone(self.ds.epochs.sets.get_items("Stable"))
 
-    def test_min_window_less_than_3_raises(self):
-        with self.assertRaises(ValueError):
-            nms.NMToolStats2.stability_test(
-                self.tf, "ST_w0_flat_y", min_window=2
-            )
+    def test_set_name_stable_contains_correct_epochs(self):
+        nms.NMToolStats2.stability_test(
+            self.tf, "ST_w0_flat_y", min_window=5,
+            dataseries=self.ds, set_name_stable="Stable",
+        )
+        epoch_names = [ep.name for ep in self.ds.epochs.sets.get_items("Stable")]
+        self.assertIn("E0", epoch_names)
+        self.assertIn("E19", epoch_names)
 
     # --- type and key validation ---
 
@@ -1097,25 +839,6 @@ class TestNMToolStats2StabilityTest(unittest.TestCase):
     def test_unknown_name_raises(self):
         with self.assertRaises(KeyError):
             nms.NMToolStats2.stability_test(self.tf, "ST_w0_missing")
-
-    # --- epoch sets ---
-
-    def test_set_name_stable_creates_epoch_set(self):
-        nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5,
-            dataseries=self.ds, set_name_stable="Stable",
-        )
-        self.assertIsNotNone(self.ds.epochs.sets.get_items("Stable"))
-
-    def test_set_name_stable_contains_correct_epochs(self):
-        # Flat array → all 20 epochs should be in the stable set
-        nms.NMToolStats2.stability_test(
-            self.tf, "ST_w0_flat_y", min_window=5,
-            dataseries=self.ds, set_name_stable="Stable",
-        )
-        epoch_names = [ep.name for ep in self.ds.epochs.sets.get_items("Stable")]
-        self.assertIn("E0", epoch_names)
-        self.assertIn("E19", epoch_names)
 
 
 class TestNMToolStats2AddEpochSetsFromMask(unittest.TestCase):

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -686,3 +686,221 @@ class TestSmoothSavgol:
     def test_rejects_non_array(self):
         with pytest.raises(TypeError):
             nm_math.smooth_savgol([1.0, 2.0, 3.0], window=3)
+
+
+# =============================================================================
+# histogram
+# =============================================================================
+
+
+class TestHistogram:
+    def test_returns_dict(self):
+        y = np.array([1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 5.0])
+        r = nm_math.histogram(y, bins=4)
+        assert "counts" in r
+        assert "edges" in r
+
+    def test_counts_length(self):
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        r = nm_math.histogram(y, bins=4)
+        assert len(r["counts"]) == 4
+
+    def test_edges_length(self):
+        y = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        r = nm_math.histogram(y, bins=4)
+        assert len(r["edges"]) == 5  # bins + 1
+
+    def test_counts_sum(self):
+        y = np.array([1.0, 2.0, 2.0, 3.0, 3.0, 3.0, 4.0, 4.0, 5.0])
+        r = nm_math.histogram(y, bins=4)
+        assert sum(r["counts"]) == 9
+
+    def test_strips_nans(self):
+        y = np.array([1.0, 2.0, np.nan, 3.0])
+        r = nm_math.histogram(y, bins=3)
+        assert sum(r["counts"]) == 3
+
+    def test_strips_infs(self):
+        y = np.array([1.0, 2.0, np.inf, 3.0])
+        r = nm_math.histogram(y, bins=3)
+        assert sum(r["counts"]) == 3
+
+    def test_density_sums_to_approx_one(self):
+        y = np.linspace(0.0, 1.0, 100)
+        r = nm_math.histogram(y, bins=10, density=True)
+        # density * bin_width should sum to ~1.0
+        bin_width = r["edges"][1] - r["edges"][0]
+        assert abs(sum(r["counts"]) * bin_width - 1.0) < 1e-10
+
+    def test_rejects_non_array(self):
+        with pytest.raises(TypeError):
+            nm_math.histogram([1.0, 2.0, 3.0])
+
+
+# =============================================================================
+# ks_test
+# =============================================================================
+
+
+class TestKSTest:
+    def setup_method(self):
+        rng = np.random.default_rng(42)
+        self.pop1 = rng.normal(loc=0, scale=1, size=50)
+        self.pop2 = rng.normal(loc=10, scale=1, size=50)
+        self.same1 = rng.normal(loc=0, scale=1, size=50)
+        self.same2 = rng.normal(loc=0, scale=1, size=50)
+
+    def test_returns_dict_keys(self):
+        r = nm_math.ks_test(self.pop1, self.pop2)
+        for key in ("d", "pvalue", "alpha", "significant", "message",
+                    "n1", "n2", "sort1", "ecdf1", "sort2", "ecdf2"):
+            assert key in r
+
+    def test_d_range(self):
+        r = nm_math.ks_test(self.pop1, self.pop2)
+        assert 0.0 <= r["d"] <= 1.0
+
+    def test_pvalue_range(self):
+        r = nm_math.ks_test(self.pop1, self.pop2)
+        assert 0.0 <= r["pvalue"] <= 1.0
+
+    def test_significant_true(self):
+        r = nm_math.ks_test(self.pop1, self.pop2)
+        assert r["significant"] is True
+
+    def test_significant_false(self):
+        r = nm_math.ks_test(self.same1, self.same2)
+        assert r["significant"] is False
+
+    def test_message_different(self):
+        r = nm_math.ks_test(self.pop1, self.pop2)
+        assert r["message"] == "different populations"
+
+    def test_message_same(self):
+        r = nm_math.ks_test(self.same1, self.same2)
+        assert r["message"] == "same population"
+
+    def test_n1_n2(self):
+        r = nm_math.ks_test(self.pop1, self.pop2)
+        assert r["n1"] == 50
+        assert r["n2"] == 50
+
+    def test_strips_nans(self):
+        y1_nan = np.concatenate([self.pop1, [np.nan, np.nan]])
+        r = nm_math.ks_test(y1_nan, self.pop2)
+        assert r["n1"] == 50  # 2 NaNs removed
+
+    def test_alpha_echoed(self):
+        r = nm_math.ks_test(self.pop1, self.pop2, alpha=0.01)
+        assert r["alpha"] == pytest.approx(0.01)
+
+    def test_ecdf_values_in_range(self):
+        r = nm_math.ks_test(self.pop1, self.pop2)
+        assert np.all(r["ecdf1"] >= 0.0)
+        assert np.all(r["ecdf1"] <= 1.0)
+
+    def test_ecdf_last_value_is_one(self):
+        r = nm_math.ks_test(self.pop1, self.pop2)
+        assert r["ecdf1"][-1] == pytest.approx(1.0)
+
+    def test_sort_array_is_sorted(self):
+        r = nm_math.ks_test(self.pop1, self.pop2)
+        assert np.all(r["sort1"][:-1] <= r["sort1"][1:])
+
+    def test_rejects_non_array_y1(self):
+        with pytest.raises(TypeError):
+            nm_math.ks_test([1.0, 2.0], self.pop2)
+
+    def test_rejects_non_array_y2(self):
+        with pytest.raises(TypeError):
+            nm_math.ks_test(self.pop1, [1.0, 2.0])
+
+
+# =============================================================================
+# stability_test
+# =============================================================================
+
+
+class TestStabilityTest:
+    def setup_method(self):
+        self.flat = np.full(20, 3.0)
+        self.trend = np.arange(20, dtype=float)
+        nan_arr = np.full(20, 3.0)
+        nan_arr[5] = np.nan
+        nan_arr[15] = np.nan
+        self.nan_arr = nan_arr
+
+    def test_stable_region_found(self):
+        r = nm_math.stability_test(self.flat, min_window=5)
+        assert r["stable"] is True
+
+    def test_returns_dict_keys(self):
+        r = nm_math.stability_test(self.flat, min_window=5)
+        for key in ("stable", "start", "end", "n", "rs", "pvalue", "alpha", "mask"):
+            assert key in r
+
+    def test_start_end_not_none_when_stable(self):
+        r = nm_math.stability_test(self.flat, min_window=5)
+        assert r["start"] is not None
+        assert r["end"] is not None
+
+    def test_n_matches_window(self):
+        r = nm_math.stability_test(self.flat, min_window=5)
+        assert r["n"] == r["end"] - r["start"] + 1
+
+    def test_rs_range(self):
+        r = nm_math.stability_test(self.flat, min_window=5)
+        assert -1.0 <= r["rs"] <= 1.0
+
+    def test_pvalue_range(self):
+        r = nm_math.stability_test(self.flat, min_window=5)
+        assert 0.0 <= r["pvalue"] <= 1.0
+
+    def test_alpha_echoed(self):
+        r = nm_math.stability_test(self.flat, alpha=0.01, min_window=5)
+        assert r["alpha"] == pytest.approx(0.01)
+
+    def test_unstable_region(self):
+        r = nm_math.stability_test(self.trend, alpha=0.05, min_window=5)
+        assert r["stable"] is False
+
+    def test_start_end_none_when_not_stable(self):
+        r = nm_math.stability_test(self.trend, alpha=0.05, min_window=5)
+        assert r["start"] is None
+        assert r["end"] is None
+
+    def test_rs_none_when_not_stable(self):
+        r = nm_math.stability_test(self.trend, alpha=0.05, min_window=5)
+        assert r["rs"] is None
+
+    def test_mask_length_equals_input(self):
+        r = nm_math.stability_test(self.flat, min_window=5)
+        assert len(r["mask"]) == len(self.flat)
+
+    def test_mask_true_at_stable_region(self):
+        r = nm_math.stability_test(self.flat, min_window=5)
+        assert np.all(r["mask"][r["start"]: r["end"] + 1])
+
+    def test_mask_all_false_when_not_stable(self):
+        r = nm_math.stability_test(self.trend, alpha=0.05, min_window=5)
+        assert not np.any(r["mask"])
+
+    def test_strips_nans_mask_length_unchanged(self):
+        r = nm_math.stability_test(self.nan_arr, min_window=5)
+        assert len(r["mask"]) == 20
+
+    def test_strips_nans_stable_found(self):
+        r = nm_math.stability_test(self.nan_arr, min_window=5)
+        assert r["stable"] is True
+
+    def test_min_window_too_large_raises(self):
+        with pytest.raises(ValueError):
+            nm_math.stability_test(self.flat, min_window=100)
+
+    def test_min_window_less_than_3_raises(self):
+        with pytest.raises(ValueError):
+            nm_math.stability_test(self.flat, min_window=2)
+
+    def test_rejects_non_array(self):
+        with pytest.raises(TypeError):
+            nm_math.stability_test([1.0, 2.0, 3.0])


### PR DESCRIPTION
## Summary
- Adds pure `histogram()`, `ks_test()`, `stability_test()` functions to
  `nm_math.py` — numpy arrays in, results dict out, no NM object dependencies
- `nm_tool_stats.py` wrappers now delegate to these pure functions and retain
  only NM-layer concerns (toolfolder lookup, `save_to_numpy`, epoch sets)
- `ks_test()` pure function returns `sort1/ecdf1/sort2/ecdf2` in the result
  dict directly, avoiding recomputation in the wrapper
- Follows the same pattern established for smooth functions in #242

## Test plan
- [ ] `tests/test_core/test_nm_math.py` — `TestHistogram`, `TestKSTest`,
  `TestStabilityTest` test pure functions directly with numpy arrays
- [ ] `tests/test_analysis/test_nm_tool_stats.py` — wrapper classes slimmed
  to NM-specific tests only (save_to_numpy, epoch sets, type/key validation)

Closes #244
