### PR TITLE
feat(analysis): add NMMainOpResample and NMMainOpInterpolate x-axis ops

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -1398,6 +1398,275 @@ class NMMainOpSmooth(NMMainOp):
 
 
 # =========================================================================
+# Resample
+# =========================================================================
+
+
+class NMMainOpResample(NMMainOp):
+    """Resample each array to a new sample interval using polyphase filtering.
+
+    Wraps ``scipy.signal.resample_poly`` via :func:`nm_math.resample`,
+    which applies an anti-aliasing FIR filter making it correct for both
+    upsampling and downsampling.  Updates ``xscale.delta`` after resampling;
+    ``xscale.start`` is unchanged.
+
+    Parameters:
+        delta: New sample interval in the same units as ``xscale.delta``.
+            Must be > 0.
+    """
+
+    name = "resample"
+
+    def __init__(self, delta: float) -> None:
+        self.delta = delta
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def delta(self) -> float:
+        """New sample interval in the same units as ``xscale.delta``."""
+        return self._delta
+
+    @delta.setter
+    def delta(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "delta", "float"))
+        if value <= 0:
+            raise ValueError("delta must be > 0, got %g" % value)
+        self._delta = float(value)
+
+    # ------------------------------------------------------------------
+    # Core
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Resample *data* in-place."""
+        y = data.nparray
+        if y is None:
+            return
+        data.nparray = nm_math.resample(y, data.xscale.delta, self._delta)
+        data.xscale.delta = self._delta
+        self._add_op_note(data, self._op_params_str())
+
+    def _op_params_str(self) -> str:
+        return "delta=%r" % self._delta
+
+
+# =========================================================================
+# Interpolate
+# =========================================================================
+
+_VALID_INTERP_X_SOURCES: frozenset[str] = frozenset({"common", "template"})
+_VALID_INTERP_X_EXTENT: frozenset[str] = frozenset({"overlap", "expand"})
+
+
+class NMMainOpInterpolate(NMMainOp):
+    """Re-grid each array onto a common x-axis via interpolation.
+
+    Useful when arrays were recorded at slightly different time points and
+    need to be aligned to a shared x-axis before averaging or comparison.
+    Uses :func:`nm_math.interpolate` (``scipy.interpolate``).
+
+    Two x-axis sources:
+
+    - ``"common"``: derive the target x-axis from the data themselves.
+      Requires ``run_all()`` (or ``NMToolMain``) so that all arrays are
+      visible before interpolation begins.
+    - ``"template"``: use the xscale of a named NMData array in the same
+      folder as the template x-axis.
+
+    When *x_source* is ``"common"``, *x_extent* controls the x-axis range:
+
+    - ``"overlap"`` (default): start = max of all array starts, end = min
+      of all array ends — only the region shared by every array is kept.
+    - ``"expand"``: start = min of all array starts, end = max of all array
+      ends — the full union is used.  Points outside an array's original
+      range are filled with NaN.
+
+    Parameters:
+        method: ``"linear"`` (default) or ``"cubic"``.
+        x_source: ``"common"`` (default) or ``"template"``.
+        x_extent: ``"overlap"`` (default) or ``"expand"``.
+            Only used when *x_source* is ``"common"``.
+        template_name: Name of the NMData template array.  Required when
+            *x_source* is ``"template"``.
+    """
+
+    name = "interpolate"
+
+    def __init__(
+        self,
+        method: str = "linear",
+        x_source: str = "common",
+        x_extent: str = "overlap",
+        template_name: str | None = None,
+    ) -> None:
+        self.method = method
+        self.x_source = x_source
+        self.x_extent = x_extent
+        self.template_name = template_name
+        self._x_new: np.ndarray | None = None
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def method(self) -> str:
+        """Interpolation method: ``'linear'`` or ``'cubic'``."""
+        return self._method
+
+    @method.setter
+    def method(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "method", "string"))
+        if value not in nm_math._VALID_INTERPOLATE_METHODS:
+            raise ValueError(
+                "method must be one of %s, got %r"
+                % (sorted(nm_math._VALID_INTERPOLATE_METHODS), value)
+            )
+        self._method = value
+
+    @property
+    def x_source(self) -> str:
+        """X-axis source: ``'common'`` or ``'template'``."""
+        return self._x_source
+
+    @x_source.setter
+    def x_source(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "x_source", "string"))
+        if value not in _VALID_INTERP_X_SOURCES:
+            raise ValueError(
+                "x_source must be one of %s, got %r"
+                % (sorted(_VALID_INTERP_X_SOURCES), value)
+            )
+        self._x_source = value
+
+    @property
+    def x_extent(self) -> str:
+        """X-axis extent when x_source='common': ``'overlap'`` or ``'expand'``."""
+        return self._x_extent
+
+    @x_extent.setter
+    def x_extent(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "x_extent", "string"))
+        if value not in _VALID_INTERP_X_EXTENT:
+            raise ValueError(
+                "x_extent must be one of %s, got %r"
+                % (sorted(_VALID_INTERP_X_EXTENT), value)
+            )
+        self._x_extent = value
+
+    @property
+    def template_name(self) -> str | None:
+        """Name of NMData template array (used when x_source='template')."""
+        return self._template_name
+
+    @template_name.setter
+    def template_name(self, value: str | None) -> None:
+        if value is not None and not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "template_name", "string"))
+        self._template_name = value
+
+    # ------------------------------------------------------------------
+    # Core
+
+    def run_init(self) -> None:
+        self._x_new = None
+        if self._x_source == "common":
+            self._x_new = self._compute_common_x()
+        elif self._x_source == "template":
+            self._x_new = self._compute_template_x()
+
+    def _compute_common_x(self) -> np.ndarray | None:
+        """Derive common x-axis from all data items.
+
+        ``x_extent='overlap'``: intersection of all x-ranges (no NaNs).
+        ``x_extent='expand'``: union of all x-ranges (NaN where an array has
+        no data).
+        """
+        items = getattr(self, "_data_items", None)
+        if not items:
+            return None
+        starts, ends, deltas = [], [], []
+        for data, _ in items:
+            y = data.nparray
+            if y is None or len(y) == 0:
+                continue
+            s = data.xscale.start
+            d = data.xscale.delta
+            starts.append(s)
+            ends.append(s + (len(y) - 1) * d)
+            deltas.append(d)
+        if not starts:
+            return None
+        if self._x_extent == "expand":
+            x_start = min(starts)   # union: earliest start
+            x_end = max(ends)       # union: latest end
+        else:
+            x_start = max(starts)   # overlap: latest start
+            x_end = min(ends)       # overlap: earliest end
+        x_delta = min(deltas)       # finest resolution
+        if x_end <= x_start:
+            return None
+        n = round((x_end - x_start) / x_delta) + 1
+        return np.linspace(x_start, x_end, n)
+
+    def _compute_template_x(self) -> np.ndarray | None:
+        """Derive x-axis from the named template NMData array."""
+        if not self._template_name:
+            return None
+        folder = getattr(self, "_folder", None)
+        if folder is None:
+            return None
+        d = folder.data.get(self._template_name)
+        if d is None or d.nparray is None:
+            return None
+        n = len(d.nparray)
+        return np.linspace(
+            d.xscale.start,
+            d.xscale.start + (n - 1) * d.xscale.delta,
+            n,
+        )
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Interpolate *data* in-place onto the target x-axis."""
+        y = data.nparray
+        if y is None:
+            return
+        if self._x_new is None:
+            raise ValueError(
+                "NMMainOpInterpolate: x_new not set — call run_all() or "
+                "run_init() before run(), or check x_source/template_name"
+            )
+        n = len(y)
+        x_old = np.linspace(
+            data.xscale.start,
+            data.xscale.start + (n - 1) * data.xscale.delta,
+            n,
+        )
+        data.nparray = nm_math.interpolate(y, x_old, self._x_new,
+                                           method=self._method)
+        data.xscale.start = float(self._x_new[0])
+        data.xscale.delta = float(self._x_new[1] - self._x_new[0])
+        self._add_op_note(data, self._op_params_str())
+
+    def _op_params_str(self) -> str:
+        return "method=%r, x_source=%r, x_extent=%r, template_name=%r" % (
+            self._method, self._x_source, self._x_extent, self._template_name
+        )
+
+
+# =========================================================================
 # Normalize
 # =========================================================================
 
@@ -2518,7 +2787,7 @@ class NMMainOpConcatenate(NMMainOpAccumulate):
     In ``"1d"`` mode arrays are joined end-to-end (``np.concatenate``);
     unequal lengths are allowed.  In ``"2d"`` mode arrays are stacked as
     rows (``np.stack``); shorter arrays are padded with NaN to ``max_len``
-    so no data is lost from longer waves.
+    so no data is lost from longer arrays.
 
     Output array is written to the destination folder as
     ``Cat_{prefix}{channel}`` (e.g. ``Cat_RecordA``).
@@ -2959,31 +3228,39 @@ class NMMainOpHistogram(NMMainOp):
 
 
 _OP_REGISTRY: dict[str, type[NMMainOp]] = {
-    "arithmetic": NMMainOpArithmetic,
-    "arithmetic_by_array": NMMainOpArithmeticByArray,
+    # --- accumulation (combine multiple arrays) ---
     "average": NMMainOpAverage,
     "concatenate": NMMainOpConcatenate,
-    "baseline": NMMainOpBaseline,
-    "delete_nans": NMMainOpDeleteNaNs,
-    "dfof": NMMainOpDFOF,
-    "delete_points": NMMainOpDeletePoints,
-    "differentiate": NMMainOpDifferentiate,
-    "histogram": NMMainOpHistogram,
-    "inequality": NMMainOpInequality,
-    "insert_points": NMMainOpInsertPoints,
-    "integrate": NMMainOpIntegrate,
-    "max": NMMainOpMax,
-    "min": NMMainOpMin,
-    "normalize": NMMainOpNormalize,
-    "redimension": NMMainOpRedimension,
-    "replace_values": NMMainOpReplaceValues,
-    "rescale": NMMainOpRescale,
-    "rescale_x": NMMainOpRescaleX,
-    "reverse": NMMainOpReverse,
-    "rotate": NMMainOpRotate,
-    "smooth": NMMainOpSmooth,
     "sum": NMMainOpSum,
     "sum_sqr": NMMainOpSumSqr,
+    # --- arithmetic / scaling (element-wise value operations) ---
+    "arithmetic": NMMainOpArithmetic,
+    "arithmetic_by_array": NMMainOpArithmeticByArray,
+    "baseline": NMMainOpBaseline,
+    "dfof": NMMainOpDFOF,
+    "normalize": NMMainOpNormalize,
+    "rescale": NMMainOpRescale,
+    # --- calculus / signal conditioning ---
+    "differentiate": NMMainOpDifferentiate,
+    "integrate": NMMainOpIntegrate,
+    "smooth": NMMainOpSmooth,
+    # --- statistics / comparison ---
+    "histogram": NMMainOpHistogram,
+    "inequality": NMMainOpInequality,
+    "max": NMMainOpMax,
+    "min": NMMainOpMin,
+    # --- array structure ---
+    "delete_nans": NMMainOpDeleteNaNs,
+    "delete_points": NMMainOpDeletePoints,
+    "insert_points": NMMainOpInsertPoints,
+    "redimension": NMMainOpRedimension,
+    "replace_values": NMMainOpReplaceValues,
+    "reverse": NMMainOpReverse,
+    "rotate": NMMainOpRotate,
+    # --- x-axis ---
+    "interpolate": NMMainOpInterpolate,
+    "resample": NMMainOpResample,
+    "rescale_x": NMMainOpRescaleX,
 }
 
 

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -793,6 +793,106 @@ def smooth_savgol(
 
 
 # =========================================================================
+# Resample and interpolate
+# =========================================================================
+
+
+def resample(
+    y: np.ndarray,
+    old_delta: float,
+    new_delta: float,
+) -> np.ndarray:
+    """Resample a 1-D array to a new sample interval using polyphase filtering.
+
+    Wraps ``scipy.signal.resample_poly`` which applies an anti-aliasing FIR
+    filter before decimation, making it appropriate for both upsampling and
+    downsampling.  The ratio ``old_delta / new_delta`` is approximated as a
+    rational number (numerator / denominator, limited to 1000) to satisfy
+    ``resample_poly``'s integer ``up`` / ``down`` requirement.
+
+    Args:
+        y: 1-D numpy array of y-values.
+        old_delta: Current sample interval (any consistent units).
+        new_delta: Desired sample interval (same units as *old_delta*).
+
+    Returns:
+        Resampled copy of *y*.  Length will be approximately
+        ``len(y) * old_delta / new_delta``.
+
+    Raises:
+        TypeError: If *y* is not a numpy ndarray, or *old_delta*/*new_delta*
+            are not numeric.
+        ValueError: If *old_delta* or *new_delta* are <= 0.
+    """
+    from fractions import Fraction  # noqa: PLC0415
+
+    from scipy.signal import resample_poly  # noqa: PLC0415
+
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+    if not isinstance(old_delta, (int, float)) or isinstance(old_delta, bool):
+        raise TypeError(nmu.type_error_str(old_delta, "old_delta", "float"))
+    if not isinstance(new_delta, (int, float)) or isinstance(new_delta, bool):
+        raise TypeError(nmu.type_error_str(new_delta, "new_delta", "float"))
+    if old_delta <= 0:
+        raise ValueError("old_delta must be > 0, got %g" % old_delta)
+    if new_delta <= 0:
+        raise ValueError("new_delta must be > 0, got %g" % new_delta)
+    frac = Fraction(old_delta / new_delta).limit_denominator(1000)
+    up, down = frac.numerator, frac.denominator
+    return resample_poly(y.copy().astype(float), up, down)
+
+
+_VALID_INTERPOLATE_METHODS: frozenset[str] = frozenset({"linear", "cubic"})
+
+
+def interpolate(
+    y: np.ndarray,
+    x_old: np.ndarray,
+    x_new: np.ndarray,
+    method: str = "linear",
+) -> np.ndarray:
+    """Interpolate a 1-D array from one x-axis to another.
+
+    Uses ``numpy.interp`` for linear interpolation and
+    ``scipy.interpolate.CubicSpline`` for cubic interpolation.  Values
+    outside the range of *x_old* are filled with ``NaN``.
+
+    Args:
+        y: 1-D numpy array of y-values corresponding to *x_old*.
+        x_old: 1-D numpy array of original x-positions (must be strictly
+            increasing).
+        x_new: 1-D numpy array of target x-positions.
+        method: ``"linear"`` (default) or ``"cubic"``.
+
+    Returns:
+        1-D numpy array of interpolated y-values at *x_new* positions.
+
+    Raises:
+        TypeError: If any array argument is not a numpy ndarray.
+        ValueError: If *method* is not ``"linear"`` or ``"cubic"``.
+    """
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+    if not isinstance(x_old, np.ndarray):
+        raise TypeError(nmu.type_error_str(x_old, "x_old", "numpy.ndarray"))
+    if not isinstance(x_new, np.ndarray):
+        raise TypeError(nmu.type_error_str(x_new, "x_new", "numpy.ndarray"))
+    if method not in _VALID_INTERPOLATE_METHODS:
+        raise ValueError(
+            "method must be one of %s, got %r"
+            % (sorted(_VALID_INTERPOLATE_METHODS), method)
+        )
+    if method == "linear":
+        return np.interp(x_new, x_old, y, left=np.nan, right=np.nan)
+    # cubic
+    from scipy.interpolate import CubicSpline  # noqa: PLC0415
+
+    cs = CubicSpline(x_old, y, extrapolate=False)
+    return cs(x_new).astype(float)
+
+
+# =========================================================================
 # Stats functions
 # =========================================================================
 

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -37,6 +37,8 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpReplaceValues,
     NMMainOpConcatenate,
     NMMainOpRescale,
+    NMMainOpInterpolate,
+    NMMainOpResample,
     NMMainOpRescaleX,
     NMMainOpReverse,
     NMMainOpRotate,
@@ -2773,20 +2775,20 @@ class TestNMMainOpDFOF(unittest.TestCase):
         op.run_init()
         op.run(d)  # should not raise
 
-    def test_multiple_waves(self):
+    def test_multiple_records(self):
         op = NMMainOpDFOF(x0=0.0, x1=0.0)
-        waves = [
+        records = [
             _make_data("RecordA0", [1.0, 5.0], xstart=0.0, xdelta=1.0),
             _make_data("RecordA1", [2.0, 6.0], xstart=0.0, xdelta=1.0),
             _make_data("RecordA2", [4.0, 8.0], xstart=0.0, xdelta=1.0),
         ]
         op.run_init()
-        for w in waves:
-            op.run(w)
-        # Each wave transformed independently
-        np.testing.assert_array_almost_equal(waves[0].nparray, [0.0, 4.0])
-        np.testing.assert_array_almost_equal(waves[1].nparray, [0.0, 2.0])
-        np.testing.assert_array_almost_equal(waves[2].nparray, [0.0, 1.0])
+        for r in records:
+            op.run(r)
+        # Each record transformed independently
+        np.testing.assert_array_almost_equal(records[0].nparray, [0.0, 4.0])
+        np.testing.assert_array_almost_equal(records[1].nparray, [0.0, 2.0])
+        np.testing.assert_array_almost_equal(records[2].nparray, [0.0, 1.0])
 
     # ------------------------------------------------------------------
     # Validation
@@ -2959,23 +2961,23 @@ class TestNMMainOpRescale(unittest.TestCase):
         op.run_init()
         op.run(d)   # should not raise
 
-    def test_multiple_waves(self):
-        waves = [
+    def test_multiple_records(self):
+        records = [
             _make_data("RecordA0", [1.0, 2.0]),
             _make_data("RecordA1", [3.0, 4.0]),
             _make_data("RecordA2", [5.0, 6.0]),
         ]
-        for w in waves:
-            w.yscale.units = "mV"
+        for r in records:
+            r.yscale.units = "mV"
         op = NMMainOpRescale(to_units="V")
         op.run_init()
-        for w in waves:
-            op.run(w)
-        np.testing.assert_array_almost_equal(waves[0].nparray, [1e-3, 2e-3])
-        np.testing.assert_array_almost_equal(waves[1].nparray, [3e-3, 4e-3])
-        np.testing.assert_array_almost_equal(waves[2].nparray, [5e-3, 6e-3])
-        for w in waves:
-            self.assertEqual(w.yscale.units, "V")
+        for r in records:
+            op.run(r)
+        np.testing.assert_array_almost_equal(records[0].nparray, [1e-3, 2e-3])
+        np.testing.assert_array_almost_equal(records[1].nparray, [3e-3, 4e-3])
+        np.testing.assert_array_almost_equal(records[2].nparray, [5e-3, 6e-3])
+        for r in records:
+            self.assertEqual(r.yscale.units, "V")
 
     def test_rescale_by_name(self):
         op = op_from_name("rescale")
@@ -3123,23 +3125,23 @@ class TestNMMainOpRescaleX(unittest.TestCase):
     # ------------------------------------------------------------------
     # Other
 
-    def test_multiple_waves(self):
-        waves = [
+    def test_multiple_records(self):
+        records = [
             _make_data("RecordA0", [1.0], xstart=0.0, xdelta=1.0),
             _make_data("RecordA1", [2.0], xstart=0.0, xdelta=2.0),
             _make_data("RecordA2", [3.0], xstart=10.0, xdelta=0.5),
         ]
-        for w in waves:
+        for w in records:
             w.xscale.units = "ms"
         op = NMMainOpRescaleX(to_units="s")
         op.run_init()
-        for w in waves:
+        for w in records:
             op.run(w)
-        self.assertAlmostEqual(waves[0].xscale.delta, 1e-3)
-        self.assertAlmostEqual(waves[1].xscale.delta, 2e-3)
-        self.assertAlmostEqual(waves[2].xscale.start, 10e-3)
-        self.assertAlmostEqual(waves[2].xscale.delta, 0.5e-3)
-        for w in waves:
+        self.assertAlmostEqual(records[0].xscale.delta, 1e-3)
+        self.assertAlmostEqual(records[1].xscale.delta, 2e-3)
+        self.assertAlmostEqual(records[2].xscale.start, 10e-3)
+        self.assertAlmostEqual(records[2].xscale.delta, 0.5e-3)
+        for w in records:
             self.assertEqual(w.xscale.units, "s")
 
     def test_rescale_x_by_name(self):
@@ -3464,6 +3466,316 @@ class TestNMMainOpSmooth(unittest.TestCase):
         # index 3: mean([3,4,5]) = 4.0
         np.testing.assert_allclose(folder.data.get("RecordA0").nparray[3], 4.0)
         np.testing.assert_allclose(folder.data.get("RecordA1").nparray[3], 4.0)
+
+
+
+# ===========================================================================
+# TestNMMainOpResample
+# ===========================================================================
+
+
+class TestNMMainOpResample(unittest.TestCase):
+
+    # --- constructor validation ---
+
+    def test_rejects_no_args(self):
+        with self.assertRaises(TypeError):
+            NMMainOpResample()
+
+    def test_rejects_zero_delta(self):
+        with self.assertRaises(ValueError):
+            NMMainOpResample(delta=0.0)
+
+    def test_rejects_negative_delta(self):
+        with self.assertRaises(ValueError):
+            NMMainOpResample(delta=-0.1)
+
+    def test_rejects_bool_delta(self):
+        with self.assertRaises(TypeError):
+            NMMainOpResample(delta=True)
+
+    def test_rejects_string_delta(self):
+        with self.assertRaises(TypeError):
+            NMMainOpResample(delta="0.1")
+
+    # --- run: downsample ---
+
+    def test_downsample_halves_length(self):
+        d = _make_data("RecordA0", np.ones(100), xdelta=0.1)
+        op = NMMainOpResample(delta=0.2)
+        op.run(d)
+        self.assertEqual(len(d.nparray), 50)
+
+    def test_downsample_updates_xscale_delta(self):
+        d = _make_data("RecordA0", np.ones(100), xdelta=0.1)
+        op = NMMainOpResample(delta=0.2)
+        op.run(d)
+        self.assertAlmostEqual(d.xscale.delta, 0.2)
+
+    def test_upsample_doubles_length(self):
+        d = _make_data("RecordA0", np.ones(50), xdelta=0.2)
+        op = NMMainOpResample(delta=0.1)
+        op.run(d)
+        self.assertEqual(len(d.nparray), 100)
+
+    def test_constant_signal_preserved(self):
+        # Use a long signal; polyphase resampling has edge transients, so
+        # check only the interior where the filter has fully settled.
+        y = np.ones(1000) * 5.0
+        d = _make_data("RecordA0", y, xdelta=0.1)
+        op = NMMainOpResample(delta=0.2)
+        op.run(d)
+        np.testing.assert_allclose(d.nparray[50:-50], 5.0, atol=1e-4)
+
+    def test_run_skips_none_array(self):
+        d = NMData(NM, name="empty")
+        op = NMMainOpResample(delta=0.2)
+        op.run(d)  # should not raise
+
+    def test_run_note_contains_op_name(self):
+        d = _make_data("RecordA0", np.ones(100), xdelta=0.1)
+        NMMainOpResample(delta=0.2).run(d)
+        self.assertIn("NMResample(", d.notes[0]["note"])
+
+    def test_run_note_contains_delta(self):
+        d = _make_data("RecordA0", np.ones(100), xdelta=0.1)
+        NMMainOpResample(delta=0.2).run(d)
+        self.assertIn("delta=0.2", d.notes[0]["note"])
+
+    def test_op_from_name_resample(self):
+        with self.assertRaises(TypeError):
+            # registry entry exists but delta is required
+            op_from_name("resample")
+
+    def test_run_all_downsample(self):
+        folder = NMFolder(name="folder0")
+        data_items = []
+        for name in ["RecordA0", "RecordA1"]:
+            d = folder.data.new(
+                name,
+                nparray=np.ones(100),
+                xscale={"start": 0.0, "delta": 0.1},
+            )
+            data_items.append((d, None))
+        op = NMMainOpResample(delta=0.2)
+        op.run_all(data_items, folder)
+        for name in ["RecordA0", "RecordA1"]:
+            self.assertEqual(len(folder.data.get(name).nparray), 50)
+
+
+# ===========================================================================
+# TestNMMainOpInterpolate
+# ===========================================================================
+
+
+class TestNMMainOpInterpolate(unittest.TestCase):
+
+    # --- constructor validation ---
+
+    def test_rejects_invalid_method(self):
+        with self.assertRaises(ValueError):
+            NMMainOpInterpolate(method="spline")
+
+    def test_rejects_non_string_method(self):
+        with self.assertRaises(TypeError):
+            NMMainOpInterpolate(method=42)
+
+    def test_rejects_invalid_x_source(self):
+        with self.assertRaises(ValueError):
+            NMMainOpInterpolate(x_source="auto")
+
+    def test_rejects_invalid_x_extent(self):
+        with self.assertRaises(ValueError):
+            NMMainOpInterpolate(x_extent="union")
+
+    def test_rejects_non_string_x_extent(self):
+        with self.assertRaises(TypeError):
+            NMMainOpInterpolate(x_extent=1)
+
+    def test_rejects_non_string_template_name(self):
+        with self.assertRaises(TypeError):
+            NMMainOpInterpolate(template_name=123)
+
+    def test_template_name_none_ok(self):
+        op = NMMainOpInterpolate(x_source="template", template_name=None)
+        self.assertIsNone(op.template_name)
+
+    # --- run (common x-axis) ---
+
+    def test_same_x_axis_length_unchanged(self):
+        """Two records on identical x-axes: common grid matches, length unchanged."""
+        folder = NMFolder(name="folder0")
+        data_items = []
+        for name in ["RecordA0", "RecordA1"]:
+            d = folder.data.new(
+                name,
+                nparray=np.ones(101),
+                xscale={"start": 0.0, "delta": 0.01},
+            )
+            data_items.append((d, None))
+        # common grid: start=0, end=1, delta=0.01 → 101 points (unchanged)
+        op = NMMainOpInterpolate(method="linear", x_source="common")
+        op.run_all(data_items, folder)
+        for name in ["RecordA0", "RecordA1"]:
+            self.assertEqual(len(folder.data.get(name).nparray), 101)
+
+    def test_run_updates_xscale_start(self):
+        folder = NMFolder(name="folder0")
+        # record 0: starts at 0, record 1: starts at 0.5 → common start = 0.5
+        d0 = folder.data.new(
+            "RecordA0",
+            nparray=np.ones(11),
+            xscale={"start": 0.0, "delta": 0.1},
+        )
+        d1 = folder.data.new(
+            "RecordA1",
+            nparray=np.ones(11),
+            xscale={"start": 0.5, "delta": 0.1},
+        )
+        data_items = [(d0, None), (d1, None)]
+        op = NMMainOpInterpolate(method="linear", x_source="common")
+        op.run_all(data_items, folder)
+        # common start = max(0.0, 0.5) = 0.5
+        # x_extent="overlap" → x_start updated to common start
+        self.assertAlmostEqual(d0.xscale.start, 0.5, places=5)
+
+    def test_run_skips_none_array(self):
+        d = NMData(NM, name="empty")
+        op = NMMainOpInterpolate(method="linear", x_source="common")
+        # run_init with no data_items set → _x_new stays None
+        op.run_init()
+        # run() with None array should return early without raising
+        op._x_new = np.linspace(0, 1, 11)
+        op.run(d)
+
+    def test_run_raises_when_x_new_not_set(self):
+        folder = NMFolder(name="folder0")
+        d = folder.data.new(
+            "RecordA0",
+            nparray=np.ones(11),
+            xscale={"start": 0.0, "delta": 0.1},
+        )
+        op = NMMainOpInterpolate(method="linear", x_source="common")
+        # x_new is None (run_init never called)
+        with self.assertRaises(ValueError):
+            op.run(d)
+
+    def test_template_x_source(self):
+        folder = NMFolder(name="folder0")
+        tmpl = folder.data.new(
+            "template",
+            nparray=np.zeros(6),
+            xscale={"start": 0.0, "delta": 0.2},
+        )
+        d = folder.data.new(
+            "RecordA0",
+            nparray=np.ones(11),
+            xscale={"start": 0.0, "delta": 0.1},
+        )
+        data_items = [(d, None)]
+        op = NMMainOpInterpolate(
+            method="linear",
+            x_source="template",
+            template_name="template",
+        )
+        op.run_all(data_items, folder)
+        # template has 6 points at delta=0.2 → new array length = 6
+        self.assertEqual(len(d.nparray), 6)
+
+    def test_run_note_contains_op_name(self):
+        folder = NMFolder(name="folder0")
+        d = folder.data.new(
+            "RecordA0",
+            nparray=np.ones(11),
+            xscale={"start": 0.0, "delta": 0.1},
+        )
+        op = NMMainOpInterpolate(method="linear", x_source="common")
+        op.run_all([(d, None)], folder)
+        self.assertIn("NMInterpolate(", d.notes[0]["note"])
+
+    def test_run_note_contains_method(self):
+        folder = NMFolder(name="folder0")
+        d = folder.data.new(
+            "RecordA0",
+            nparray=np.ones(11),
+            xscale={"start": 0.0, "delta": 0.1},
+        )
+        op = NMMainOpInterpolate(method="cubic", x_source="common")
+        op.run_all([(d, None)], folder)
+        self.assertIn("method='cubic'", d.notes[0]["note"])
+
+    # --- x_extent="expand" ---
+
+    def test_expand_uses_union_x_range(self):
+        # record 0: x 0.0 .. 0.5 (6 pts, delta=0.1)
+        # record 1: x 0.3 .. 1.0 (8 pts, delta=0.1)
+        # expand → x_start=0.0, x_end=1.0 → 11 points
+        folder = NMFolder(name="folder0")
+        d0 = folder.data.new(
+            "RecordA0",
+            nparray=np.ones(6),
+            xscale={"start": 0.0, "delta": 0.1},
+        )
+        d1 = folder.data.new(
+            "RecordA1",
+            nparray=np.ones(8),
+            xscale={"start": 0.3, "delta": 0.1},
+        )
+        data_items = [(d0, None), (d1, None)]
+        op = NMMainOpInterpolate(method="linear", x_source="common",
+                                 x_extent="expand")
+        op.run_all(data_items, folder)
+        self.assertEqual(len(d0.nparray), 11)
+        self.assertEqual(len(d1.nparray), 11)
+
+    def test_expand_fills_nan_outside_range(self):
+        # record 0 covers 0.0..0.5; after expand to 0.0..1.0
+        # points beyond 0.5 should be NaN for record 0
+        folder = NMFolder(name="folder0")
+        d0 = folder.data.new(
+            "RecordA0",
+            nparray=np.ones(6),
+            xscale={"start": 0.0, "delta": 0.1},
+        )
+        d1 = folder.data.new(
+            "RecordA1",
+            nparray=np.ones(8),
+            xscale={"start": 0.3, "delta": 0.1},
+        )
+        data_items = [(d0, None), (d1, None)]
+        op = NMMainOpInterpolate(method="linear", x_source="common",
+                                 x_extent="expand")
+        op.run_all(data_items, folder)
+        # d0 should have NaN for x > 0.5 (last 5 of 11 points)
+        self.assertTrue(np.any(np.isnan(d0.nparray)))
+        self.assertTrue(np.isnan(d0.nparray[-1]))
+        # d0 should have NaN for x < 0.3 (first 3 of 11 points)
+        self.assertTrue(np.any(np.isnan(d1.nparray)))
+        self.assertTrue(np.isnan(d1.nparray[0]))
+
+    def test_overlap_no_nans(self):
+        # overlap mode: only shared region, so no NaN
+        folder = NMFolder(name="folder0")
+        d0 = folder.data.new(
+            "RecordA0",
+            nparray=np.ones(6),
+            xscale={"start": 0.0, "delta": 0.1},
+        )
+        d1 = folder.data.new(
+            "RecordA1",
+            nparray=np.ones(8),
+            xscale={"start": 0.3, "delta": 0.1},
+        )
+        data_items = [(d0, None), (d1, None)]
+        op = NMMainOpInterpolate(method="linear", x_source="common",
+                                 x_extent="overlap")
+        op.run_all(data_items, folder)
+        self.assertFalse(np.any(np.isnan(d0.nparray)))
+        self.assertFalse(np.any(np.isnan(d1.nparray)))
+
+    def test_op_from_name_interpolate(self):
+        op = op_from_name("interpolate")
+        self.assertIsInstance(op, NMMainOpInterpolate)
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -904,3 +904,123 @@ class TestStabilityTest:
     def test_rejects_non_array(self):
         with pytest.raises(TypeError):
             nm_math.stability_test([1.0, 2.0, 3.0])
+
+
+# ---------------------------------------------------------------------------
+# resample
+# ---------------------------------------------------------------------------
+
+
+class TestResample:
+    """Tests for nm_math.resample()."""
+
+    def test_downsample_halves_length(self):
+        y = np.ones(100)
+        result = nm_math.resample(y, old_delta=0.1, new_delta=0.2)
+        assert len(result) == 50
+
+    def test_upsample_doubles_length(self):
+        y = np.ones(50)
+        result = nm_math.resample(y, old_delta=0.2, new_delta=0.1)
+        assert len(result) == 100
+
+    def test_same_delta_returns_same_length(self):
+        y = np.arange(10, dtype=float)
+        result = nm_math.resample(y, old_delta=0.1, new_delta=0.1)
+        assert len(result) == 10
+
+    def test_constant_signal_preserved(self):
+        # Use a long signal; polyphase resampling has edge transients, so
+        # check only the interior where the filter has fully settled.
+        y = np.ones(1000) * 3.0
+        result = nm_math.resample(y, old_delta=0.1, new_delta=0.2)
+        np.testing.assert_allclose(result[50:-50], 3.0, atol=1e-4)
+
+    def test_rejects_non_array(self):
+        with pytest.raises(TypeError):
+            nm_math.resample([1, 2, 3], old_delta=0.1, new_delta=0.2)
+
+    def test_rejects_zero_old_delta(self):
+        with pytest.raises(ValueError):
+            nm_math.resample(np.ones(10), old_delta=0.0, new_delta=0.1)
+
+    def test_rejects_zero_new_delta(self):
+        with pytest.raises(ValueError):
+            nm_math.resample(np.ones(10), old_delta=0.1, new_delta=0.0)
+
+    def test_rejects_negative_delta(self):
+        with pytest.raises(ValueError):
+            nm_math.resample(np.ones(10), old_delta=-0.1, new_delta=0.1)
+
+    def test_returns_ndarray(self):
+        result = nm_math.resample(np.ones(10), old_delta=0.1, new_delta=0.2)
+        assert isinstance(result, np.ndarray)
+
+
+# ---------------------------------------------------------------------------
+# interpolate
+# ---------------------------------------------------------------------------
+
+
+class TestInterpolate:
+    """Tests for nm_math.interpolate()."""
+
+    def test_linear_same_grid_unchanged(self):
+        x = np.linspace(0, 1, 11)
+        y = x ** 2
+        result = nm_math.interpolate(y, x, x, method="linear")
+        np.testing.assert_allclose(result, y, atol=1e-10)
+
+    def test_linear_coarser_grid(self):
+        x_old = np.linspace(0, 1, 101)
+        y = np.sin(x_old)
+        x_new = np.linspace(0, 1, 11)
+        result = nm_math.interpolate(y, x_old, x_new, method="linear")
+        assert len(result) == 11
+
+    def test_cubic_same_grid_unchanged(self):
+        x = np.linspace(0, 1, 21)
+        y = x ** 3
+        result = nm_math.interpolate(y, x, x, method="cubic")
+        np.testing.assert_allclose(result, y, atol=1e-10)
+
+    def test_outside_range_is_nan(self):
+        x_old = np.linspace(0, 1, 11)
+        y = np.ones(11)
+        x_new = np.array([-1.0, 0.5, 2.0])
+        result = nm_math.interpolate(y, x_old, x_new, method="linear")
+        assert np.isnan(result[0])
+        assert np.isnan(result[2])
+        assert not np.isnan(result[1])
+
+    def test_cubic_outside_range_is_nan(self):
+        x_old = np.linspace(0, 1, 21)
+        y = np.ones(21)
+        x_new = np.array([-1.0, 0.5, 2.0])
+        result = nm_math.interpolate(y, x_old, x_new, method="cubic")
+        assert np.isnan(result[0])
+        assert np.isnan(result[2])
+        assert not np.isnan(result[1])
+
+    def test_rejects_non_array_y(self):
+        with pytest.raises(TypeError):
+            nm_math.interpolate([1, 2, 3], np.array([0, 1, 2]),
+                                np.array([0, 1, 2]))
+
+    def test_rejects_non_array_x_old(self):
+        with pytest.raises(TypeError):
+            nm_math.interpolate(np.ones(3), [0, 1, 2], np.array([0, 1, 2]))
+
+    def test_rejects_non_array_x_new(self):
+        with pytest.raises(TypeError):
+            nm_math.interpolate(np.ones(3), np.array([0, 1, 2]), [0, 1, 2])
+
+    def test_rejects_invalid_method(self):
+        x = np.linspace(0, 1, 5)
+        with pytest.raises(ValueError):
+            nm_math.interpolate(np.ones(5), x, x, method="spline")
+
+    def test_returns_ndarray(self):
+        x = np.linspace(0, 1, 11)
+        result = nm_math.interpolate(np.ones(11), x, x)
+        assert isinstance(result, np.ndarray)


### PR DESCRIPTION
## Summary

- Add `NMMainOpResample`: polyphase resampling to a new sample interval
  (`delta` parameter) via `scipy.signal.resample_poly`; updates
  `xscale.delta` after resampling; rate→delta conversion left to GUI
- Add `NMMainOpInterpolate`: re-grid arrays onto a common or template
  x-axis via `numpy.interp` (linear) or `scipy.interpolate.CubicSpline`
  (cubic); `x_extent="overlap"` keeps the shared region only,
  `x_extent="expand"` uses the full union and fills out-of-range points
  with NaN
- Add pure functions `resample()` and `interpolate()` to `nm_math.py`
- Replace deprecated `scipy.interpolate.interp1d` with `numpy.interp`
- Register both ops in `_OP_REGISTRY`; group registry by functionality

## Test plan

- [ ] `nm_math.py`: `TestResample` and `TestInterpolate` cover shape
  changes, constant-signal preservation, NaN outside range,
  type/value validation
- [ ] `test_nm_tool_main.py`: `TestNMMainOpResample` and
  `TestNMMainOpInterpolate` cover parameter validation, downsample/
  upsample, xscale updates, overlap/expand modes, NaN boundary
  behaviour, note contents, and registry lookup
- [ ] Full test suite passes: `python3 -m pytest -q`

Closes #248
