### PR TITLE
feat(analysis): add NMMainOpAlign for x-axis alignment to reference events

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -431,7 +431,7 @@ class NMMainOpArithmeticByArray(NMMainOp):
 
     Parameters:
         ref: Reference operand — either an ``np.ndarray`` or a ``str`` data
-            name that will be looked up in the source folder at run time.
+            name that will be looked up in the source folder at runtime.
         op: Operation string — same choices as :class:`NMMainOpArithmetic`.
             Default is ``"x"``.
     """
@@ -1103,8 +1103,8 @@ class NMMainOpBaseline(NMMainOp):
       array in that channel.
 
     Parameters:
-        x0: Baseline window start in time units (default 0.0).
-        x1: Baseline window end in time units (default 0.0).  Must be >=
+        x0: Baseline window start in xscale units (default 0.0).
+        x1: Baseline window end in xscale units (default 0.0).  Must be >=
             ``x0``.
         mode: ``"per_array"`` (default) or ``"average"``.
         ignore_nans: If True (default) use ``np.nanmean``; otherwise ``np.mean``
@@ -1132,7 +1132,7 @@ class NMMainOpBaseline(NMMainOp):
 
     @property
     def x0(self) -> float:
-        """Baseline window start (time units)."""
+        """Baseline window start (xscale units)."""
         return self._x0
 
     @x0.setter
@@ -1145,7 +1145,7 @@ class NMMainOpBaseline(NMMainOp):
 
     @property
     def x1(self) -> float:
-        """Baseline window end (time units)."""
+        """Baseline window end (xscale units)."""
         return self._x1
 
     @x1.setter
@@ -1219,7 +1219,7 @@ class NMMainOpBaseline(NMMainOp):
             parsed = nmu.parse_data_name(data.name)
             channel_name = parsed[1] if parsed is not None else "A"
 
-        sl = nm_math.time_window_to_slice(
+        sl = nm_math.xscale_window_to_slice(
             data.nparray, data.xscale.to_dict(), self._x0, self._x1
         )
         segment = data.nparray[sl].astype(float)
@@ -1467,13 +1467,13 @@ _VALID_INTERP_X_EXTENT: frozenset[str] = frozenset({"overlap", "expand"})
 class NMMainOpInterpolate(NMMainOp):
     """Re-grid each array onto a common x-axis via interpolation.
 
-    Useful when arrays were recorded at slightly different time points and
-    need to be aligned to a shared x-axis before averaging or comparison.
+    Useful when arrays were recorded at slightly different sample rates and
+    need to be interpolated onto a shared x-axis before averaging or comparison.
     Uses :func:`nm_math.interpolate` (``scipy.interpolate``).
 
     Two x-axis sources:
 
-    - ``"common"``: derive the target x-axis from the data themselves.
+    - ``"common"``: derive the x-axis target from the data themselves.
       Requires ``run_all()`` (or ``NMToolMain``) so that all arrays are
       visible before interpolation begins.
     - ``"template"``: use the xscale of a named NMData array in the same
@@ -1639,7 +1639,7 @@ class NMMainOpInterpolate(NMMainOp):
         data: NMData,
         channel_name: str | None = None,
     ) -> None:
-        """Interpolate *data* in-place onto the target x-axis."""
+        """Interpolate *data* in-place onto the x-axis target."""
         y = data.nparray
         if y is None:
             return
@@ -1667,6 +1667,149 @@ class NMMainOpInterpolate(NMMainOp):
 
 
 # =========================================================================
+# Align
+# =========================================================================
+
+_VALID_ALIGN_TARGETS: frozenset[str] = frozenset({"mean", "min", "max"})
+
+
+class NMMainOpAlign(NMMainOp):
+    """Shift xscale.start of each array so reference xvalues align to a target.
+
+    For each array i, computes ``shift = target_value - xvalues[i]`` and sets::
+
+        data.xscale.start += shift
+
+    The data values and ``xscale.delta`` are unchanged.  To re-grid onto a
+    common x-axis after aligning, run :class:`NMMainOpInterpolate` afterwards.
+
+    Parameters:
+        xvalues: Reference xvalue(s), one per array:
+
+            - ``float``: the same xvalue is applied to every array.
+            - ``list[float]``: one per array in order; length must match
+              the number of data items.
+            - ``dict[str, float]``: lookup by data name; arrays whose name
+              is not in the dict are silently skipped.
+
+        target: Where to place the reference after alignment:
+
+            - ``float`` (default ``0.0``): a fixed xvalue.
+            - ``"mean"`` / ``"min"`` / ``"max"``: computed from *xvalues*
+              at runtime.
+    """
+
+    name = "align"
+
+    def __init__(
+        self,
+        xvalues: float | list[float] | dict[str, float] = 0.0,
+        target: float | str = 0.0,
+    ) -> None:
+        self.xvalues = xvalues
+        self.target = target
+        self._index: int = 0
+        self._target_xvalue: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def xvalues(self) -> float | list[float] | dict[str, float]:
+        """Reference xvalues: float, list[float], or dict[str, float]."""
+        return self._xvalues
+
+    @xvalues.setter
+    def xvalues(self, value: float | list[float] | dict[str, float]) -> None:
+        if isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "xvalues", "float, list, or dict"))
+        if isinstance(value, (int, float)):
+            self._xvalues = float(value)
+        elif isinstance(value, list):
+            self._xvalues = value
+        elif isinstance(value, dict):
+            self._xvalues = value
+        else:
+            raise TypeError(nmu.type_error_str(value, "xvalues", "float, list, or dict"))
+
+    @property
+    def target(self) -> float | str:
+        """Alignment target: float or ``'mean'`` / ``'min'`` / ``'max'``."""
+        return self._target
+
+    @target.setter
+    def target(self, value: float | str) -> None:
+        if isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "target", "float or string"))
+        if isinstance(value, (int, float)):
+            self._target = float(value)
+        elif isinstance(value, str):
+            if value not in _VALID_ALIGN_TARGETS:
+                raise ValueError(
+                    "target must be a float or one of %s, got %r"
+                    % (sorted(_VALID_ALIGN_TARGETS), value)
+                )
+            self._target = value
+        else:
+            raise TypeError(nmu.type_error_str(value, "target", "float or string"))
+
+    # ------------------------------------------------------------------
+    # Core
+
+    def run_init(self) -> None:
+        self._index = 0
+        if isinstance(self._xvalues, list) and len(self._xvalues) != self._n_items:
+            raise IndexError(
+                "NMMainOpAlign: xvalues list length must match number of "
+                "data items (need %d, got %d)" % (self._n_items, len(self._xvalues))
+            )
+        if isinstance(self._target, (int, float)):
+            self._target_xvalue = float(self._target)
+        else:
+            values = self._collect_xvalues()
+            if self._target == "mean":
+                self._target_xvalue = float(np.mean(values))
+            elif self._target == "min":
+                self._target_xvalue = float(np.min(values))
+            else:  # "max"
+                self._target_xvalue = float(np.max(values))
+
+    def _collect_xvalues(self) -> list[float]:
+        """Flatten xvalues to a list of floats for target computation."""
+        if isinstance(self._xvalues, (int, float)):
+            return [self._xvalues] * self._n_items
+        if isinstance(self._xvalues, list):
+            return [float(v) for v in self._xvalues]
+        return [float(v) for v in self._xvalues.values()]  # dict
+
+    def _get_xvalue(self, name: str) -> float | None:
+        if isinstance(self._xvalues, (int, float)):
+            return self._xvalues
+        if isinstance(self._xvalues, list):
+            v = float(self._xvalues[self._index])
+            self._index += 1
+            return v
+        return self._xvalues.get(name)  # dict: None → skip
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Shift *data* xscale.start in-place."""
+        xvalue = self._get_xvalue(data.name)
+        if xvalue is None:
+            return  # dict mode: name not found — skip
+        xshift = self._target_xvalue - xvalue
+        data.xscale.start = data.xscale.start + xshift
+        self._add_op_note(data, "xvalue=%.6g, target=%.6g, xshift=%.6g" % (
+            xvalue, self._target_xvalue, xshift))
+
+    def _op_params_str(self) -> str:
+        return "xvalues=%r, target=%r" % (self._xvalues, self._target)
+
+
+# =========================================================================
 # Normalize
 # =========================================================================
 
@@ -1674,7 +1817,7 @@ class NMMainOpInterpolate(NMMainOp):
 class NMMainOpNormalize(NMMainOp):
     """Rescale each array so a low reference maps to norm_min and a high reference maps to norm_max.
 
-    Two independent time windows are used:
+    Two independent xscale windows are used:
 
     - Window 1 (``x0_min``/``x1_min``) computes the "low" reference via
       ``fxn1`` (``"mean"``, ``"min"``, or ``"mean@min"``).
@@ -1688,13 +1831,13 @@ class NMMainOpNormalize(NMMainOp):
       then applied to every array in that channel.
 
     Parameters:
-        x0_min: Window 1 start in time units (default 0.0).
-        x1_min: Window 1 end in time units (default 0.0).
+        x0_min: Window 1 start in xscale units (default 0.0).
+        x1_min: Window 1 end in xscale units (default 0.0).
         fxn1: Function for the low reference: ``"mean"``, ``"min"``, or
             ``"mean@min"`` (default ``"mean"``).
         n_mean1: Points around min for ``mean@min`` (default 1).
-        x0_max: Window 2 start in time units (default 0.0).
-        x1_max: Window 2 end in time units (default 0.0).
+        x0_max: Window 2 start in xscale units (default 0.0).
+        x1_max: Window 2 end in xscale units (default 0.0).
         fxn2: Function for the high reference: ``"mean"``, ``"max"``, or
             ``"mean@max"`` (default ``"mean"``).
         n_mean2: Points around max for ``mean@max`` (default 1).
@@ -1740,7 +1883,7 @@ class NMMainOpNormalize(NMMainOp):
 
     @property
     def x0_min(self) -> float:
-        """Window 1 start (time units)."""
+        """Window 1 start (xscale units)."""
         return self._x0_min
 
     @x0_min.setter
@@ -1753,7 +1896,7 @@ class NMMainOpNormalize(NMMainOp):
 
     @property
     def x1_min(self) -> float:
-        """Window 1 end (time units)."""
+        """Window 1 end (xscale units)."""
         return self._x1_min
 
     @x1_min.setter
@@ -1794,7 +1937,7 @@ class NMMainOpNormalize(NMMainOp):
 
     @property
     def x0_max(self) -> float:
-        """Window 2 start (time units)."""
+        """Window 2 start (xscale units)."""
         return self._x0_max
 
     @x0_max.setter
@@ -1807,7 +1950,7 @@ class NMMainOpNormalize(NMMainOp):
 
     @property
     def x1_max(self) -> float:
-        """Window 2 end (time units)."""
+        """Window 2 end (xscale units)."""
         return self._x1_max
 
     @x1_max.setter
@@ -1944,8 +2087,8 @@ class NMMainOpNormalize(NMMainOp):
 
         arr = data.nparray.astype(float)
         xd = data.xscale.to_dict()
-        sl1 = nm_math.time_window_to_slice(arr, xd, self._x0_min, self._x1_min)
-        sl2 = nm_math.time_window_to_slice(arr, xd, self._x0_max, self._x1_max)
+        sl1 = nm_math.xscale_window_to_slice(arr, xd, self._x0_min, self._x1_min)
+        sl2 = nm_math.xscale_window_to_slice(arr, xd, self._x0_max, self._x1_max)
         ref_min = nm_math.compute_ref_value(arr[sl1], self._fxn1, self._n_mean1)
         ref_max = nm_math.compute_ref_value(arr[sl2], self._fxn2, self._n_mean2)
 
@@ -1998,7 +2141,7 @@ class NMMainOpNormalize(NMMainOp):
 class NMMainOpDFOF(NMMainOp):
     """Compute dF/F₀ = (F − F₀) / F₀ in-place for each data array.
 
-    F₀ is the mean fluorescence over the baseline time window [x0, x1].
+    F₀ is the mean fluorescence over the baseline xscale window [x0, x1].
     The array name is unchanged; a note records the transformation and F₀.
     After transformation, ``yscale.label`` is set to ``"dF/F"`` and
     ``yscale.units`` to ``""`` (dimensionless).
@@ -2130,7 +2273,7 @@ class NMMainOpDFOF(NMMainOp):
             channel_name = parsed[1] if parsed is not None else "A"
 
         arr = data.nparray.astype(float)
-        sl = nm_math.time_window_to_slice(
+        sl = nm_math.xscale_window_to_slice(
             arr, data.xscale.to_dict(), self._x0, self._x1
         )
         segment = arr[sl]
@@ -2206,7 +2349,7 @@ class NMMainOpRescale(NMMainOp):
 
     Parameters:
         to_units:   Target units string (e.g. ``"nA"``).  Required; must
-                    not be empty at run time.
+                    not be empty at runtime.
         from_units: Source units string.  Defaults to ``None``, which
                     means the source units are read from
                     ``data.yscale.units`` at runtime.  Raises
@@ -2297,7 +2440,7 @@ class NMMainOpRescaleX(NMMainOp):
 
     Parameters:
         to_units:   Target units string (e.g. ``"s"``).  Required; must
-                    not be empty at run time.
+                    not be empty at runtime.
         from_units: Source units string.  Defaults to ``None``, which
                     means the source units are read from
                     ``data.xscale.units`` at runtime.  Raises
@@ -3031,7 +3174,7 @@ class NMMainOpHistogram(NMMainOp):
     and the resulting bin-counts array is written as a new array
     ``H_{data.name}`` in the source folder (non-destructive).
 
-    The output array's x-scale represents the histogram bins:
+    The output array's xscale represents the histogram bins:
     ``xscale.start`` = left edge of the first bin,
     ``xscale.delta`` = uniform bin width.
     ``xscale.label`` / ``xscale.units`` are taken from the input
@@ -3043,9 +3186,9 @@ class NMMainOpHistogram(NMMainOp):
     Args:
         bins:    Number of equal-width bins (int) or explicit bin-edge
                  list.  Defaults to 10.
-        x0:      Start of the time window (default ``-inf`` = beginning
+        x0:      Start of the xscale window (default ``-inf`` = beginning
                  of array).
-        x1:      End of the time window (default ``+inf`` = end of array).
+        x1:      End of the xscale window (default ``+inf`` = end of array).
         xrange:  ``(min, max)`` tuple to restrict the amplitude range.
                  Defaults to None (full range of each array).
         density: If True, return probability density instead of counts.
@@ -3097,14 +3240,14 @@ class NMMainOpHistogram(NMMainOp):
             if value < 1:
                 raise ValueError("bins must be >= 1, got %d" % value)
         elif isinstance(value, list):
-            pass  # numpy validates content at histogram time
+            pass  # numpy validates content at np.histogram in run()
         else:
             raise TypeError(nmu.type_error_str(value, "bins", "int or list"))
         self._bins = value
 
     @property
     def x0(self) -> float:
-        """Start of the time window (default ``-inf``)."""
+        """Start of the xscale window (default ``-inf``)."""
         return self._x0
 
     @x0.setter
@@ -3117,7 +3260,7 @@ class NMMainOpHistogram(NMMainOp):
 
     @property
     def x1(self) -> float:
-        """End of the time window (default ``+inf``)."""
+        """End of the xscale window (default ``+inf``)."""
         return self._x1
 
     @x1.setter
@@ -3178,9 +3321,9 @@ class NMMainOpHistogram(NMMainOp):
             return
         arr = data.nparray.astype(float)
 
-        # Apply time window if either bound is finite
+        # Apply xscale window if either bound is finite
         if not (self._x0 == -math.inf and self._x1 == math.inf):
-            sl = nm_math.time_window_to_slice(
+            sl = nm_math.xscale_window_to_slice(
                 arr, data.xscale.to_dict(), self._x0, self._x1
             )
             arr = arr[sl]
@@ -3258,6 +3401,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "reverse": NMMainOpReverse,
     "rotate": NMMainOpRotate,
     # --- x-axis ---
+    "align": NMMainOpAlign,
     "interpolate": NMMainOpInterpolate,
     "resample": NMMainOpResample,
     "rescale_x": NMMainOpRescaleX,

--- a/pyneuromatic/analysis/nm_stat_func.py
+++ b/pyneuromatic/analysis/nm_stat_func.py
@@ -290,7 +290,7 @@ class NMStatFuncMaxMin(NMStatFunc):
 
 
 class NMStatFuncLevel(NMStatFunc):
-    """Level crossing with an explicit absolute y-value threshold.
+    """Level crossing with an explicit absolute yvalue threshold.
 
     Accepted names: level, level+, level-.
 

--- a/pyneuromatic/analysis/nm_stat_utilities.py
+++ b/pyneuromatic/analysis/nm_stat_utilities.py
@@ -110,7 +110,7 @@ def _stat_level(f, func, yarray, data, i0, ignore_nans, results, yunits,
             fxn.update({"yunits": yunits})
     if indexes.size > 0:  # return first level crossing
         results["i"] = indexes[0] + i0  # shift due to slicing
-        results["x"] = xvalues[0]  # shift not needed for x-values
+        results["x"] = xvalues[0]  # shift not needed for xvalues
         results["xunits"] = xunits
     else:
         results["i"] = None
@@ -320,7 +320,7 @@ def stat(
     """Compute a single statistic on an NMData object over an x-axis window.
 
     Args:
-        data: NMData containing the y-values (data.nparray) and x-scale.
+        data: NMData containing the yvalues (data.nparray) and x-scale.
         func: Dict specifying the statistic to compute. Must contain "name".
             Additional keys depend on the function type:
             - Basic stats (median, mean, var, std, sem, rms, sum, etc.):
@@ -358,7 +358,7 @@ def stat(
             "s"      — scalar result (float)
             "sunits" — units of "s" (str or None)
             "i"      — index of peak or level crossing (int or None)
-            "x"      — x-value at peak or level crossing (float or None)
+            "x"      — xvalue at peak or level crossing (float or None)
             "xunits" — units of "x" (str)
             "b"      — regression intercept (float), set by slope
             "bunits" — units of "b" (str or None), set by slope

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -94,8 +94,8 @@ class NMToolStats(NMTool):
 
         self.__xclip = True
         # if x0|x1 OOB, clip to data x-scale limits
-        # if x0 = -math.inf, then x0 will be clipped to smallest x-value
-        # if x1 = math.inf, then x1 will be clipped to largest x-value
+        # if x0 = -math.inf, then x0 will be clipped to smallest xvalue
+        # if x1 = math.inf, then x1 will be clipped to largest xvalue
 
         self.__ignore_nans = True
         # NumPy array analysis

--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -59,7 +59,7 @@ class NMData(NMObject):
     """
     NM Data class.
 
-    Holds a numpy array of data (y-values), optional x-array,
+    Holds a numpy array of data (yvalues), optional x-array,
     and x/y scale metadata as simple dicts.
     """
 
@@ -291,7 +291,7 @@ class NMData(NMObject):
         xvalue: float,
         clip: bool = False
     ) -> int | None:
-        """Convert an x-value to an array index.
+        """Convert an xvalue to an array index.
 
         Args:
             xvalue: The x-axis value to find.
@@ -350,7 +350,7 @@ class NMData(NMObject):
         index: int,
         clip: bool = False
     ) -> float | None:
-        """Convert an array index to an x-value.
+        """Convert an array index to an xvalue.
 
         Args:
             index: The array index.

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -196,17 +196,17 @@ def compute_ref_value(arr: np.ndarray, fxn: str, n_mean: int) -> float:
 
 
 # =========================================================================
-# Time-window helper
+# Xscale-window helper
 # =========================================================================
 
 
-def time_window_to_slice(
+def xscale_window_to_slice(
     arr: np.ndarray,
     xscale_dict: dict,
     x0: float,
     x1: float,
 ) -> slice:
-    """Convert a time window to an array slice using xscale start/delta.
+    """Convert a xscale window to an array slice using xscale start/delta.
 
     Clips to valid range; returns an empty slice if the window is fully
     outside the array bounds.  Infinite bounds are treated as array
@@ -215,9 +215,9 @@ def time_window_to_slice(
     Args:
         arr:         Array whose length defines the valid index range.
         xscale_dict: Dict with ``"start"`` and ``"delta"`` keys (floats).
-        x0:     Start of the time window.  ``-inf`` selects from the
+        x0:     Start of the xscale window.  ``-inf`` selects from the
                      beginning of the array.
-        x1:       End of the time window (inclusive).  ``+inf`` selects
+        x1:       End of the xscale window (inclusive).  ``+inf`` selects
                      to the end of the array.
 
     Returns:
@@ -417,7 +417,7 @@ def array_stats(
 def interp_x(ylevel: float, x0: float, y0: float, x1: float, y1: float) -> float:
     """Interpolate the x-coordinate where a line segment crosses *ylevel*.
 
-    Fits a line through (x0, y0) and (x1, y1) and returns the x-value
+    Fits a line through (x0, y0) and (x1, y1) and returns the xvalue
     where that line equals *ylevel*.
 
     Args:
@@ -426,7 +426,7 @@ def interp_x(ylevel: float, x0: float, y0: float, x1: float, y1: float) -> float
         x1, y1: Coordinates of the second point.
 
     Returns:
-        Interpolated x-value (float) at y = ylevel.
+        Interpolated xvalue (float) at y = ylevel.
     """
     dx = x1 - x0
     dy = y1 - y0
@@ -451,16 +451,16 @@ def find_level_crossings(
 
     A crossing is detected wherever the signal transitions across *ylevel*
     (i.e. ``np.diff(yarray > ylevel)`` is True). For each crossing, the
-    nearest sample index and interpolated x-value are returned.
+    nearest sample index and interpolated xvalue are returned.
 
     Args:
-        yarray:      1-D numpy array of y-values to search.
+        yarray:      1-D numpy array of yvalues to search.
         ylevel:      The y-axis threshold to search for.
         func_name:   Controls which crossing directions are returned:
                      ``"level"`` — all crossings (both rising and falling).
                      ``"level+"`` — rising crossings only.
                      ``"level-"`` — falling crossings only.
-        xarray:      Optional 1-D numpy array of x-values (same size as
+        xarray:      Optional 1-D numpy array of xvalues (same size as
                      *yarray*). Used instead of *xstart*/*xdelta* when
                      provided.
         xstart:      X-scale start value; used when *xarray* is None.
@@ -468,8 +468,8 @@ def find_level_crossings(
         i_nearest:   If True (default), returns the sample index nearest to
                      the crossing via linear interpolation. If False, returns
                      the index immediately after the crossing.
-        x_interp:    If True (default), returns the interpolated x-value at
-                     the exact crossing. If False, returns the x-value at
+        x_interp:    If True (default), returns the interpolated xvalue at
+                     the exact crossing. If False, returns the xvalue at
                      the nearest sample index.
         ignore_nans: If True (default), NaN values are included in the
                      transition detection.
@@ -477,7 +477,7 @@ def find_level_crossings(
     Returns:
         Tuple ``(indexes, xvalues)`` of numpy arrays:
         *indexes* — sample indices (int) nearest to each crossing.
-        *xvalues* — x-values (float) at each crossing location.
+        *xvalues* — xvalues (float) at each crossing location.
         Both arrays are empty if no crossings are found.
 
     Raises:
@@ -603,8 +603,8 @@ def linear_regression(
     """Fit a linear regression line to y-data using ``numpy.polyfit``.
 
     Args:
-        yarray:      1-D numpy array of y-values.
-        xarray:      Optional 1-D numpy array of x-values (same size as
+        yarray:      1-D numpy array of yvalues.
+        xarray:      Optional 1-D numpy array of xvalues (same size as
                      *yarray*). Used instead of *xstart*/*xdelta* when
                      provided.
         xstart:      X-scale start value; used to build a uniform x-array
@@ -686,7 +686,7 @@ def smooth_boxcar(
     """Boxcar (moving average) smooth via ``np.convolve``.
 
     Args:
-        y: 1-D numpy array of y-values.
+        y: 1-D numpy array of yvalues.
         window: Kernel width in points. Must be an odd integer >= 3.
         passes: Number of times to apply the kernel. Must be >= 1. Default 1.
 
@@ -724,7 +724,7 @@ def smooth_binomial(
     """Binomial smooth: apply 3-point binomial kernel via ``np.convolve``.
 
     Args:
-        y: 1-D numpy array of y-values.
+        y: 1-D numpy array of yvalues.
         passes: Number of times to apply the 3-point binomial kernel.
             Must be >= 1. More passes produce a wider effective smooth.
 
@@ -757,7 +757,7 @@ def smooth_savgol(
     """Savitzky-Golay smooth via ``scipy.signal.savgol_filter``.
 
     Args:
-        y: 1-D numpy array of y-values.
+        y: 1-D numpy array of yvalues.
         window: Kernel width in points. Must be an odd integer and
             >= *polyorder* + 2.
         polyorder: Polynomial order. Must be an integer >= 1 and
@@ -811,7 +811,7 @@ def resample(
     ``resample_poly``'s integer ``up`` / ``down`` requirement.
 
     Args:
-        y: 1-D numpy array of y-values.
+        y: 1-D numpy array of yvalues.
         old_delta: Current sample interval (any consistent units).
         new_delta: Desired sample interval (same units as *old_delta*).
 
@@ -859,14 +859,14 @@ def interpolate(
     outside the range of *x_old* are filled with ``NaN``.
 
     Args:
-        y: 1-D numpy array of y-values corresponding to *x_old*.
+        y: 1-D numpy array of yvalues corresponding to *x_old*.
         x_old: 1-D numpy array of original x-positions (must be strictly
             increasing).
         x_new: 1-D numpy array of target x-positions.
         method: ``"linear"`` (default) or ``"cubic"``.
 
     Returns:
-        1-D numpy array of interpolated y-values at *x_new* positions.
+        1-D numpy array of interpolated yvalues at *x_new* positions.
 
     Raises:
         TypeError: If any array argument is not a numpy ndarray.
@@ -1014,7 +1014,7 @@ def stability_test(
     """Find the largest stable (trend-free) window in a 1-D array.
 
     Tests whether consecutive subsets of values have no significant monotonic
-    trend over time using the Spearman rank-order correlation between values
+    trend using the Spearman rank-order correlation between values
     and their array indices. Searches from the largest possible window down to
     ``min_window``, stopping as soon as the largest stable window is found.
 

--- a/pyneuromatic/core/nm_transform.py
+++ b/pyneuromatic/core/nm_transform.py
@@ -41,7 +41,7 @@ class NMTransform:
     that subclasses override.
 
     Transforms operate on numpy ndarrays (y-data) and optionally receive
-    NMScaleX for x-scale information. Simple transforms ignore xscale.
+    NMScaleX for xscale information. Simple transforms ignore xscale.
     """
 
     _path_suffix: str = "transform"
@@ -106,11 +106,11 @@ class NMTransform:
         """Apply this transform to y-data.
 
         Args:
-            ydata: numpy ndarray of y-values.
-            xscale: optional NMScaleX for x-scale info (start, delta).
+            ydata: numpy ndarray of yvalues.
+            xscale: optional NMScaleX for xscale info (start, delta).
 
         Returns:
-            numpy ndarray of transformed y-values.
+            numpy ndarray of transformed yvalues.
 
         Raises:
             NotImplementedError: if subclass does not override.
@@ -453,9 +453,9 @@ def apply_transforms(
     """Apply an ordered list of transforms to y-data.
 
     Args:
-        ydata: numpy ndarray of y-values.
+        ydata: numpy ndarray of yvalues.
         transforms: ordered list of NMTransform objects, or None.
-        xscale: optional NMScaleX for x-scale info.
+        xscale: optional NMScaleX for xscale info.
 
     Returns:
         Transformed numpy ndarray (copy; original is never modified).

--- a/tests/test_analysis/test_nm_stat_igor.py
+++ b/tests/test_analysis/test_nm_stat_igor.py
@@ -64,7 +64,7 @@ _N_MEAN = 500  # n_mean for mean@max and mean@min (10 ms window at 0.02 ms sampl
 #     baseline: mean over [0, T0-dx]
 #     signal:   [T0, T0+TAU]
 
-_S_DX  = 0.02   # ms, x-scale delta
+_S_DX  = 0.02   # ms, xscale delta
 _S_T0  = 10.0   # ms, pulse start (baseline ends just before this)
 _S_TAU = 20.0   # ms, half-sine duration (peak at T0 + TAU/2 = 20 ms)
 _S_AMP = 1.0    # amplitude (y-units)

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -37,6 +37,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpReplaceValues,
     NMMainOpConcatenate,
     NMMainOpRescale,
+    NMMainOpAlign,
     NMMainOpInterpolate,
     NMMainOpResample,
     NMMainOpRescaleX,
@@ -3776,6 +3777,161 @@ class TestNMMainOpInterpolate(unittest.TestCase):
     def test_op_from_name_interpolate(self):
         op = op_from_name("interpolate")
         self.assertIsInstance(op, NMMainOpInterpolate)
+
+
+# ===========================================================================
+# TestNMMainOpAlign
+# ===========================================================================
+
+
+class TestNMMainOpAlign(unittest.TestCase):
+
+    # --- constructor validation ---
+
+    def test_rejects_bool_xvalues(self):
+        with self.assertRaises(TypeError):
+            NMMainOpAlign(xvalues=True)
+
+    def test_rejects_string_xvalues(self):
+        with self.assertRaises(TypeError):
+            NMMainOpAlign(xvalues="0.1")
+
+    def test_rejects_bool_target(self):
+        with self.assertRaises(TypeError):
+            NMMainOpAlign(target=True)
+
+    def test_rejects_invalid_target_string(self):
+        with self.assertRaises(ValueError):
+            NMMainOpAlign(target="median")
+
+    def test_valid_target_strings(self):
+        for t in ("mean", "min", "max"):
+            op = NMMainOpAlign(target=t)
+            self.assertEqual(op.target, t)
+
+    # --- helpers ---
+
+    def _make_items(self, arrays_by_name, xstart=0.0, xdelta=0.1):
+        """Build NMFolder + data_items list from {name: array} dict."""
+        folder = NMFolder(name="folder0")
+        data_items = []
+        for name, arr in arrays_by_name.items():
+            d = folder.data.new(
+                name,
+                nparray=np.array(arr, dtype=float),
+                xscale={"start": xstart, "delta": xdelta},
+            )
+            data_items.append((d, None))
+        return folder, data_items
+
+    # --- scalar xvalues ---
+
+    def test_scalar_shifts_all_arrays(self):
+        # x_time=0.05 for all, target=0.0 → shift=-0.05
+        folder, data_items = self._make_items(
+            {"RecordA0": [1.0, 2.0], "RecordA1": [3.0, 4.0]}, xstart=0.0
+        )
+        op = NMMainOpAlign(xvalues=0.05, target=0.0)
+        op.run_all(data_items, folder)
+        for d, _ in data_items:
+            self.assertAlmostEqual(d.xscale.start, -0.05)
+
+    # --- list xvalues ---
+
+    def test_list_each_array_gets_own_shift(self):
+        folder, data_items = self._make_items(
+            {"RecordA0": [1.0], "RecordA1": [1.0], "RecordA2": [1.0]}, xstart=0.0
+        )
+        op = NMMainOpAlign(xvalues=[0.1, 0.2, 0.3], target=0.0)
+        op.run_all(data_items, folder)
+        expected = [-0.1, -0.2, -0.3]
+        for (d, _), exp in zip(data_items, expected):
+            self.assertAlmostEqual(d.xscale.start, exp)
+
+    def test_list_length_mismatch_raises(self):
+        folder, data_items = self._make_items(
+            {"RecordA0": [1.0], "RecordA1": [1.0]}
+        )
+        op = NMMainOpAlign(xvalues=[0.1, 0.2, 0.3])  # 3 != 2
+        with self.assertRaises(IndexError):
+            op.run_all(data_items, folder)
+
+    # --- dict xvalues ---
+
+    def test_dict_shifts_named_arrays(self):
+        folder, data_items = self._make_items(
+            {"RecordA0": [1.0], "RecordA1": [1.0]}, xstart=0.0
+        )
+        op = NMMainOpAlign(xvalues={"RecordA0": 0.1}, target=0.0)
+        op.run_all(data_items, folder)
+        self.assertAlmostEqual(folder.data.get("RecordA0").xscale.start, -0.1)
+        self.assertAlmostEqual(folder.data.get("RecordA1").xscale.start, 0.0)  # skipped
+
+    # --- target="mean" / "min" / "max" ---
+
+    def test_target_mean(self):
+        # xvalues=[0.1, 0.3] → mean=0.2; shifts: 0.1, -0.1
+        folder, data_items = self._make_items(
+            {"RecordA0": [1.0], "RecordA1": [1.0]}, xstart=0.0
+        )
+        op = NMMainOpAlign(xvalues=[0.1, 0.3], target="mean")
+        op.run_all(data_items, folder)
+        self.assertAlmostEqual(folder.data.get("RecordA0").xscale.start, 0.1)
+        self.assertAlmostEqual(folder.data.get("RecordA1").xscale.start, -0.1)
+
+    def test_target_min(self):
+        # xvalues=[0.1, 0.3] → min=0.1; shifts: 0.0, -0.2
+        folder, data_items = self._make_items(
+            {"RecordA0": [1.0], "RecordA1": [1.0]}, xstart=0.0
+        )
+        op = NMMainOpAlign(xvalues=[0.1, 0.3], target="min")
+        op.run_all(data_items, folder)
+        self.assertAlmostEqual(folder.data.get("RecordA0").xscale.start, 0.0)
+        self.assertAlmostEqual(folder.data.get("RecordA1").xscale.start, -0.2)
+
+    def test_target_max(self):
+        # xvalues=[0.1, 0.3] → max=0.3; shifts: 0.2, 0.0
+        folder, data_items = self._make_items(
+            {"RecordA0": [1.0], "RecordA1": [1.0]}, xstart=0.0
+        )
+        op = NMMainOpAlign(xvalues=[0.1, 0.3], target="max")
+        op.run_all(data_items, folder)
+        self.assertAlmostEqual(folder.data.get("RecordA0").xscale.start, 0.2)
+        self.assertAlmostEqual(folder.data.get("RecordA1").xscale.start, 0.0)
+
+    # --- data values and delta unchanged ---
+
+    def test_data_values_unchanged(self):
+        folder, data_items = self._make_items({"RecordA0": [1.0, 2.0, 3.0]})
+        NMMainOpAlign(xvalues=0.1, target=0.0).run_all(data_items, folder)
+        np.testing.assert_array_equal(
+            folder.data.get("RecordA0").nparray, [1.0, 2.0, 3.0]
+        )
+
+    def test_xscale_delta_unchanged(self):
+        folder, data_items = self._make_items(
+            {"RecordA0": [1.0, 2.0]}, xdelta=0.1
+        )
+        NMMainOpAlign(xvalues=0.05, target=0.0).run_all(data_items, folder)
+        self.assertAlmostEqual(data_items[0][0].xscale.delta, 0.1)
+
+    # --- notes ---
+
+    def test_note_contains_op_name(self):
+        folder, data_items = self._make_items({"RecordA0": [1.0]})
+        NMMainOpAlign(xvalues=0.1, target=0.0).run_all(data_items, folder)
+        self.assertIn("NMAlign(", folder.data.get("RecordA0").notes[0]["note"])
+
+    def test_note_contains_xshift(self):
+        folder, data_items = self._make_items({"RecordA0": [1.0]})
+        NMMainOpAlign(xvalues=0.1, target=0.0).run_all(data_items, folder)
+        self.assertIn("xshift=", folder.data.get("RecordA0").notes[0]["note"])
+
+    # --- registry ---
+
+    def test_op_from_name_align(self):
+        op = op_from_name("align")
+        self.assertIsInstance(op, NMMainOpAlign)
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -22,7 +22,7 @@ from pyneuromatic.core.nm_math import (
     linear_regression,
     parse_si_units,
     si_scale_factor,
-    time_window_to_slice,
+    xscale_window_to_slice,
 )
 
 
@@ -245,48 +245,48 @@ class TestComputeRefValue:
 
 
 # ---------------------------------------------------------------------------
-# TestTimeWindowToSlice
+# TestXscaleWindowToSlice
 # ---------------------------------------------------------------------------
 
 
-class TestTimeWindowToSlice:
+class TestXscaleWindowToSlice:
     ARR = np.zeros(10)
     XD = {"start": 0.0, "delta": 1.0}
 
     def test_basic_slice(self):
-        s = time_window_to_slice(self.ARR, self.XD, 2.0, 4.0)
+        s = xscale_window_to_slice(self.ARR, self.XD, 2.0, 4.0)
         assert s == slice(2, 5)
 
     def test_clips_low(self):
-        s = time_window_to_slice(self.ARR, self.XD, -5.0, 3.0)
+        s = xscale_window_to_slice(self.ARR, self.XD, -5.0, 3.0)
         assert s.start == 0
 
     def test_clips_high(self):
-        s = time_window_to_slice(self.ARR, self.XD, 7.0, 20.0)
+        s = xscale_window_to_slice(self.ARR, self.XD, 7.0, 20.0)
         assert s.stop == len(self.ARR)
 
     def test_zero_delta_returns_empty(self):
         xd = {"start": 0.0, "delta": 0.0}
-        s = time_window_to_slice(self.ARR, xd, 0.0, 5.0)
+        s = xscale_window_to_slice(self.ARR, xd, 0.0, 5.0)
         assert s == slice(0, 0)
 
     def test_non_unit_delta(self):
         xd = {"start": 0.0, "delta": 0.5}
         arr = np.zeros(20)
-        s = time_window_to_slice(arr, xd, 1.0, 2.0)
+        s = xscale_window_to_slice(arr, xd, 1.0, 2.0)
         # i0 = round((1.0-0)/0.5)=2, i1 = round((2.0-0)/0.5)+1=5
         assert s == slice(2, 5)
 
     def test_neg_inf_begin(self):
-        s = time_window_to_slice(self.ARR, self.XD, -math.inf, 4.0)
+        s = xscale_window_to_slice(self.ARR, self.XD, -math.inf, 4.0)
         assert s.start == 0
 
     def test_pos_inf_end(self):
-        s = time_window_to_slice(self.ARR, self.XD, 2.0, math.inf)
+        s = xscale_window_to_slice(self.ARR, self.XD, 2.0, math.inf)
         assert s.stop == len(self.ARR)
 
     def test_both_inf(self):
-        s = time_window_to_slice(self.ARR, self.XD, -math.inf, math.inf)
+        s = xscale_window_to_slice(self.ARR, self.XD, -math.inf, math.inf)
         assert s == slice(0, len(self.ARR))
 
 


### PR DESCRIPTION
## Summary

- Add `NMMainOpAlign` to shift `xscale.start` of each array so that a
  per-array reference x-value (e.g. EPSC peak x-time from Stats Tool)
  aligns to a chosen target x-value
- Data values and `xscale.delta` are unchanged; run `NMMainOpInterpolate`
  afterwards if a common x-grid is needed
- `xvalues` accepts `float` (scalar), `list[float]` (one per array in
  order), or `dict[str, float]` (lookup by data name — unmatched arrays
  are silently skipped)
- `target` accepts a `float` (default `0.0`) or `"mean"` / `"min"` /
  `"max"` computed from `xvalues` at run time
- Registered as `"align"` in `_OP_REGISTRY` (x-axis group)

## Test plan

- [ ] `TestNMMainOpAlign` in `test_nm_tool_main.py` covers: constructor
  validation, scalar/list/dict `xvalues` modes, list length mismatch,
  all three string targets, data values unchanged, delta unchanged,
  note contents, and registry lookup
- [ ] Full test suite passes: `python3 -m pytest -q`

Closes #250

