### PR TITLE
feat: add NMMainOpFilter and NMTransformFilter (Butterworth, Bessel, notch)

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -1398,6 +1398,202 @@ class NMMainOpSmooth(NMMainOp):
 
 
 # =========================================================================
+# Filter
+# =========================================================================
+
+
+class NMMainOpFilter(NMMainOp):
+    """Filter each array using Butterworth, Bessel, or notch filtering.
+
+    All filters are applied zero-phase (forward-backward) via
+    ``sosfiltfilt`` or ``filtfilt``, so no phase distortion is introduced.
+
+    Three filter types:
+
+    - ``"butterworth"``: maximally flat magnitude; general-purpose low-pass,
+      high-pass, or band-pass.
+    - ``"bessel"``: maximally flat group delay; preferred when waveform
+      shape must be preserved (e.g. spike kinetics, EPSC rise times).
+    - ``"notch"``: narrow band-stop at *cutoff* Hz; removes mains
+      interference (50 or 60 Hz).
+
+    Parameters:
+        filter_type: ``"butterworth"`` (default), ``"bessel"``, or
+            ``"notch"``.
+        cutoff: Cutoff frequency in Hz.  For ``btype='bandpass'`` supply
+            ``[low_hz, high_hz]``.  For ``"notch"`` this is the centre
+            frequency to remove.
+        order: Filter order (int >= 1).  Not used for ``"notch"``.
+            Default 4.
+        btype: ``"low"`` (default), ``"high"``, or ``"bandpass"``.
+            Not used for ``"notch"``.
+        q: Quality factor for ``"notch"`` — ratio of centre frequency to
+            bandwidth; higher values give a narrower notch. Default 30.
+        sample_rate: Sample rate in Hz.  If ``None`` (default), derived
+            from ``xscale.delta`` and ``xscale.units`` at run time
+            (assumes SI-prefixed time units, e.g. ``"ms"``).
+    """
+
+    name = "filter"
+
+    def __init__(
+        self,
+        filter_type: str = "butterworth",
+        cutoff: float | list[float] = 1000.0,
+        order: int = 4,
+        btype: str = "low",
+        q: float = 30.0,
+        sample_rate: float | None = None,
+    ) -> None:
+        self.filter_type = filter_type
+        self.cutoff = cutoff
+        self.order = order
+        self.btype = btype
+        self.q = q
+        self.sample_rate = sample_rate
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def filter_type(self) -> str:
+        """Filter type: ``'butterworth'``, ``'bessel'``, or ``'notch'``."""
+        return self._filter_type
+
+    @filter_type.setter
+    def filter_type(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "filter_type", "string"))
+        if value not in nm_math._VALID_FILTER_TYPES:
+            raise ValueError(
+                "filter_type must be one of %s, got %r"
+                % (sorted(nm_math._VALID_FILTER_TYPES), value)
+            )
+        self._filter_type = value
+
+    @property
+    def cutoff(self) -> float | list[float]:
+        """Cutoff frequency in Hz (float, or [low, high] for bandpass)."""
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value: float | list[float]) -> None:
+        if isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "cutoff", "float or list"))
+        if isinstance(value, (int, float)):
+            if value <= 0:
+                raise ValueError("cutoff must be > 0, got %g" % value)
+            self._cutoff = float(value)
+        elif isinstance(value, list):
+            self._cutoff = value
+        else:
+            raise TypeError(nmu.type_error_str(value, "cutoff", "float or list"))
+
+    @property
+    def order(self) -> int:
+        """Filter order (int >= 1). Not used for notch."""
+        return self._order
+
+    @order.setter
+    def order(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "order", "int"))
+        if value < 1:
+            raise ValueError("order must be >= 1, got %d" % value)
+        self._order = value
+
+    @property
+    def btype(self) -> str:
+        """Filter band type: ``'low'``, ``'high'``, or ``'bandpass'``. Not used for notch."""
+        return self._btype
+
+    @btype.setter
+    def btype(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "btype", "string"))
+        if value not in nm_math._VALID_FILTER_BTYPES:
+            raise ValueError(
+                "btype must be one of %s, got %r"
+                % (sorted(nm_math._VALID_FILTER_BTYPES), value)
+            )
+        self._btype = value
+
+    @property
+    def q(self) -> float:
+        """Quality factor for notch filter (float > 0). Not used for other types."""
+        return self._q
+
+    @q.setter
+    def q(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "q", "float"))
+        if value <= 0:
+            raise ValueError("q must be > 0, got %g" % value)
+        self._q = float(value)
+
+    @property
+    def sample_rate(self) -> float | None:
+        """Sample rate in Hz. If None, derived from xscale at run time."""
+        return self._sample_rate
+
+    @sample_rate.setter
+    def sample_rate(self, value: float | None) -> None:
+        if value is None:
+            self._sample_rate = None
+            return
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "sample_rate", "float"))
+        if value <= 0:
+            raise ValueError("sample_rate must be > 0, got %g" % value)
+        self._sample_rate = float(value)
+
+    # ------------------------------------------------------------------
+    # Core
+
+    def _resolve_sample_rate(self, data: NMData) -> float:
+        """Return sample rate in Hz from parameter or xscale."""
+        if self._sample_rate is not None:
+            return self._sample_rate
+        delta = data.xscale.delta
+        units = data.xscale.units
+        if units:
+            factor = nm_math.si_scale_factor(units, "s")
+            return 1.0 / (delta * factor)
+        return 1.0 / delta  # assume seconds
+
+    def run(
+        self,
+        data: NMData,
+        channel_name: str | None = None,
+    ) -> None:
+        """Filter *data* in-place."""
+        y = data.nparray
+        if y is None:
+            return
+        sr = self._resolve_sample_rate(data)
+        if self._filter_type == "butterworth":
+            data.nparray = nm_math.filter_butterworth(
+                y, self._cutoff, sr, self._order, self._btype
+            )
+        elif self._filter_type == "bessel":
+            data.nparray = nm_math.filter_bessel(
+                y, self._cutoff, sr, self._order, self._btype
+            )
+        else:  # notch
+            data.nparray = nm_math.filter_notch(y, self._cutoff, sr, self._q)
+        self._add_op_note(data, self._op_params_str())
+
+    def _op_params_str(self) -> str:
+        if self._filter_type == "notch":
+            return "filter_type=%r, cutoff=%r, q=%r" % (
+                self._filter_type, self._cutoff, self._q
+            )
+        return "filter_type=%r, cutoff=%r, order=%r, btype=%r" % (
+            self._filter_type, self._cutoff, self._order, self._btype
+        )
+
+
+# =========================================================================
 # Resample
 # =========================================================================
 
@@ -3385,6 +3581,7 @@ _OP_REGISTRY: dict[str, type[NMMainOp]] = {
     "rescale": NMMainOpRescale,
     # --- calculus / signal conditioning ---
     "differentiate": NMMainOpDifferentiate,
+    "filter": NMMainOpFilter,
     "integrate": NMMainOpIntegrate,
     "smooth": NMMainOpSmooth,
     # --- statistics / comparison ---

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -793,6 +793,187 @@ def smooth_savgol(
 
 
 # =========================================================================
+# Filter functions
+# =========================================================================
+
+_VALID_FILTER_TYPES: frozenset[str] = frozenset({"butterworth", "bessel", "notch"})
+_VALID_FILTER_BTYPES: frozenset[str] = frozenset({"low", "high", "bandpass"})
+
+
+def filter_butterworth(
+    y: np.ndarray,
+    cutoff: float | list[float],
+    sample_rate: float,
+    order: int = 4,
+    btype: str = "low",
+) -> np.ndarray:
+    """Butterworth filter via ``scipy.signal.butter`` + ``sosfiltfilt``.
+
+    Applies a zero-phase Butterworth filter (forward-backward via
+    ``sosfiltfilt``), which introduces no phase distortion.  Suitable for
+    general-purpose low-pass, high-pass, and band-pass filtering.
+
+    Args:
+        y: 1-D numpy array of y-values.
+        cutoff: Cutoff frequency in Hz.  For ``btype='bandpass'`` supply a
+            two-element list ``[low_hz, high_hz]``.
+        sample_rate: Sample rate in Hz (must be > 0).
+        order: Filter order (int >= 1). Default 4.
+        btype: ``'low'``, ``'high'``, or ``'bandpass'``. Default ``'low'``.
+
+    Returns:
+        Filtered copy of *y* with the same length.
+
+    Raises:
+        TypeError: If *y* is not a numpy ndarray or numeric params have
+            wrong types (bool rejected for int params).
+        ValueError: If *sample_rate* <= 0, *order* < 1, *btype* is invalid,
+            or *cutoff* is at or above the Nyquist frequency.
+    """
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+    if isinstance(sample_rate, bool) or not isinstance(sample_rate, (int, float)):
+        raise TypeError(nmu.type_error_str(sample_rate, "sample_rate", "float"))
+    if sample_rate <= 0:
+        raise ValueError("sample_rate must be > 0, got %g" % sample_rate)
+    if isinstance(order, bool) or not isinstance(order, int):
+        raise TypeError(nmu.type_error_str(order, "order", "int"))
+    if order < 1:
+        raise ValueError("order must be >= 1, got %d" % order)
+    if not isinstance(btype, str) or btype not in _VALID_FILTER_BTYPES:
+        raise ValueError(
+            "btype must be one of %s, got %r" % (sorted(_VALID_FILTER_BTYPES), btype)
+        )
+    if isinstance(cutoff, bool):
+        raise TypeError(nmu.type_error_str(cutoff, "cutoff", "float or list"))
+    if isinstance(cutoff, (int, float)):
+        if cutoff <= 0:
+            raise ValueError("cutoff must be > 0, got %g" % cutoff)
+    elif not isinstance(cutoff, list):
+        raise TypeError(nmu.type_error_str(cutoff, "cutoff", "float or list"))
+    from scipy.signal import butter, sosfiltfilt
+    nyq = sample_rate / 2.0
+    if isinstance(cutoff, (list, np.ndarray)):
+        norm = [c / nyq for c in cutoff]
+    else:
+        norm = cutoff / nyq
+    sos = butter(order, norm, btype=btype, output="sos")
+    return sosfiltfilt(sos, y.astype(float))
+
+
+def filter_bessel(
+    y: np.ndarray,
+    cutoff: float | list[float],
+    sample_rate: float,
+    order: int = 4,
+    btype: str = "low",
+) -> np.ndarray:
+    """Bessel filter via ``scipy.signal.bessel`` + ``sosfiltfilt``.
+
+    Applies a zero-phase Bessel filter (forward-backward via
+    ``sosfiltfilt``).  Bessel filters have maximally flat group delay,
+    which preserves waveform shape — preferred when timing is critical
+    (e.g. spike kinetics, EPSC rise times).
+
+    Args:
+        y: 1-D numpy array of y-values.
+        cutoff: Cutoff frequency in Hz.  For ``btype='bandpass'`` supply a
+            two-element list ``[low_hz, high_hz]``.
+        sample_rate: Sample rate in Hz (must be > 0).
+        order: Filter order (int >= 1). Default 4.
+        btype: ``'low'``, ``'high'``, or ``'bandpass'``. Default ``'low'``.
+
+    Returns:
+        Filtered copy of *y* with the same length.
+
+    Raises:
+        TypeError: If *y* is not a numpy ndarray or numeric params have
+            wrong types (bool rejected for int params).
+        ValueError: If *sample_rate* <= 0, *order* < 1, *btype* is invalid,
+            or *cutoff* is at or above the Nyquist frequency.
+    """
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+    if isinstance(sample_rate, bool) or not isinstance(sample_rate, (int, float)):
+        raise TypeError(nmu.type_error_str(sample_rate, "sample_rate", "float"))
+    if sample_rate <= 0:
+        raise ValueError("sample_rate must be > 0, got %g" % sample_rate)
+    if isinstance(order, bool) or not isinstance(order, int):
+        raise TypeError(nmu.type_error_str(order, "order", "int"))
+    if order < 1:
+        raise ValueError("order must be >= 1, got %d" % order)
+    if not isinstance(btype, str) or btype not in _VALID_FILTER_BTYPES:
+        raise ValueError(
+            "btype must be one of %s, got %r" % (sorted(_VALID_FILTER_BTYPES), btype)
+        )
+    if isinstance(cutoff, bool):
+        raise TypeError(nmu.type_error_str(cutoff, "cutoff", "float or list"))
+    if isinstance(cutoff, (int, float)):
+        if cutoff <= 0:
+            raise ValueError("cutoff must be > 0, got %g" % cutoff)
+    elif not isinstance(cutoff, list):
+        raise TypeError(nmu.type_error_str(cutoff, "cutoff", "float or list"))
+    from scipy.signal import bessel, sosfiltfilt
+    nyq = sample_rate / 2.0
+    if isinstance(cutoff, (list, np.ndarray)):
+        norm = [c / nyq for c in cutoff]
+    else:
+        norm = cutoff / nyq
+    sos = bessel(order, norm, btype=btype, output="sos", norm="phase")
+    return sosfiltfilt(sos, y.astype(float))
+
+
+def filter_notch(
+    y: np.ndarray,
+    freq: float,
+    sample_rate: float,
+    q: float = 30.0,
+) -> np.ndarray:
+    """Notch (band-stop) filter via ``scipy.signal.iirnotch`` + ``filtfilt``.
+
+    Removes a narrow frequency band centred on *freq* (e.g. 50 or 60 Hz
+    mains interference).  Applies zero-phase filtering via ``filtfilt``.
+
+    Args:
+        y: 1-D numpy array of y-values.
+        freq: Centre frequency to remove, in Hz (must be > 0 and < Nyquist).
+        sample_rate: Sample rate in Hz (must be > 0).
+        q: Quality factor — ratio of centre frequency to bandwidth.
+            Higher values give a narrower notch. Default 30.
+
+    Returns:
+        Filtered copy of *y* with the same length.
+
+    Raises:
+        TypeError: If *y* is not a numpy ndarray or numeric params have
+            wrong types (bool rejected).
+        ValueError: If *sample_rate* <= 0, *freq* <= 0 or >= Nyquist,
+            or *q* <= 0.
+    """
+    if not isinstance(y, np.ndarray):
+        raise TypeError(nmu.type_error_str(y, "y", "numpy.ndarray"))
+    if isinstance(sample_rate, bool) or not isinstance(sample_rate, (int, float)):
+        raise TypeError(nmu.type_error_str(sample_rate, "sample_rate", "float"))
+    if sample_rate <= 0:
+        raise ValueError("sample_rate must be > 0, got %g" % sample_rate)
+    if isinstance(freq, bool) or not isinstance(freq, (int, float)):
+        raise TypeError(nmu.type_error_str(freq, "freq", "float"))
+    nyq = sample_rate / 2.0
+    if freq <= 0 or freq >= nyq:
+        raise ValueError(
+            "freq must be > 0 and < Nyquist (%.6g Hz), got %g" % (nyq, freq)
+        )
+    if isinstance(q, bool) or not isinstance(q, (int, float)):
+        raise TypeError(nmu.type_error_str(q, "q", "float"))
+    if q <= 0:
+        raise ValueError("q must be > 0, got %g" % q)
+    from scipy.signal import iirnotch, sosfiltfilt, tf2sos
+    b, a = iirnotch(freq / nyq, q)
+    sos = tf2sos(b, a)
+    return sosfiltfilt(sos, y.astype(float))
+
+
+# =========================================================================
 # Resample and interpolate
 # =========================================================================
 

--- a/pyneuromatic/core/nm_transform.py
+++ b/pyneuromatic/core/nm_transform.py
@@ -378,6 +378,230 @@ class NMTransformSmooth(NMTransform):
 
 
 # =========================================================================
+# Filter transform
+# =========================================================================
+
+
+class NMTransformFilter(NMTransform):
+    """Filter transform: Butterworth, Bessel, or notch.
+
+    Applies the chosen filter to y-data via the shared pure functions
+    in :mod:`pyneuromatic.core.nm_math`.  All filters are zero-phase
+    (forward-backward via ``sosfiltfilt``).
+
+    The sample rate can be supplied explicitly or derived at apply time
+    from the ``xscale`` argument passed to :meth:`apply`.  If neither is
+    available, :meth:`apply` raises a ``ValueError``.
+
+    Args:
+        filter_type: ``"butterworth"`` (default), ``"bessel"``, or
+            ``"notch"``.
+        cutoff: Cutoff frequency in Hz.  For ``btype='bandpass'`` supply
+            ``[low_hz, high_hz]``.  For ``"notch"`` this is the centre
+            frequency to remove.
+        sample_rate: Sample rate in Hz (must be > 0), or ``None`` to
+            derive it from the ``xscale`` passed to :meth:`apply`.
+        order: Filter order (int >= 1). Not used for ``"notch"``. Default 4.
+        btype: ``"low"`` (default), ``"high"``, or ``"bandpass"``.
+            Not used for ``"notch"``.
+        q: Quality factor for ``"notch"`` (float > 0). Default 30.
+    """
+
+    def __init__(
+        self,
+        parent: object | None = None,
+        filter_type: str = "butterworth",
+        cutoff: float | list[float] = 1000.0,
+        sample_rate: float | None = None,
+        order: int = 4,
+        btype: str = "low",
+        q: float = 30.0,
+    ) -> None:
+        super().__init__(parent=parent)
+        self.filter_type = filter_type
+        self.cutoff = cutoff
+        self.sample_rate = sample_rate
+        self.order = order
+        self.btype = btype
+        self.q = q
+
+    def __repr__(self) -> str:
+        sr = "" if self._sample_rate is None else ", sample_rate=%r" % self._sample_rate
+        if self._filter_type == "notch":
+            return "%s(filter_type=%r, cutoff=%r%s, q=%r)" % (
+                self.__class__.__name__, self._filter_type, self._cutoff, sr, self._q,
+            )
+        return (
+            "%s(filter_type=%r, cutoff=%r%s, order=%r, btype=%r)"
+            % (self.__class__.__name__, self._filter_type, self._cutoff,
+               sr, self._order, self._btype)
+        )
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, NMTransformFilter):
+            return (
+                self._filter_type == other._filter_type
+                and self._cutoff == other._cutoff
+                and self._sample_rate == other._sample_rate
+                and self._order == other._order
+                and self._btype == other._btype
+                and self._q == other._q
+            )
+        if isinstance(other, dict):
+            return self.to_dict() == other
+        return NotImplemented
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def filter_type(self) -> str:
+        """Filter type: ``'butterworth'``, ``'bessel'``, or ``'notch'``."""
+        return self._filter_type
+
+    @filter_type.setter
+    def filter_type(self, value: str) -> None:
+        import pyneuromatic.core.nm_math as nm_math
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "filter_type", "string"))
+        if value not in nm_math._VALID_FILTER_TYPES:
+            raise ValueError(
+                "filter_type must be one of %s, got %r"
+                % (sorted(nm_math._VALID_FILTER_TYPES), value)
+            )
+        self._filter_type = value
+
+    @property
+    def cutoff(self) -> float | list[float]:
+        """Cutoff frequency in Hz (float, or [low, high] for bandpass)."""
+        return self._cutoff
+
+    @cutoff.setter
+    def cutoff(self, value: float | list[float]) -> None:
+        if isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "cutoff", "float or list"))
+        if isinstance(value, (int, float)):
+            if value <= 0:
+                raise ValueError("cutoff must be > 0, got %g" % value)
+            self._cutoff = float(value)
+        elif isinstance(value, list):
+            self._cutoff = value
+        else:
+            raise TypeError(nmu.type_error_str(value, "cutoff", "float or list"))
+
+    @property
+    def sample_rate(self) -> float | None:
+        """Sample rate in Hz (must be > 0), or ``None`` to derive from xscale."""
+        return self._sample_rate
+
+    @sample_rate.setter
+    def sample_rate(self, value: float | None) -> None:
+        if value is None:
+            self._sample_rate = None
+            return
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "sample_rate", "float"))
+        if value <= 0:
+            raise ValueError("sample_rate must be > 0, got %g" % value)
+        self._sample_rate = float(value)
+
+    @property
+    def order(self) -> int:
+        """Filter order (int >= 1). Not used for notch."""
+        return self._order
+
+    @order.setter
+    def order(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "order", "int"))
+        if value < 1:
+            raise ValueError("order must be >= 1, got %d" % value)
+        self._order = value
+
+    @property
+    def btype(self) -> str:
+        """Filter band type: ``'low'``, ``'high'``, or ``'bandpass'``. Not used for notch."""
+        return self._btype
+
+    @btype.setter
+    def btype(self, value: str) -> None:
+        import pyneuromatic.core.nm_math as nm_math
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "btype", "string"))
+        if value not in nm_math._VALID_FILTER_BTYPES:
+            raise ValueError(
+                "btype must be one of %s, got %r"
+                % (sorted(nm_math._VALID_FILTER_BTYPES), value)
+            )
+        self._btype = value
+
+    @property
+    def q(self) -> float:
+        """Quality factor for notch filter (float > 0). Not used for other types."""
+        return self._q
+
+    @q.setter
+    def q(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "q", "float"))
+        if value <= 0:
+            raise ValueError("q must be > 0, got %g" % value)
+        self._q = float(value)
+
+    # ------------------------------------------------------------------
+    # Core
+
+    def _resolve_sample_rate(self, xscale: NMScaleX | None) -> float:
+        """Return the effective sample rate.
+
+        Uses ``self._sample_rate`` when set; otherwise derives it from
+        *xscale*.  Raises ``ValueError`` if neither is available.
+        """
+        if self._sample_rate is not None:
+            return self._sample_rate
+        if xscale is not None and xscale.delta and xscale.delta != 0:
+            import pyneuromatic.core.nm_math as nm_math
+            factor = nm_math.si_scale_factor(xscale.units, "s") if xscale.units else 1.0
+            return 1.0 / (xscale.delta * factor)
+        raise ValueError(
+            "NMTransformFilter: sample_rate is None and no usable xscale was provided"
+        )
+
+    def apply(
+        self,
+        ydata: np.ndarray,
+        xscale: NMScaleX | None = None,
+    ) -> np.ndarray:
+        """Apply the filter to *ydata* and return the result."""
+        import pyneuromatic.core.nm_math as nm_math
+        if not isinstance(ydata, np.ndarray):
+            raise TypeError(nmu.type_error_str(ydata, "ydata", "numpy.ndarray"))
+        sr = self._resolve_sample_rate(xscale)
+        if self._filter_type == "butterworth":
+            return nm_math.filter_butterworth(
+                ydata, self._cutoff, sr, self._order, self._btype
+            )
+        if self._filter_type == "bessel":
+            return nm_math.filter_bessel(
+                ydata, self._cutoff, sr, self._order, self._btype
+            )
+        # notch
+        return nm_math.filter_notch(ydata, self._cutoff, sr, self._q)
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d.update({
+            "filter_type": self._filter_type,
+            "cutoff": self._cutoff,
+            "sample_rate": self._sample_rate,
+            "order": self._order,
+            "btype": self._btype,
+            "q": self._q,
+        })
+        return d
+
+
+# =========================================================================
 # Registry and helper functions
 # =========================================================================
 
@@ -390,6 +614,7 @@ _TRANSFORM_REGISTRY: dict[str, type[NMTransform]] = {
     "NMTransformLog": NMTransformLog,
     "NMTransformLn": NMTransformLn,
     "NMTransformSmooth": NMTransformSmooth,
+    "NMTransformFilter": NMTransformFilter,
 }
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers=
 
 [options]
 install_requires =
-    numpy
+    numpy>=1.24
     scipy
     h5py
     colorama

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -26,6 +26,7 @@ from pyneuromatic.analysis.nm_main_op import (
     NMMainOpDeletePoints,
     NMMainOpDFOF,
     NMMainOpDifferentiate,
+    NMMainOpFilter,
     NMMainOpHistogram,
     NMMainOpInequality,
     NMMainOpInsertPoints,
@@ -3932,6 +3933,207 @@ class TestNMMainOpAlign(unittest.TestCase):
     def test_op_from_name_align(self):
         op = op_from_name("align")
         self.assertIsInstance(op, NMMainOpAlign)
+
+
+# ===========================================================================
+# TestNMMainOpFilter
+# ===========================================================================
+
+# Sample rate used across filter tests: 10 kHz (delta = 0.1 ms)
+_FILTER_SR = 10000.0
+_FILTER_N = 1000  # long enough for sosfiltfilt padding
+
+
+def _make_filter_data(name="RecordA0", n=_FILTER_N, sr=_FILTER_SR):
+    """NMData with a DC signal and xscale matching sample_rate."""
+    delta_ms = 1000.0 / sr
+    d = NMData(
+        NM,
+        name=name,
+        nparray=np.ones(n, dtype=float),
+        xscale={"start": 0.0, "delta": delta_ms, "label": "Time", "units": "ms"},
+    )
+    return d
+
+
+class TestNMMainOpFilter(unittest.TestCase):
+
+    # --- constructor / property validation ---
+
+    def test_rejects_invalid_filter_type(self):
+        with self.assertRaises(ValueError):
+            NMMainOpFilter(filter_type="gaussian")
+
+    def test_rejects_non_string_filter_type(self):
+        with self.assertRaises(TypeError):
+            NMMainOpFilter(filter_type=1)
+
+    def test_rejects_zero_cutoff(self):
+        with self.assertRaises(ValueError):
+            NMMainOpFilter(cutoff=0.0)
+
+    def test_rejects_bool_cutoff(self):
+        with self.assertRaises(TypeError):
+            NMMainOpFilter(cutoff=True)
+
+    def test_rejects_order_zero(self):
+        with self.assertRaises(ValueError):
+            NMMainOpFilter(order=0)
+
+    def test_rejects_bool_order(self):
+        with self.assertRaises(TypeError):
+            NMMainOpFilter(order=True)
+
+    def test_rejects_invalid_btype(self):
+        with self.assertRaises(ValueError):
+            NMMainOpFilter(btype="band")
+
+    def test_rejects_non_positive_q(self):
+        with self.assertRaises(ValueError):
+            NMMainOpFilter(q=0.0)
+
+    def test_rejects_non_positive_sample_rate(self):
+        with self.assertRaises(ValueError):
+            NMMainOpFilter(sample_rate=0.0)
+
+    def test_sample_rate_none_ok(self):
+        op = NMMainOpFilter()
+        self.assertIsNone(op.sample_rate)
+
+    # --- Butterworth low-pass ---
+
+    def test_butterworth_lowpass_preserves_dc(self):
+        # DC signal (all ones) should pass through a low-pass filter unchanged
+        d = _make_filter_data()
+        op = NMMainOpFilter(
+            filter_type="butterworth", cutoff=1000.0,
+            btype="low", sample_rate=_FILTER_SR,
+        )
+        op.run(d)
+        np.testing.assert_allclose(d.nparray, 1.0, atol=1e-6)
+
+    def test_butterworth_lowpass_output_length(self):
+        d = _make_filter_data()
+        NMMainOpFilter(
+            filter_type="butterworth", cutoff=1000.0,
+            btype="low", sample_rate=_FILTER_SR,
+        ).run(d)
+        self.assertEqual(len(d.nparray), _FILTER_N)
+
+    def test_butterworth_highpass_attenuates_dc(self):
+        # High-pass should remove DC component
+        d = _make_filter_data()
+        NMMainOpFilter(
+            filter_type="butterworth", cutoff=100.0,
+            btype="high", sample_rate=_FILTER_SR,
+        ).run(d)
+        np.testing.assert_allclose(d.nparray[100:-100], 0.0, atol=1e-6)
+
+    def test_butterworth_bandpass(self):
+        d = _make_filter_data()
+        NMMainOpFilter(
+            filter_type="butterworth", cutoff=[100.0, 2000.0],
+            btype="bandpass", sample_rate=_FILTER_SR,
+        ).run(d)
+        self.assertEqual(len(d.nparray), _FILTER_N)
+
+    # --- Bessel ---
+
+    def test_bessel_lowpass_preserves_dc(self):
+        d = _make_filter_data()
+        NMMainOpFilter(
+            filter_type="bessel", cutoff=1000.0,
+            btype="low", sample_rate=_FILTER_SR,
+        ).run(d)
+        np.testing.assert_allclose(d.nparray, 1.0, atol=1e-6)
+
+    def test_bessel_output_length(self):
+        d = _make_filter_data()
+        NMMainOpFilter(
+            filter_type="bessel", cutoff=1000.0,
+            btype="low", sample_rate=_FILTER_SR,
+        ).run(d)
+        self.assertEqual(len(d.nparray), _FILTER_N)
+
+    # --- Notch ---
+
+    def test_notch_output_length(self):
+        d = _make_filter_data()
+        NMMainOpFilter(
+            filter_type="notch", cutoff=60.0,
+            sample_rate=_FILTER_SR,
+        ).run(d)
+        self.assertEqual(len(d.nparray), _FILTER_N)
+
+    def test_notch_preserves_dc(self):
+        d = _make_filter_data()
+        NMMainOpFilter(
+            filter_type="notch", cutoff=60.0,
+            sample_rate=_FILTER_SR,
+        ).run(d)
+        np.testing.assert_allclose(d.nparray, 1.0, atol=1e-6)
+
+    def test_notch_attenuates_target_frequency(self):
+        # Signal = pure 60 Hz sine; after notch at 60 Hz, amplitude should drop.
+        # Uses a long signal (10000 pts) because Q=30 at 60 Hz has a slow
+        # transient (~1600 samples); check only the settled centre region.
+        n = 10000
+        t = np.arange(n) / _FILTER_SR
+        y = np.sin(2 * np.pi * 60.0 * t)
+        d = NMData(NM, name="RecordA0", nparray=y,
+                   xscale={"start": 0.0, "delta": 1000.0 / _FILTER_SR,
+                            "units": "ms"})
+        NMMainOpFilter(
+            filter_type="notch", cutoff=60.0, q=30.0,
+            sample_rate=_FILTER_SR,
+        ).run(d)
+        rms = np.sqrt(np.mean(d.nparray[2000:-2000] ** 2))
+        self.assertLess(rms, 0.1)  # amplitude substantially reduced
+
+    # --- sample_rate from xscale ---
+
+    def test_sample_rate_derived_from_xscale(self):
+        # delta=0.1 ms, units="ms" → sample_rate = 1/(0.1e-3) = 10000 Hz
+        d = _make_filter_data()
+        op = NMMainOpFilter(
+            filter_type="butterworth", cutoff=1000.0,
+            btype="low",  # sample_rate=None → derived
+        )
+        op.run(d)
+        self.assertEqual(len(d.nparray), _FILTER_N)
+
+    # --- run skips None array ---
+
+    def test_run_skips_none_array(self):
+        d = NMData(NM, name="empty")
+        NMMainOpFilter(filter_type="butterworth", cutoff=1000.0,
+                       sample_rate=_FILTER_SR).run(d)  # should not raise
+
+    # --- notes ---
+
+    def test_note_contains_op_name(self):
+        d = _make_filter_data()
+        NMMainOpFilter(filter_type="butterworth", cutoff=1000.0,
+                       sample_rate=_FILTER_SR).run(d)
+        self.assertIn("NMFilter(", d.notes[0]["note"])
+
+    def test_note_contains_filter_type(self):
+        d = _make_filter_data()
+        NMMainOpFilter(filter_type="bessel", cutoff=500.0,
+                       sample_rate=_FILTER_SR).run(d)
+        self.assertIn("filter_type='bessel'", d.notes[0]["note"])
+
+    def test_note_notch_contains_q(self):
+        d = _make_filter_data()
+        NMMainOpFilter(filter_type="notch", cutoff=60.0,
+                       q=30.0, sample_rate=_FILTER_SR).run(d)
+        self.assertIn("q=30.0", d.notes[0]["note"])
+
+    # --- registry ---
+
+    def test_op_from_name_filter(self):
+        op = op_from_name("filter")
+        self.assertIsInstance(op, NMMainOpFilter)
 
 
 if __name__ == "__main__":

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -1024,3 +1024,274 @@ class TestInterpolate:
         x = np.linspace(0, 1, 11)
         result = nm_math.interpolate(np.ones(11), x, x)
         assert isinstance(result, np.ndarray)
+
+# ---------------------------------------------------------------------------
+# filter helpers shared by Butterworth and Bessel tests
+# ---------------------------------------------------------------------------
+
+_SR = 10000.0  # sample rate (Hz) used across filter tests
+_N = 1000      # signal length
+
+
+def _dc(val=5.0):
+    return np.ones(_N) * val
+
+
+def _sine(freq):
+    t = np.arange(_N) / _SR
+    return np.sin(2 * np.pi * freq * t)
+
+
+# ---------------------------------------------------------------------------
+# filter_butterworth
+# ---------------------------------------------------------------------------
+
+
+class TestFilterButterworth:
+    """Tests for nm_math.filter_butterworth."""
+
+    # --- input validation ---
+
+    def test_rejects_non_array_y(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_butterworth([1.0, 2.0], 1000.0, _SR)
+
+    def test_rejects_bool_cutoff(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_butterworth(_dc(), True, _SR)
+
+    def test_rejects_zero_cutoff(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_butterworth(_dc(), 0.0, _SR)
+
+    def test_rejects_negative_cutoff(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_butterworth(_dc(), -500.0, _SR)
+
+    def test_rejects_string_cutoff(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_butterworth(_dc(), "1000", _SR)
+
+    def test_rejects_bool_sample_rate(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_butterworth(_dc(), 1000.0, True)
+
+    def test_rejects_zero_sample_rate(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_butterworth(_dc(), 1000.0, 0.0)
+
+    def test_rejects_bool_order(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_butterworth(_dc(), 1000.0, _SR, order=True)
+
+    def test_rejects_zero_order(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_butterworth(_dc(), 1000.0, _SR, order=0)
+
+    def test_rejects_invalid_btype(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_butterworth(_dc(), 1000.0, _SR, btype="bandstop")
+
+    # --- output ---
+
+    def test_output_is_ndarray(self):
+        result = nm_math.filter_butterworth(_dc(), 1000.0, _SR)
+        assert isinstance(result, np.ndarray)
+
+    def test_output_length_preserved(self):
+        result = nm_math.filter_butterworth(_dc(), 1000.0, _SR)
+        assert len(result) == _N
+
+    def test_accepts_list_cutoff_bandpass(self):
+        result = nm_math.filter_butterworth(_dc(), [500.0, 2000.0], _SR, btype="bandpass")
+        assert isinstance(result, np.ndarray)
+
+    # --- functional ---
+
+    def test_dc_preserved_lowpass(self):
+        result = nm_math.filter_butterworth(_dc(5.0), 1000.0, _SR)
+        np.testing.assert_allclose(result[100:-100], 5.0, atol=1e-6)
+
+    def test_lowpass_passes_low_freq(self):
+        y = _sine(100)  # 100 Hz << 1 kHz cutoff
+        result = nm_math.filter_butterworth(y, 1000.0, _SR)
+        rms_in = np.sqrt(np.mean(y[100:-100] ** 2))
+        rms_out = np.sqrt(np.mean(result[100:-100] ** 2))
+        assert abs(rms_in - rms_out) < 0.05
+
+    def test_lowpass_attenuates_high_freq(self):
+        y = _sine(4000)  # 4 kHz >> 1 kHz cutoff
+        result = nm_math.filter_butterworth(y, 1000.0, _SR)
+        rms_out = np.sqrt(np.mean(result[100:-100] ** 2))
+        assert rms_out < 0.1
+
+    def test_highpass_attenuates_low_freq(self):
+        y = _sine(100)  # 100 Hz << 1 kHz cutoff
+        result = nm_math.filter_butterworth(y, 1000.0, _SR, btype="high")
+        rms_out = np.sqrt(np.mean(result[100:-100] ** 2))
+        assert rms_out < 0.1
+
+
+# ---------------------------------------------------------------------------
+# filter_bessel
+# ---------------------------------------------------------------------------
+
+
+class TestFilterBessel:
+    """Tests for nm_math.filter_bessel."""
+
+    # --- input validation ---
+
+    def test_rejects_non_array_y(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_bessel([1.0, 2.0], 1000.0, _SR)
+
+    def test_rejects_bool_cutoff(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_bessel(_dc(), True, _SR)
+
+    def test_rejects_zero_cutoff(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_bessel(_dc(), 0.0, _SR)
+
+    def test_rejects_negative_cutoff(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_bessel(_dc(), -500.0, _SR)
+
+    def test_rejects_string_cutoff(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_bessel(_dc(), "1000", _SR)
+
+    def test_rejects_bool_sample_rate(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_bessel(_dc(), 1000.0, True)
+
+    def test_rejects_zero_sample_rate(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_bessel(_dc(), 1000.0, 0.0)
+
+    def test_rejects_bool_order(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_bessel(_dc(), 1000.0, _SR, order=True)
+
+    def test_rejects_zero_order(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_bessel(_dc(), 1000.0, _SR, order=0)
+
+    def test_rejects_invalid_btype(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_bessel(_dc(), 1000.0, _SR, btype="bandstop")
+
+    # --- output ---
+
+    def test_output_is_ndarray(self):
+        result = nm_math.filter_bessel(_dc(), 1000.0, _SR)
+        assert isinstance(result, np.ndarray)
+
+    def test_output_length_preserved(self):
+        result = nm_math.filter_bessel(_dc(), 1000.0, _SR)
+        assert len(result) == _N
+
+    def test_accepts_list_cutoff_bandpass(self):
+        result = nm_math.filter_bessel(_dc(), [500.0, 2000.0], _SR, btype="bandpass")
+        assert isinstance(result, np.ndarray)
+
+    # --- functional ---
+
+    def test_dc_preserved_lowpass(self):
+        result = nm_math.filter_bessel(_dc(5.0), 1000.0, _SR)
+        np.testing.assert_allclose(result[100:-100], 5.0, atol=1e-6)
+
+    def test_lowpass_passes_low_freq(self):
+        y = _sine(100)
+        result = nm_math.filter_bessel(y, 1000.0, _SR)
+        rms_in = np.sqrt(np.mean(y[100:-100] ** 2))
+        rms_out = np.sqrt(np.mean(result[100:-100] ** 2))
+        assert abs(rms_in - rms_out) < 0.05
+
+    def test_lowpass_attenuates_high_freq(self):
+        y = _sine(4000)
+        result = nm_math.filter_bessel(y, 1000.0, _SR)
+        rms_out = np.sqrt(np.mean(result[100:-100] ** 2))
+        assert rms_out < 0.1
+
+    def test_highpass_attenuates_low_freq(self):
+        y = _sine(100)
+        result = nm_math.filter_bessel(y, 1000.0, _SR, btype="high")
+        rms_out = np.sqrt(np.mean(result[100:-100] ** 2))
+        assert rms_out < 0.1
+
+
+# ---------------------------------------------------------------------------
+# filter_notch
+# ---------------------------------------------------------------------------
+
+
+class TestFilterNotch:
+    """Tests for nm_math.filter_notch."""
+
+    _N_LONG = 10000  # longer signal needed for high-Q transient to decay
+
+    def _sine_long(self, freq):
+        t = np.arange(self._N_LONG) / _SR
+        return np.sin(2 * np.pi * freq * t)
+
+    # --- input validation ---
+
+    def test_rejects_non_array_y(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_notch([1.0, 2.0], 60.0, _SR)
+
+    def test_rejects_bool_sample_rate(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_notch(_dc(), 60.0, True)
+
+    def test_rejects_zero_sample_rate(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_notch(_dc(), 60.0, 0.0)
+
+    def test_rejects_bool_freq(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_notch(_dc(), True, _SR)
+
+    def test_rejects_zero_freq(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_notch(_dc(), 0.0, _SR)
+
+    def test_rejects_bool_q(self):
+        with pytest.raises(TypeError):
+            nm_math.filter_notch(_dc(), 60.0, _SR, q=True)
+
+    def test_rejects_zero_q(self):
+        with pytest.raises(ValueError):
+            nm_math.filter_notch(_dc(), 60.0, _SR, q=0.0)
+
+    # --- output ---
+
+    def test_output_is_ndarray(self):
+        result = nm_math.filter_notch(_dc(), 60.0, _SR)
+        assert isinstance(result, np.ndarray)
+
+    def test_output_length_preserved(self):
+        result = nm_math.filter_notch(_dc(), 60.0, _SR)
+        assert len(result) == _N
+
+    # --- functional ---
+
+    def test_dc_preserved(self):
+        result = nm_math.filter_notch(_dc(3.0), 60.0, _SR)
+        np.testing.assert_allclose(result[100:-100], 3.0, atol=1e-6)
+
+    def test_attenuates_notch_frequency(self):
+        y = self._sine_long(60)
+        result = nm_math.filter_notch(y, 60.0, _SR, q=30.0)
+        rms_out = np.sqrt(np.mean(result[2000:-2000] ** 2))
+        assert rms_out < 0.1
+
+    def test_passes_off_notch_frequency(self):
+        y = self._sine_long(100)  # 100 Hz, notch at 60 Hz
+        result = nm_math.filter_notch(y, 60.0, _SR, q=30.0)
+        rms_in = np.sqrt(np.mean(y[2000:-2000] ** 2))
+        rms_out = np.sqrt(np.mean(result[2000:-2000] ** 2))
+        assert abs(rms_in - rms_out) < 0.05
+

--- a/tests/test_core/test_nm_transform.py
+++ b/tests/test_core/test_nm_transform.py
@@ -15,6 +15,7 @@ from pyneuromatic.core.nm_transform import (
     NMTransformLog,
     NMTransformLn,
     NMTransformSmooth,
+    NMTransformFilter,
     _transform_from_dict,
     _transforms_from_list,
     apply_transforms,
@@ -460,6 +461,224 @@ class TestNMTransformSmooth(unittest.TestCase):
         t = NMTransformSmooth(method="boxcar", window=5, passes=1, polyorder=2)
         self.assertIn("NMTransformSmooth", repr(t))
         self.assertIn("boxcar", repr(t))
+
+
+class TestNMTransformFilter(unittest.TestCase):
+    """Tests for NMTransformFilter."""
+
+    SR = 10000.0  # sample rate Hz used across tests
+
+    def setUp(self):
+        # 1000-point DC signal at sample rate 10 kHz
+        self.y_dc = np.ones(1000) * 5.0
+        # Low-frequency sine (100 Hz) — passes through a 1 kHz lowpass
+        t = np.arange(1000) / self.SR
+        self.y_low = np.sin(2 * np.pi * 100 * t)
+        # High-frequency sine (4 kHz) — attenuated by a 1 kHz lowpass
+        self.y_high = np.sin(2 * np.pi * 4000 * t)
+
+    # --- Constructor / property validation ---
+
+    def test_default_params(self):
+        t = NMTransformFilter()
+        self.assertEqual(t.filter_type, "butterworth")
+        self.assertEqual(t.cutoff, 1000.0)
+        self.assertIsNone(t.sample_rate)
+        self.assertEqual(t.order, 4)
+        self.assertEqual(t.btype, "low")
+        self.assertEqual(t.q, 30.0)
+
+    def test_sample_rate_explicit(self):
+        t = NMTransformFilter(sample_rate=self.SR)
+        self.assertEqual(t.sample_rate, self.SR)
+
+    def test_rejects_invalid_filter_type(self):
+        with self.assertRaises(ValueError):
+            NMTransformFilter(filter_type="fir", sample_rate=self.SR)
+
+    def test_rejects_non_string_filter_type(self):
+        with self.assertRaises(TypeError):
+            NMTransformFilter(filter_type=1, sample_rate=self.SR)
+
+    def test_rejects_zero_cutoff(self):
+        with self.assertRaises(ValueError):
+            NMTransformFilter(cutoff=0.0, sample_rate=self.SR)
+
+    def test_rejects_bool_cutoff(self):
+        with self.assertRaises(TypeError):
+            NMTransformFilter(cutoff=True, sample_rate=self.SR)
+
+    def test_rejects_non_positive_sample_rate(self):
+        with self.assertRaises(ValueError):
+            NMTransformFilter(sample_rate=0.0)
+
+    def test_rejects_bool_sample_rate(self):
+        with self.assertRaises(TypeError):
+            NMTransformFilter(sample_rate=True)
+
+    def test_rejects_invalid_btype(self):
+        with self.assertRaises(ValueError):
+            NMTransformFilter(btype="bandstop", sample_rate=self.SR)
+
+    def test_rejects_non_positive_order(self):
+        with self.assertRaises(ValueError):
+            NMTransformFilter(order=0, sample_rate=self.SR)
+
+    def test_rejects_bool_order(self):
+        with self.assertRaises(TypeError):
+            NMTransformFilter(order=True, sample_rate=self.SR)
+
+    def test_rejects_non_positive_q(self):
+        with self.assertRaises(ValueError):
+            NMTransformFilter(q=0.0, sample_rate=self.SR)
+
+    def test_rejects_bool_q(self):
+        with self.assertRaises(TypeError):
+            NMTransformFilter(q=True, sample_rate=self.SR)
+
+    # --- Output shape ---
+
+    def test_butterworth_output_length(self):
+        t = NMTransformFilter(filter_type="butterworth", cutoff=1000.0,
+                              sample_rate=self.SR)
+        result = t.apply(self.y_dc)
+        self.assertEqual(result.shape, self.y_dc.shape)
+
+    def test_bessel_output_length(self):
+        t = NMTransformFilter(filter_type="bessel", cutoff=1000.0,
+                              sample_rate=self.SR)
+        result = t.apply(self.y_dc)
+        self.assertEqual(result.shape, self.y_dc.shape)
+
+    def test_notch_output_length(self):
+        t = NMTransformFilter(filter_type="notch", cutoff=60.0,
+                              sample_rate=self.SR)
+        result = t.apply(self.y_dc)
+        self.assertEqual(result.shape, self.y_dc.shape)
+
+    # --- Functional behaviour ---
+
+    def test_butterworth_dc_preserved(self):
+        t = NMTransformFilter(filter_type="butterworth", cutoff=1000.0,
+                              sample_rate=self.SR)
+        result = t.apply(self.y_dc)
+        np.testing.assert_allclose(result[100:-100], 5.0, atol=1e-6)
+
+    def test_bessel_dc_preserved(self):
+        t = NMTransformFilter(filter_type="bessel", cutoff=1000.0,
+                              sample_rate=self.SR)
+        result = t.apply(self.y_dc)
+        np.testing.assert_allclose(result[100:-100], 5.0, atol=1e-6)
+
+    def test_butterworth_lowpass_passes_low_freq(self):
+        t = NMTransformFilter(filter_type="butterworth", cutoff=1000.0,
+                              sample_rate=self.SR)
+        result = t.apply(self.y_low)
+        # 100 Hz should pass — RMS should be close to input RMS
+        rms_in = np.sqrt(np.mean(self.y_low[100:-100] ** 2))
+        rms_out = np.sqrt(np.mean(result[100:-100] ** 2))
+        self.assertAlmostEqual(rms_in, rms_out, delta=0.05)
+
+    def test_butterworth_lowpass_attenuates_high_freq(self):
+        t = NMTransformFilter(filter_type="butterworth", cutoff=1000.0,
+                              sample_rate=self.SR)
+        result = t.apply(self.y_high)
+        # 4 kHz should be substantially attenuated
+        rms_out = np.sqrt(np.mean(result[100:-100] ** 2))
+        self.assertLess(rms_out, 0.1)
+
+    def test_highpass_attenuates_low_freq(self):
+        t = NMTransformFilter(filter_type="butterworth", cutoff=1000.0,
+                              sample_rate=self.SR, btype="high")
+        result = t.apply(self.y_low)
+        # 100 Hz should be attenuated by a 1 kHz highpass
+        rms_out = np.sqrt(np.mean(result[100:-100] ** 2))
+        self.assertLess(rms_out, 0.1)
+
+    def test_notch_attenuates_target_frequency(self):
+        # Use a longer signal so the high-Q notch transient decays
+        n = 10000
+        t_arr = np.arange(n) / self.SR
+        y_60 = np.sin(2 * np.pi * 60 * t_arr)
+        tf = NMTransformFilter(filter_type="notch", cutoff=60.0,
+                               sample_rate=self.SR, q=30.0)
+        result = tf.apply(y_60)
+        rms_out = np.sqrt(np.mean(result[2000:-2000] ** 2))
+        self.assertLess(rms_out, 0.1)
+
+    def test_apply_rejects_non_ndarray(self):
+        t = NMTransformFilter(sample_rate=self.SR)
+        with self.assertRaises(TypeError):
+            t.apply([1.0, 2.0, 3.0])
+
+    def test_apply_raises_without_sample_rate_or_xscale(self):
+        t = NMTransformFilter()  # sample_rate=None
+        with self.assertRaises(ValueError):
+            t.apply(self.y_dc)
+
+    def test_apply_derives_sample_rate_from_xscale(self):
+        from pyneuromatic.core.nm_scale import NMScaleX
+        t = NMTransformFilter(filter_type="butterworth", cutoff=1000.0)
+        xscale = NMScaleX()
+        xscale.delta = 1.0 / self.SR  # delta in seconds → SR = 10 kHz
+        result = t.apply(self.y_dc, xscale=xscale)
+        self.assertEqual(result.shape, self.y_dc.shape)
+        np.testing.assert_allclose(result[100:-100], 5.0, atol=1e-6)
+
+    # --- Serialisation / equality ---
+
+    def test_to_dict_butterworth(self):
+        t = NMTransformFilter(filter_type="butterworth", cutoff=500.0,
+                              sample_rate=self.SR, order=2, btype="high")
+        d = t.to_dict()
+        self.assertEqual(d["type"], "NMTransformFilter")
+        self.assertEqual(d["filter_type"], "butterworth")
+        self.assertEqual(d["cutoff"], 500.0)
+        self.assertEqual(d["sample_rate"], self.SR)
+        self.assertEqual(d["order"], 2)
+        self.assertEqual(d["btype"], "high")
+
+    def test_to_dict_notch(self):
+        t = NMTransformFilter(filter_type="notch", cutoff=60.0,
+                              sample_rate=self.SR, q=20.0)
+        d = t.to_dict()
+        self.assertEqual(d["filter_type"], "notch")
+        self.assertEqual(d["q"], 20.0)
+
+    def test_equality(self):
+        t1 = NMTransformFilter(filter_type="butterworth", cutoff=1000.0,
+                               sample_rate=self.SR, order=4, btype="low")
+        t2 = NMTransformFilter(filter_type="butterworth", cutoff=1000.0,
+                               sample_rate=self.SR, order=4, btype="low")
+        t3 = NMTransformFilter(filter_type="bessel", cutoff=1000.0,
+                               sample_rate=self.SR)
+        self.assertEqual(t1, t2)
+        self.assertNotEqual(t1, t3)
+
+    def test_from_dict_registered(self):
+        t = NMTransformFilter(filter_type="bessel", cutoff=500.0,
+                              sample_rate=self.SR, order=3)
+        d = t.to_dict()
+        t2 = _transform_from_dict(d)
+        self.assertIsInstance(t2, NMTransformFilter)
+        self.assertEqual(t, t2)
+
+    def test_repr_butterworth(self):
+        t = NMTransformFilter(filter_type="butterworth", cutoff=1000.0,
+                              sample_rate=self.SR)
+        r = repr(t)
+        self.assertIn("NMTransformFilter", r)
+        self.assertIn("butterworth", r)
+        self.assertIn("btype", r)
+
+    def test_repr_notch(self):
+        t = NMTransformFilter(filter_type="notch", cutoff=60.0,
+                              sample_rate=self.SR)
+        r = repr(t)
+        self.assertIn("NMTransformFilter", r)
+        self.assertIn("notch", r)
+        self.assertIn("q=", r)
+        self.assertNotIn("btype", r)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add `NMMainOpFilter` to `nm_main_op.py`: applies Butterworth, Bessel,
  or notch filter permanently to data arrays; `sample_rate` can be set
  explicitly or derived from `xscale.delta` and `xscale.units` at run time
- Add `NMTransformFilter` to `nm_transform.py`: same three filter types as
  a lightweight reversible transform; `sample_rate` optional — derived from
  `xscale` passed to `apply()` if not set, raises `ValueError` if neither
  is available
- Add pure filter functions `filter_butterworth`, `filter_bessel`,
  `filter_notch` to `nm_math.py` using `scipy.signal` (`sosfiltfilt` for
  zero-phase, `iirnotch` → `tf2sos` for numerical stability)
- Upgrade numpy 1.23.5 → 2.0.2 and pin `numpy>=1.24` in `setup.cfg`

## Test plan
- [ ] `TestNMMainOpFilter` in `tests/test_analysis/test_nm_tool_main.py`
- [ ] `TestNMTransformFilter` in `tests/test_core/test_nm_transform.py`
- [ ] `TestFilterButterworth`, `TestFilterBessel`, `TestFilterNotch` in `tests/test_core/test_nm_math.py`
- [ ] Full test suite passes (`2418 passed`)

Closes #252
