### PR TITLE
feat(analysis): NMToolSpike — spike detection tool

### DIFF
--- a/pyneuromatic/analysis/nm_tool_folder.py
+++ b/pyneuromatic/analysis/nm_tool_folder.py
@@ -171,3 +171,38 @@ class NMToolFolderContainer(NMObjectContainer):
         if super()._add(f, select=select, quiet=quiet):
             return f
         return None
+
+    def get_or_create(
+        self,
+        base: str,
+        overwrite: bool = True,
+    ) -> NMToolFolder:
+        """Return a tool subfolder for *base*, respecting the overwrite flag.
+
+        Args:
+            base: Base name without trailing sequence number, e.g.
+                ``"spike_Record_A"`` or ``"stats_Record_A"``.
+            overwrite: If ``True`` (default), target ``{base}_0``.  If that
+                subfolder already exists, its data container is cleared and it
+                is returned for reuse.  If it does not exist, it is created.
+                If ``False``, find the first unused name ``{base}_0``,
+                ``{base}_1``, … and create a new subfolder there.
+
+        Returns:
+            The target :class:`NMToolFolder`.
+        """
+        if overwrite:
+            name = "%s_0" % base
+            existing = self.get(name)
+            if existing is not None:
+                existing.data.clear(quiet=True)
+                return existing
+            return self.new(name=name)
+        i = 0
+        f = None
+        while f is None:
+            try:
+                f = self.new(name="%s_%d" % (base, i))
+            except KeyError:
+                i += 1
+        return f

--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -1,0 +1,526 @@
+# -*- coding: utf-8 -*-
+"""
+NMToolSpike: spike detection tool.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from pyneuromatic.analysis.nm_tool import NMTool
+from pyneuromatic.analysis.nm_tool_config import NMToolConfig
+from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
+from pyneuromatic.core.nm_data import NMData
+from pyneuromatic.core.nm_folder import NMFolder
+import pyneuromatic.core.nm_command_history as nmch
+import pyneuromatic.core.nm_configurations as nmc
+import pyneuromatic.core.nm_history as nmh
+import pyneuromatic.core.nm_math as nm_math
+import pyneuromatic.core.nm_utilities as nmu
+
+_VALID_FUNC_NAMES: frozenset[str] = frozenset({"level", "level+", "level-"})
+
+
+class NMToolSpikeConfig(NMToolConfig):
+    """Configuration for NMToolSpike.
+
+    Parameters:
+        ylevel: Y-axis detection threshold. Default 0.0.
+        func_name: Crossing direction — ``"level+"`` (rising, default),
+            ``"level-"`` (falling), or ``"level"`` (both).
+        results_to_history: If True, print spike counts to the history log
+            after each run. Default False.
+        results_to_cache: If True, save spike times dict to
+            ``folder.toolresults`` after each run. Default True.
+        results_to_numpy: If True, write ``SP_`` NMData arrays to a new
+            Spike subfolder after each run. Default True.
+    """
+
+    _TOML_TYPE = "spike_config"
+    _schema = {
+        "ylevel":             {"type": float, "default": 0.0},
+        "func_name":          {"type": str,   "default": "level+",
+                               "choices": ["level", "level+", "level-"]},
+        "overwrite":          {"type": bool,  "default": True},
+        "results_to_history": {"type": bool,  "default": False},
+        "results_to_cache":   {"type": bool,  "default": True},
+        "results_to_numpy":   {"type": bool,  "default": True},
+    }
+
+
+class NMToolSpike(NMTool):
+    """Spike detection tool using threshold crossings.
+
+    Detects action potentials (or other threshold-crossing events) in
+    NMData arrays via :func:`~pyneuromatic.core.nm_math.find_level_crossings`.
+    Per-epoch spike time arrays (``SP_`` prefix) and a spike-count array
+    (``SP_count``) are written to a new Spike subfolder after each run.
+
+    After detection, call :meth:`pst` or :meth:`isi` to compute histograms
+    from the most recent run's spike times.
+
+    Attributes:
+        ylevel: Y-axis detection threshold. Default 0.0.
+        func_name: Crossing direction — ``"level+"`` (rising, default),
+            ``"level-"`` (falling), or ``"level"`` (both).
+        results_to_history: If True, print spike counts to the history log
+            after each run. Default False.
+        results_to_cache: If True, save spike times dict to
+            ``folder.toolresults`` after each run. Default True.
+        results_to_numpy: If True, write ``SP_`` NMData arrays to a new
+            Spike subfolder after each run. Default True.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(name="spike")
+        self._config = NMToolSpikeConfig()
+
+        self.__ylevel: float = 0.0
+        self.__func_name: str = "level+"
+        self.__overwrite: bool = True
+
+        self.__results_to_history: bool = False
+        self.__results_to_cache: bool = True
+        self.__results_to_numpy: bool = True
+
+        # Internal run state — reset by run_init()
+        self._spike_times: list[np.ndarray] = []
+        self._epoch_names: list[str] = []
+        self._detected_xunits: str | None = None
+        self._toolfolder: NMToolFolder | None = None
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def ylevel(self) -> float:
+        """Y-axis detection threshold."""
+        return self.__ylevel
+
+    @ylevel.setter
+    def ylevel(self, value: float) -> None:
+        self._ylevel_set(value)
+
+    def _ylevel_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        """Set ylevel.
+
+        Args:
+            value: Threshold y-value (float, bool rejected).
+            quiet: If True, suppress history log output.
+        """
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "ylevel", "float"))
+        self.__ylevel = float(value)
+        nmh.history("set ylevel=%g" % self.__ylevel, quiet=quiet)
+        nmch.add_nm_command("%s.ylevel = %r" % (self._name, self.__ylevel))
+
+    @property
+    def func_name(self) -> str:
+        """Crossing direction: ``'level+'``, ``'level-'``, or ``'level'``."""
+        return self.__func_name
+
+    @func_name.setter
+    def func_name(self, value: str) -> None:
+        self._func_name_set(value)
+
+    def _func_name_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
+        """Set func_name.
+
+        Args:
+            value: One of ``'level'``, ``'level+'``, ``'level-'``.
+            quiet: If True, suppress history log output.
+        """
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "func_name", "string"))
+        if value not in _VALID_FUNC_NAMES:
+            raise ValueError(
+                "func_name must be one of %s, got %r"
+                % (sorted(_VALID_FUNC_NAMES), value)
+            )
+        self.__func_name = value
+        nmh.history("set func_name=%r" % self.__func_name, quiet=quiet)
+        nmch.add_nm_command("%s.func_name = %r" % (self._name, self.__func_name))
+
+    @property
+    def overwrite(self) -> bool:
+        """If True, reuse ``{base}_0`` subfolder (clearing old arrays) on each run.
+
+        If False, each run creates a new numbered subfolder
+        (``{base}_0``, ``{base}_1``, …) preserving previous results.
+        """
+        return self.__overwrite
+
+    @overwrite.setter
+    def overwrite(self, value: bool) -> None:
+        self._overwrite_set(value)
+
+    def _overwrite_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "overwrite", "boolean"))
+        self.__overwrite = value
+        nmh.history("set overwrite=%s" % value, quiet=quiet)
+        nmch.add_nm_command("%s.overwrite = %r" % (self._name, self.__overwrite))
+
+    @property
+    def results_to_history(self) -> bool:
+        """If True, print spike counts to the history log after each run."""
+        return self.__results_to_history
+
+    @results_to_history.setter
+    def results_to_history(self, value: bool) -> None:
+        self._results_to_history_set(value)
+
+    def _results_to_history_set(
+        self, value: bool, quiet: bool = nmc.QUIET
+    ) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(
+                nmu.type_error_str(value, "results_to_history", "boolean")
+            )
+        self.__results_to_history = value
+        nmh.history("set results_to_history=%s" % value, quiet=quiet)
+        nmch.add_nm_command(
+            "%s.results_to_history = %r" % (self._name, self.__results_to_history)
+        )
+
+    @property
+    def results_to_cache(self) -> bool:
+        """If True, save spike times dict to folder.toolresults after each run."""
+        return self.__results_to_cache
+
+    @results_to_cache.setter
+    def results_to_cache(self, value: bool) -> None:
+        self._results_to_cache_set(value)
+
+    def _results_to_cache_set(
+        self, value: bool, quiet: bool = nmc.QUIET
+    ) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(
+                nmu.type_error_str(value, "results_to_cache", "boolean")
+            )
+        self.__results_to_cache = value
+        nmh.history("set results_to_cache=%s" % value, quiet=quiet)
+        nmch.add_nm_command(
+            "%s.results_to_cache = %r" % (self._name, self.__results_to_cache)
+        )
+
+    @property
+    def results_to_numpy(self) -> bool:
+        """If True, write SP_ NMData arrays to a Spike subfolder after each run."""
+        return self.__results_to_numpy
+
+    @results_to_numpy.setter
+    def results_to_numpy(self, value: bool) -> None:
+        self._results_to_numpy_set(value)
+
+    def _results_to_numpy_set(
+        self, value: bool, quiet: bool = nmc.QUIET
+    ) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(
+                nmu.type_error_str(value, "results_to_numpy", "boolean")
+            )
+        self.__results_to_numpy = value
+        nmh.history("set results_to_numpy=%s" % value, quiet=quiet)
+        nmch.add_nm_command(
+            "%s.results_to_numpy = %r" % (self._name, self.__results_to_numpy)
+        )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run_init(self) -> bool:
+        """Reset internal state before the run loop."""
+        self._spike_times = []
+        self._epoch_names = []
+        self._detected_xunits = None
+        self._toolfolder = None
+        return True
+
+    def run(self) -> bool:
+        """Detect threshold crossings in the current NMData array.
+
+        Appends the detected spike times (interpolated x-values) and the
+        data name to the internal lists.  Silently skips arrays with no
+        numpy data (``nparray`` is None).
+
+        Returns:
+            True on success.
+        """
+        data = self.data
+        if not isinstance(data, NMData):
+            raise RuntimeError("no data selected")
+        y = data.nparray
+        if y is None:
+            return True
+        if self._detected_xunits is None:
+            self._detected_xunits = data.xscale.units
+        _indexes, x_times = nm_math.find_level_crossings(
+            y,
+            self.__ylevel,
+            func_name=self.__func_name,
+            xstart=data.xscale.start,
+            xdelta=data.xscale.delta,
+        )
+        self._spike_times.append(x_times)
+        self._epoch_names.append(data.name)
+        return True
+
+    def run_finish(self) -> bool:
+        """Persist results via the enabled output sinks.
+
+        Dispatches to :meth:`_results_to_history`, :meth:`_results_to_cache`,
+        and/or :meth:`_results_to_numpy` based on the ``results_to_*`` flags.
+
+        Returns:
+            True on success.
+        """
+        if not self._epoch_names:
+            return True
+        if self.__results_to_history:
+            self._results_to_history()
+        if self.__results_to_cache:
+            self._results_to_cache()
+        if self.__results_to_numpy:
+            self._results_to_numpy()
+        return True
+
+    # ------------------------------------------------------------------
+    # Output sinks
+
+    def _add_note(self, data: NMData, text: str) -> None:
+        """Append a note to *data*.notes if available."""
+        notes = getattr(data, "notes", None)
+        if notes is not None:
+            notes.add(text)
+
+    def _results_to_numpy(self) -> NMToolFolder | None:
+        """Write SP_ NMData arrays to a new Spike subfolder.
+
+        Creates a subfolder named ``spike_{dataseries}_{channel}_N``
+        (first unused N) under the current folder's toolfolder, then writes:
+
+        * One ``SP_{epoch_name}`` array per epoch containing the spike times.
+        * One ``SP_count`` array (length = number of epochs) containing the
+          spike count per epoch.
+
+        Returns:
+            The newly created NMToolFolder, or None if no folder is set.
+        """
+        if not isinstance(self.folder, NMFolder):
+            return None
+        self._toolfolder = self._make_toolfolder()
+        f = self._toolfolder
+        for name, times in zip(self._epoch_names, self._spike_times):
+            d = f.data.new(
+                "SP_" + name,
+                nparray=times,
+                yscale={"label": "Time", "units": self._detected_xunits},
+            )
+            self._add_note(
+                d,
+                "NMSpike(source=%s, ylevel=%g, func_name=%r, n=%d)"
+                % (name, self.__ylevel, self.__func_name, len(times)),
+            )
+        counts = np.array([len(t) for t in self._spike_times], dtype=float)
+        d_count = f.data.new("SP_count", nparray=counts)
+        self._add_note(
+            d_count,
+            "NMSpike(ylevel=%g, func_name=%r, n_epochs=%d)"
+            % (self.__ylevel, self.__func_name, len(self._epoch_names)),
+        )
+        return f
+
+    def _results_to_cache(self) -> None:
+        """Save spike times dict to folder.toolresults."""
+        if not isinstance(self.folder, NMFolder):
+            return
+        results = {
+            name: times
+            for name, times in zip(self._epoch_names, self._spike_times)
+        }
+        self.folder.toolresults_save("spike", results)
+
+    def _results_to_history(self) -> None:
+        """Print spike counts to the history log."""
+        for name, times in zip(self._epoch_names, self._spike_times):
+            nmh.history("spike: %s: %d spike(s)" % (name, len(times)))
+
+    def _make_toolfolder(self) -> NMToolFolder:
+        """Return the target ``spike_{dataseries}_{channel}_N`` subfolder."""
+        parts = ["Spike"]
+        if self.dataseries is not None:
+            parts.append(self.dataseries.name)
+        if self.channel is not None:
+            parts.append(self.channel.name)
+        base = "_".join(parts)
+        return self.folder.toolfolder.get_or_create(base, overwrite=self.__overwrite)
+
+    # ------------------------------------------------------------------
+    # Convenience methods (called after run_all)
+
+    def raster(self) -> tuple[list[np.ndarray], list[str]]:
+        """Return spike times and epoch labels ready for raster plotting.
+
+        Returns the internal spike times collected during the most recent
+        :meth:`run_all` call as a pair of parallel lists — one entry per
+        epoch — without requiring the caller to know the subfolder structure.
+
+        Example::
+
+            times_list, labels = tool.raster()
+            for i, (times, label) in enumerate(zip(times_list, labels)):
+                ax.scatter(times, np.full_like(times, i), marker="|")
+            ax.set_yticks(range(len(labels)))
+            ax.set_yticklabels(labels)
+
+        Returns:
+            ``(spike_times, epoch_names)`` where *spike_times* is a list of
+            numpy arrays (one per epoch, possibly empty) and *epoch_names*
+            is the corresponding list of data array names.
+
+        Raises:
+            RuntimeError: If called before :meth:`run_all`.
+        """
+        if self._toolfolder is None and not self._epoch_names:
+            raise RuntimeError(
+                "NMToolSpike.raster: no spike data — run detection first"
+            )
+        return list(self._spike_times), list(self._epoch_names)
+
+    # ------------------------------------------------------------------
+    # Histogram methods (called after run_all)
+
+    def pst(
+        self,
+        bins: int = 100,
+        tstart: float | None = None,
+        tend: float | None = None,
+    ) -> NMData | None:
+        """Compute a peri-stimulus time (PST) histogram from spike times.
+
+        Pools all spike times across epochs from the most recent
+        :meth:`run_all` call, computes a histogram via
+        :func:`~pyneuromatic.core.nm_math.histogram`, and writes the result
+        as ``SP_PST`` in the current Spike subfolder.
+
+        Args:
+            bins: Number of histogram bins. Default 100.
+            tstart: Lower edge of the first bin (inclusive). Default None
+                (use minimum spike time).
+            tend: Upper edge of the last bin (exclusive). Default None
+                (use maximum spike time).
+
+        Returns:
+            The new ``SP_PST`` NMData, or None if no spikes were detected.
+
+        Raises:
+            RuntimeError: If called before :meth:`run_all`.
+        """
+        if self._toolfolder is None:
+            raise RuntimeError(
+                "NMToolSpike.pst: no spike data — run detection first"
+            )
+        if not self._spike_times:
+            return None
+        all_times = np.concatenate(self._spike_times)
+        if len(all_times) == 0:
+            return None
+        xrange: tuple[float, float] | None = None
+        if tstart is not None or tend is not None:
+            lo = float(tstart) if tstart is not None else float(all_times.min())
+            hi = float(tend) if tend is not None else float(all_times.max())
+            xrange = (lo, hi)
+        result = nm_math.histogram(all_times, bins=bins, xrange=xrange)
+        counts, edges = result["counts"], result["edges"]
+        delta = float(edges[1] - edges[0])
+        d = self._toolfolder.data.new(
+            "SP_PST",
+            nparray=counts.astype(float),
+            xscale={
+                "start": float(edges[0]),
+                "delta": delta,
+                "label": "Time",
+                "units": self._detected_xunits,
+            },
+            yscale={"label": "Spike count"},
+        )
+        self._add_note(
+            d,
+            "NMSpike.pst(bins=%d, tstart=%s, tend=%s, n_spikes=%d)"
+            % (bins, tstart, tend, int(counts.sum())),
+        )
+        return d
+
+    def isi(
+        self,
+        bins: int = 100,
+        max_isi: float | None = None,
+    ) -> NMData | None:
+        """Compute an interspike interval (ISI) histogram from spike times.
+
+        Computes ``numpy.diff`` of each epoch's spike times, pools the
+        intervals across all epochs, and writes the histogram as ``SP_ISI``
+        in the current Spike subfolder.  Epochs with fewer than two spikes
+        contribute no intervals.
+
+        Args:
+            bins: Number of histogram bins. Default 100.
+            max_isi: Upper bound of the last bin. Default None (use the
+                maximum interval).
+
+        Returns:
+            The new ``SP_ISI`` NMData, or None if fewer than 2 spikes total.
+
+        Raises:
+            RuntimeError: If called before :meth:`run_all`.
+        """
+        if self._toolfolder is None:
+            raise RuntimeError(
+                "NMToolSpike.isi: no spike data — run detection first"
+            )
+        intervals = [
+            np.diff(t) for t in self._spike_times if len(t) >= 2
+        ]
+        if not intervals:
+            return None
+        all_isis = np.concatenate(intervals)
+        xrange: tuple[float, float] | None = (
+            (0.0, float(max_isi)) if max_isi is not None else None
+        )
+        result = nm_math.histogram(all_isis, bins=bins, xrange=xrange)
+        counts, edges = result["counts"], result["edges"]
+        delta = float(edges[1] - edges[0])
+        d = self._toolfolder.data.new(
+            "SP_ISI",
+            nparray=counts.astype(float),
+            xscale={
+                "start": float(edges[0]),
+                "delta": delta,
+                "label": "ISI",
+                "units": self._detected_xunits,
+            },
+            yscale={"label": "Count"},
+        )
+        self._add_note(
+            d,
+            "NMSpike.isi(bins=%d, max_isi=%s, n_intervals=%d)"
+            % (bins, max_isi, int(counts.sum())),
+        )
+        return d

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -501,13 +501,7 @@ class NMToolStats(NMTool):
         if ch is not None:
             parts.append(ch.name)
         base = "_".join(parts)
-        i = 0
-        f = None
-        while f is None:
-            try:
-                f = tf.new(name="%s_%d" % (base, i))
-            except KeyError:
-                i += 1
+        f = tf.get_or_create(base, overwrite=False)
 
         for wname, vlist in self.__results.items():
             # vlist: list of lists, one inner list per data array

--- a/pyneuromatic/core/nm_tool_registry.py
+++ b/pyneuromatic/core/nm_tool_registry.py
@@ -33,10 +33,12 @@ if TYPE_CHECKING:
 DEFAULT_TOOL_REGISTRY: dict[str, tuple[str, str]] = {
     "main": ("pyneuromatic.analysis.nm_tool_main", "NMToolMain"),
     "stats": ("pyneuromatic.analysis.nm_tool_stats", "NMToolStats"),
+    "spike": ("pyneuromatic.analysis.nm_tool_spike", "NMToolSpike"),
     # Future tools (uncomment when implemented):
-    # "spike": ("pyneuromatic.analysis.nm_tool_spike", "NMToolSpike"),
     # "event": ("pyneuromatic.analysis.nm_tool_event", "NMToolEvent"),
     # "fit": ("pyneuromatic.analysis.nm_tool_fit", "NMToolFit"),
+    # "art": ("pyneuromatic.analysis.nm_tool_fit", "NMToolArt"),
+    # "roi": ("pyneuromatic.analysis.nm_tool_fit", "NMToolROI"),
     # "pulse": ("pyneuromatic.analysis.nm_tool_pulse", "NMToolPulse"),
     # "model": ("pyneuromatic.analysis.nm_tool_model", "NMToolModel"),
     # "clamp": ("pyneuromatic.acquisition.nm_tool_clamp", "NMToolClamp"),

--- a/tests/test_analysis/test_nm_tool_folder.py
+++ b/tests/test_analysis/test_nm_tool_folder.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for nm_tool_folder: NMToolFolder and NMToolFolderContainer.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+"""
+import unittest
+
+import numpy as np
+
+from pyneuromatic.analysis.nm_tool_folder import NMToolFolder, NMToolFolderContainer
+from pyneuromatic.core.nm_manager import NMManager
+
+NM = NMManager(quiet=True)
+
+
+def _make_container() -> NMToolFolderContainer:
+    return NMToolFolderContainer(parent=NM)
+
+
+class TestNMToolFolderContainerGetOrCreate(unittest.TestCase):
+    """Tests for NMToolFolderContainer.get_or_create()."""
+
+    def test_overwrite_true_creates_base_0_when_absent(self):
+        tf = _make_container()
+        f = tf.get_or_create("spike", overwrite=True)
+        self.assertIsInstance(f, NMToolFolder)
+        self.assertEqual(f.name, "spike_0")
+
+    def test_overwrite_true_reuses_existing_base_0(self):
+        tf = _make_container()
+        f1 = tf.get_or_create("spike", overwrite=True)
+        f2 = tf.get_or_create("spike", overwrite=True)
+        self.assertIs(f1, f2)
+
+    def test_overwrite_true_clears_data(self):
+        tf = _make_container()
+        f = tf.get_or_create("spike", overwrite=True)
+        f.data.new("SP_rec0", nparray=np.zeros(5))
+        self.assertEqual(len(list(f.data)), 1)
+        f2 = tf.get_or_create("spike", overwrite=True)
+        self.assertIs(f, f2)
+        self.assertEqual(len(list(f2.data)), 0)
+
+    def test_overwrite_false_creates_base_0_when_absent(self):
+        tf = _make_container()
+        f = tf.get_or_create("spike", overwrite=False)
+        self.assertEqual(f.name, "spike_0")
+
+    def test_overwrite_false_increments_to_1(self):
+        tf = _make_container()
+        tf.get_or_create("spike", overwrite=False)
+        f1 = tf.get_or_create("spike", overwrite=False)
+        self.assertEqual(f1.name, "spike_1")
+
+    def test_overwrite_false_increments_to_2(self):
+        tf = _make_container()
+        tf.get_or_create("spike", overwrite=False)
+        tf.get_or_create("spike", overwrite=False)
+        f2 = tf.get_or_create("spike", overwrite=False)
+        self.assertEqual(f2.name, "spike_2")
+
+    def test_overwrite_false_does_not_clear_existing_data(self):
+        tf = _make_container()
+        f0 = tf.get_or_create("spike", overwrite=False)
+        f0.data.new("SP_rec0", nparray=np.zeros(3))
+        tf.get_or_create("spike", overwrite=False)
+        self.assertEqual(len(list(f0.data)), 1)
+
+    def test_default_overwrite_is_true(self):
+        tf = _make_container()
+        f1 = tf.get_or_create("spike")
+        f2 = tf.get_or_create("spike")
+        self.assertIs(f1, f2)
+        self.assertEqual(f1.name, "spike_0")
+
+    def test_different_bases_are_independent(self):
+        tf = _make_container()
+        fs = tf.get_or_create("spike", overwrite=False)
+        fst = tf.get_or_create("stats", overwrite=False)
+        self.assertEqual(fs.name, "spike_0")
+        self.assertEqual(fst.name, "stats_0")
+        self.assertIsNot(fs, fst)
+
+    def test_overwrite_false_does_not_affect_other_base(self):
+        tf = _make_container()
+        tf.get_or_create("spike", overwrite=False)
+        tf.get_or_create("spike", overwrite=False)
+        # stats base starts fresh at _0
+        f = tf.get_or_create("stats", overwrite=False)
+        self.assertEqual(f.name, "stats_0")
+
+    def test_overwrite_true_targets_0_after_false_increments(self):
+        # Build spike_0, spike_1, spike_2 with overwrite=False,
+        # each containing one data array.
+        tf = _make_container()
+        f0 = tf.get_or_create("spike", overwrite=False)
+        f0.data.new("SP_rec0", nparray=np.zeros(3))
+        f1 = tf.get_or_create("spike", overwrite=False)
+        f1.data.new("SP_rec1", nparray=np.ones(3))
+        f2 = tf.get_or_create("spike", overwrite=False)
+        f2.data.new("SP_rec2", nparray=np.full(3, 2.0))
+
+        # Now call with overwrite=True — must reuse spike_0 (cleared)
+        fw = tf.get_or_create("spike", overwrite=True)
+        self.assertIs(fw, f0)
+        self.assertEqual(fw.name, "spike_0")
+        self.assertEqual(len(list(fw.data)), 0)  # data cleared
+
+        # spike_1 and spike_2 are untouched
+        self.assertEqual(len(list(f1.data)), 1)
+        self.assertEqual(len(list(f2.data)), 1)
+
+    def test_returned_folder_is_in_container(self):
+        tf = _make_container()
+        f = tf.get_or_create("mybase", overwrite=True)
+        self.assertIn("mybase_0", tf)
+
+    def test_overwrite_false_all_returned_folders_in_container(self):
+        tf = _make_container()
+        f0 = tf.get_or_create("mybase", overwrite=False)
+        f1 = tf.get_or_create("mybase", overwrite=False)
+        f2 = tf.get_or_create("mybase", overwrite=False)
+        self.assertIn("mybase_0", tf)
+        self.assertIn("mybase_1", tf)
+        self.assertIn("mybase_2", tf)
+        self.assertIsNot(f0, f1)
+        self.assertIsNot(f1, f2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -4000,7 +4000,7 @@ class TestNMMainOpFilter(unittest.TestCase):
         op = NMMainOpFilter()
         self.assertIsNone(op.sample_rate)
 
-    # --- Butterworth low-pass ---
+    # --- Butterworth ---
 
     def test_butterworth_lowpass_preserves_dc(self):
         # DC signal (all ones) should pass through a low-pass filter unchanged
@@ -4029,7 +4029,7 @@ class TestNMMainOpFilter(unittest.TestCase):
         ).run(d)
         np.testing.assert_allclose(d.nparray[100:-100], 0.0, atol=1e-6)
 
-    def test_butterworth_bandpass(self):
+    def test_butterworth_bandpass_output_length(self):
         d = _make_filter_data()
         NMMainOpFilter(
             filter_type="butterworth", cutoff=[100.0, 2000.0],

--- a/tests/test_analysis/test_nm_tool_spike.py
+++ b/tests/test_analysis/test_nm_tool_spike.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for nm_tool_spike: NMToolSpike.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+"""
+import unittest
+
+import numpy as np
+
+from pyneuromatic.analysis.nm_tool_spike import NMToolSpike, NMToolSpikeConfig
+from pyneuromatic.core.nm_channel import NMChannel
+from pyneuromatic.core.nm_data import NMData
+from pyneuromatic.core.nm_dataseries import NMDataSeries
+from pyneuromatic.core.nm_folder import NMFolder
+from pyneuromatic.core.nm_manager import NMManager, HIERARCHY_SELECT_KEYS
+
+NM = NMManager(quiet=True)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SR = 10000.0   # sample rate (Hz) used in test signals
+_DELTA = 1.0 / _SR
+
+
+def _sine_data(name="recordA0", freq=200.0, n=1000, ylevel=0.0):
+    """NMData containing one full second of a sine wave at *freq* Hz.
+
+    The number of upward crossings of *ylevel* = 0 equals *freq* (one per
+    cycle when the signal starts at 0 and rises first).
+    """
+    t = np.arange(n) * _DELTA
+    y = np.sin(2 * np.pi * freq * t)
+    return NMData(
+        NM,
+        name=name,
+        nparray=y,
+        xscale={"start": 0.0, "delta": _DELTA, "label": "Time", "units": "s"},
+        yscale={"label": "Voltage", "units": "mV"},
+    )
+
+
+def _make_targets(data, folder=None):
+    """Build run targets list from a list of NMData objects."""
+    if folder is None:
+        folder = NMFolder(NM, name="TestFolder")
+    return [
+        {k: None for k in HIERARCHY_SELECT_KEYS} | {"folder": folder, "data": d}
+        for d in data
+    ]
+
+
+def _run(tool, data, folder=None):
+    """Run detection on *data* and return (tool, folder)."""
+    if folder is None:
+        folder = NMFolder(NM, name="TestFolder")
+    targets = _make_targets(data, folder=folder)
+    tool.run_all(targets)
+    return folder
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestNMToolSpikeDefaults(unittest.TestCase):
+    """Constructor defaults."""
+
+    def setUp(self):
+        self.tool = NMToolSpike()
+
+    def test_ylevel_default(self):
+        self.assertEqual(self.tool.ylevel, 0.0)
+
+    def test_func_name_default(self):
+        self.assertEqual(self.tool.func_name, "level+")
+
+    def test_results_to_history_default(self):
+        self.assertFalse(self.tool.results_to_history)
+
+    def test_results_to_cache_default(self):
+        self.assertTrue(self.tool.results_to_cache)
+
+    def test_results_to_numpy_default(self):
+        self.assertTrue(self.tool.results_to_numpy)
+
+
+class TestNMToolSpikeProperties(unittest.TestCase):
+    """Property validation."""
+
+    def setUp(self):
+        self.tool = NMToolSpike()
+
+    # ylevel
+    def test_ylevel_accepts_float(self):
+        self.tool.ylevel = -10.5
+        self.assertEqual(self.tool.ylevel, -10.5)
+
+    def test_ylevel_accepts_int(self):
+        self.tool.ylevel = 5
+        self.assertEqual(self.tool.ylevel, 5.0)
+
+    def test_ylevel_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.ylevel = True
+
+    def test_ylevel_rejects_string(self):
+        with self.assertRaises(TypeError):
+            self.tool.ylevel = "0"
+
+    # func_name
+    def test_func_name_accepts_level(self):
+        self.tool.func_name = "level"
+        self.assertEqual(self.tool.func_name, "level")
+
+    def test_func_name_accepts_level_minus(self):
+        self.tool.func_name = "level-"
+        self.assertEqual(self.tool.func_name, "level-")
+
+    def test_func_name_rejects_invalid(self):
+        with self.assertRaises(ValueError):
+            self.tool.func_name = "peak"
+
+    def test_func_name_rejects_non_string(self):
+        with self.assertRaises(TypeError):
+            self.tool.func_name = 1
+
+    # results_to_* flags
+    def test_results_to_history_set(self):
+        self.tool.results_to_history = True
+        self.assertTrue(self.tool.results_to_history)
+
+    def test_results_to_history_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.results_to_history = 1
+
+    def test_results_to_cache_set(self):
+        self.tool.results_to_cache = False
+        self.assertFalse(self.tool.results_to_cache)
+
+    def test_results_to_cache_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.results_to_cache = "yes"
+
+    def test_results_to_numpy_set(self):
+        self.tool.results_to_numpy = False
+        self.assertFalse(self.tool.results_to_numpy)
+
+    def test_results_to_numpy_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.results_to_numpy = None
+
+
+class TestNMToolSpikeDetection(unittest.TestCase):
+    """run_all detection behaviour."""
+
+    def setUp(self):
+        self.tool = NMToolSpike()
+
+    def test_rising_crossings_count(self):
+        # 200 Hz sine, 1000 samples at 10 kHz → 20 cycles → 20 rising crossings
+        # func_name="level+" counts upward crossings of ylevel=0.0
+        d = _sine_data(freq=200.0, n=1000)
+        folder = _run(self.tool, [d])
+        tf = folder.toolfolder
+        f = tf.get("Spike_0")
+        count_arr = f.data.get("SP_count")
+        self.assertEqual(int(count_arr.nparray[0]), 20)
+
+    def test_falling_crossings(self):
+        self.tool.func_name = "level-"
+        d = _sine_data(freq=200.0, n=1000)
+        folder = _run(self.tool, [d])
+        f = folder.toolfolder.get("Spike_0")
+        count_arr = f.data.get("SP_count")
+        self.assertEqual(int(count_arr.nparray[0]), 20)
+
+    def test_both_directions_double_count(self):
+        self.tool.func_name = "level"
+        d = _sine_data(freq=200.0, n=1000)
+        folder = _run(self.tool, [d])
+        f = folder.toolfolder.get("Spike_0")
+        count_arr = f.data.get("SP_count")
+        self.assertEqual(int(count_arr.nparray[0]), 40)
+
+    def test_per_epoch_sp_arrays_created(self):
+        data = [_sine_data(name="recA%d" % i) for i in range(3)]
+        folder = _run(self.tool, data)
+        f = folder.toolfolder.get("Spike_0")
+        for i in range(3):
+            self.assertIn("SP_recA%d" % i, f.data)
+
+    def test_sp_count_length_equals_epoch_count(self):
+        data = [_sine_data(name="recA%d" % i) for i in range(5)]
+        folder = _run(self.tool, data)
+        f = folder.toolfolder.get("Spike_0")
+        self.assertEqual(len(f.data.get("SP_count").nparray), 5)
+
+    def test_sp_count_matches_sp_array_lengths(self):
+        data = [_sine_data(name="recA%d" % i, freq=100.0 * (i + 1)) for i in range(3)]
+        folder = _run(self.tool, data)
+        f = folder.toolfolder.get("Spike_0")
+        counts = f.data.get("SP_count").nparray
+        for i, d in enumerate(data):
+            times = f.data.get("SP_recA%d" % i).nparray
+            self.assertEqual(int(counts[i]), len(times))
+
+    def test_epoch_with_no_crossings(self):
+        # Constant signal — no crossings
+        y = np.ones(500) * 5.0
+        d = NMData(NM, name="flat", nparray=y,
+                   xscale={"start": 0.0, "delta": _DELTA})
+        folder = _run(self.tool, [d])
+        f = folder.toolfolder.get("Spike_0")
+        self.assertEqual(int(f.data.get("SP_count").nparray[0]), 0)
+        self.assertEqual(len(f.data.get("SP_flat").nparray), 0)
+
+    def test_none_nparray_skipped(self):
+        d = NMData(NM, name="empty",
+                   xscale={"start": 0.0, "delta": _DELTA})
+        # nparray is None — should not appear in epoch_names
+        folder = _run(self.tool, [d])
+        # run_finish skips when no epoch_names
+        self.assertIsNone(self.tool._toolfolder)
+
+    def test_sp_times_are_floats(self):
+        d = _sine_data(freq=100.0)
+        folder = _run(self.tool, [d])
+        f = folder.toolfolder.get("Spike_0")
+        times = f.data.get("SP_recordA0").nparray
+        self.assertEqual(times.dtype.kind, "f")
+
+    def test_xscale_units_captured(self):
+        d = _sine_data()
+        _run(self.tool, [d])
+        self.assertEqual(self.tool._detected_xunits, "s")
+
+
+class TestNMToolSpikeSubfolderNaming(unittest.TestCase):
+    """Subfolder naming follows spike_{dataseries}_{channel}_N pattern."""
+
+    def setUp(self):
+        self.tool = NMToolSpike()
+
+    def _run_with_selection(self, folder, dataseries=None, channel=None):
+        d = _sine_data()
+        target = {k: None for k in HIERARCHY_SELECT_KEYS}
+        target["folder"] = folder
+        target["data"] = d
+        if dataseries is not None:
+            target["dataseries"] = dataseries
+        if channel is not None:
+            target["channel"] = channel
+        self.tool.run_all([target])
+
+    def test_no_dataseries_no_channel(self):
+        folder = NMFolder(NM, name="F")
+        self._run_with_selection(folder)
+        self.assertIn("Spike_0", folder.toolfolder)
+
+    def test_with_dataseries(self):
+        folder = NMFolder(NM, name="F")
+        ds = NMDataSeries(NM, name="Record")
+        self._run_with_selection(folder, dataseries=ds)
+        self.assertIn("Spike_Record_0", folder.toolfolder)
+
+    def test_with_dataseries_and_channel(self):
+        folder = NMFolder(NM, name="F")
+        ds = NMDataSeries(NM, name="Record")
+        ch = NMChannel(NM, name="A")
+        self._run_with_selection(folder, dataseries=ds, channel=ch)
+        self.assertIn("Spike_Record_A_0", folder.toolfolder)
+
+    def test_second_run_increments_suffix_when_overwrite_false(self):
+        folder = NMFolder(NM, name="F")
+        self.tool.overwrite = False
+        self._run_with_selection(folder)
+        self.tool = NMToolSpike()
+        self.tool.overwrite = False
+        self._run_with_selection(folder)
+        self.assertIn("Spike_0", folder.toolfolder)
+        self.assertIn("Spike_1", folder.toolfolder)
+
+
+class TestNMToolSpikePST(unittest.TestCase):
+    """pst() histogram method."""
+
+    def setUp(self):
+        self.tool = NMToolSpike()
+        data = [_sine_data(name="recA%d" % i, freq=100.0) for i in range(3)]
+        self.folder = _run(self.tool, data)
+
+    def test_pst_returns_nmdata(self):
+        result = self.tool.pst(bins=50)
+        self.assertIsInstance(result, NMData)
+
+    def test_pst_length_equals_bins(self):
+        result = self.tool.pst(bins=50)
+        self.assertEqual(len(result.nparray), 50)
+
+    def test_pst_total_counts_equals_total_spikes(self):
+        f = self.folder.toolfolder.get("Spike_0")
+        total_spikes = int(f.data.get("SP_count").nparray.sum())
+        result = self.tool.pst(bins=50)
+        self.assertEqual(int(result.nparray.sum()), total_spikes)
+
+    def test_pst_xscale_delta_equals_bin_width(self):
+        result = self.tool.pst(bins=100)
+        all_times = np.concatenate(self.tool._spike_times)
+        expected_delta = (all_times.max() - all_times.min()) / 100
+        self.assertAlmostEqual(result.xscale.delta, expected_delta, places=10)
+
+    def test_pst_tstart_tend_restricts_range(self):
+        result = self.tool.pst(bins=50, tstart=0.0, tend=0.05)
+        self.assertIsNotNone(result)
+        self.assertAlmostEqual(result.xscale.start, 0.0, places=10)
+
+    def test_pst_returns_none_when_no_spikes(self):
+        tool2 = NMToolSpike()
+        y = np.ones(500) * 5.0
+        d = NMData(NM, name="flat", nparray=y,
+                   xscale={"start": 0.0, "delta": _DELTA})
+        _run(tool2, [d])
+        result = tool2.pst()
+        self.assertIsNone(result)
+
+    def test_pst_raises_before_run(self):
+        tool2 = NMToolSpike()
+        with self.assertRaises(RuntimeError):
+            tool2.pst()
+
+    def test_pst_written_to_subfolder(self):
+        self.tool.pst(bins=50)
+        f = self.folder.toolfolder.get("Spike_0")
+        self.assertIn("SP_PST", f.data)
+
+
+class TestNMToolSpikeISI(unittest.TestCase):
+    """isi() histogram method."""
+
+    def setUp(self):
+        self.tool = NMToolSpike()
+        # Three epochs, each with ~10 spikes (100 Hz, 0.1 s)
+        data = [_sine_data(name="recA%d" % i, freq=100.0, n=1000) for i in range(3)]
+        self.folder = _run(self.tool, data)
+
+    def test_isi_returns_nmdata(self):
+        result = self.tool.isi(bins=50)
+        self.assertIsInstance(result, NMData)
+
+    def test_isi_length_equals_bins(self):
+        result = self.tool.isi(bins=50)
+        self.assertEqual(len(result.nparray), 50)
+
+    def test_isi_xscale_start_nonnegative(self):
+        result = self.tool.isi(bins=50)
+        self.assertGreaterEqual(result.xscale.start, 0.0)
+
+    def test_isi_max_isi_sets_upper_bound(self):
+        result = self.tool.isi(bins=50, max_isi=0.02)
+        self.assertIsNotNone(result)
+
+    def test_isi_returns_none_when_fewer_than_2_spikes(self):
+        # Signal with exactly one crossing
+        y = np.zeros(100)
+        y[50] = 1.0  # single upward crossing
+        d = NMData(NM, name="single", nparray=y,
+                   xscale={"start": 0.0, "delta": _DELTA})
+        tool2 = NMToolSpike()
+        _run(tool2, [d])
+        result = tool2.isi()
+        self.assertIsNone(result)
+
+    def test_isi_raises_before_run(self):
+        tool2 = NMToolSpike()
+        with self.assertRaises(RuntimeError):
+            tool2.isi()
+
+    def test_isi_written_to_subfolder(self):
+        self.tool.isi(bins=50)
+        f = self.folder.toolfolder.get("Spike_0")
+        self.assertIn("SP_ISI", f.data)
+
+    def test_isi_total_intervals_correct(self):
+        # Each epoch: 10 spikes → 9 ISIs; 3 epochs → 27 total ISIs
+        result = self.tool.isi(bins=50)
+        total_intervals = sum(
+            len(np.diff(t)) for t in self.tool._spike_times if len(t) >= 2
+        )
+        self.assertEqual(int(result.nparray.sum()), total_intervals)
+
+
+class TestNMToolSpikeOverwrite(unittest.TestCase):
+    """overwrite flag controls subfolder reuse vs. new numbered subfolders."""
+
+    def _run_once(self, tool, folder, freq=100.0):
+        d = _sine_data(freq=freq)
+        targets = _make_targets([d], folder=folder)
+        tool.run_all(targets)
+
+    def test_overwrite_true_default(self):
+        self.assertTrue(NMToolSpike().overwrite)
+
+    def test_overwrite_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            NMToolSpike().overwrite = 1
+
+    def test_overwrite_true_creates_Spike_0(self):
+        tool = NMToolSpike()
+        folder = NMFolder(NM, name="F")
+        self._run_once(tool, folder)
+        self.assertIn("Spike_0", folder.toolfolder)
+
+    def test_overwrite_true_reuses_Spike_0_on_second_run(self):
+        tool = NMToolSpike()
+        folder = NMFolder(NM, name="F")
+        self._run_once(tool, folder)
+        self._run_once(tool, folder)
+        self.assertIn("Spike_0", folder.toolfolder)
+        self.assertNotIn("Spike_1", folder.toolfolder)
+
+    def test_overwrite_true_replaces_sp_arrays(self):
+        tool = NMToolSpike()
+        folder = NMFolder(NM, name="F")
+        self._run_once(tool, folder, freq=100.0)
+        f = folder.toolfolder.get("Spike_0")
+        count_first = int(f.data.get("SP_count").nparray[0])
+        # Run again with different freq — different spike count
+        tool2 = NMToolSpike()
+        self._run_once(tool2, folder, freq=200.0)
+        count_second = int(f.data.get("SP_count").nparray[0])
+        self.assertNotEqual(count_first, count_second)
+
+    def test_overwrite_false_creates_new_subfolder_each_run(self):
+        tool = NMToolSpike()
+        tool.overwrite = False
+        folder = NMFolder(NM, name="F")
+        self._run_once(tool, folder)
+        tool2 = NMToolSpike()
+        tool2.overwrite = False
+        self._run_once(tool2, folder)
+        self.assertIn("Spike_0", folder.toolfolder)
+        self.assertIn("Spike_1", folder.toolfolder)
+
+    def test_config_overwrite_default(self):
+        cfg = NMToolSpikeConfig()
+        self.assertTrue(cfg.overwrite)
+
+    def test_config_overwrite_set_false(self):
+        cfg = NMToolSpikeConfig()
+        cfg.overwrite = False
+        self.assertFalse(cfg.overwrite)
+
+    def test_config_overwrite_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            NMToolSpikeConfig().overwrite = 1
+
+
+class TestNMToolSpikeResultsToCache(unittest.TestCase):
+    """results_to_cache saves spike times to folder.toolresults."""
+
+    def test_cache_saved(self):
+        tool = NMToolSpike()
+        d = _sine_data()
+        folder = _run(tool, [d])
+        self.assertIn("spike", folder.toolresults)
+
+    def test_cache_disabled(self):
+        tool = NMToolSpike()
+        tool.results_to_cache = False
+        d = _sine_data()
+        folder = _run(tool, [d])
+        self.assertNotIn("spike", folder.toolresults)
+
+
+class TestNMToolSpikeNotes(unittest.TestCase):
+    """Notes are written to SP_ output arrays."""
+
+    def setUp(self):
+        self.tool = NMToolSpike()
+        self.tool.ylevel = 0.0
+        self.tool.func_name = "level+"
+        data = [_sine_data(name="recA%d" % i, freq=100.0) for i in range(2)]
+        self.folder = _run(self.tool, data)
+        self.f = self.folder.toolfolder.get("Spike_0")
+
+    def test_sp_epoch_note_contains_nmspike(self):
+        note = self.f.data.get("SP_recA0").notes.note
+        self.assertIn("NMSpike", note)
+
+    def test_sp_epoch_note_contains_source(self):
+        note = self.f.data.get("SP_recA0").notes.note
+        self.assertIn("recA0", note)
+
+    def test_sp_epoch_note_contains_ylevel(self):
+        note = self.f.data.get("SP_recA0").notes.note
+        self.assertIn("ylevel=", note)
+
+    def test_sp_epoch_note_contains_func_name(self):
+        note = self.f.data.get("SP_recA0").notes.note
+        self.assertIn("func_name=", note)
+
+    def test_sp_epoch_note_contains_spike_count(self):
+        note = self.f.data.get("SP_recA0").notes.note
+        self.assertIn("n=", note)
+
+    def test_sp_count_note_contains_n_epochs(self):
+        note = self.f.data.get("SP_count").notes.note
+        self.assertIn("n_epochs=2", note)
+
+    def test_pst_note_contains_nmspike_pst(self):
+        self.tool.pst(bins=50)
+        note = self.f.data.get("SP_PST").notes.note
+        self.assertIn("NMSpike.pst", note)
+
+    def test_pst_note_contains_bins(self):
+        self.tool.pst(bins=50)
+        note = self.f.data.get("SP_PST").notes.note
+        self.assertIn("bins=50", note)
+
+    def test_pst_note_contains_n_spikes(self):
+        self.tool.pst(bins=50)
+        note = self.f.data.get("SP_PST").notes.note
+        self.assertIn("n_spikes=", note)
+
+    def test_isi_note_contains_nmspike_isi(self):
+        self.tool.isi(bins=50)
+        note = self.f.data.get("SP_ISI").notes.note
+        self.assertIn("NMSpike.isi", note)
+
+    def test_isi_note_contains_bins(self):
+        self.tool.isi(bins=50)
+        note = self.f.data.get("SP_ISI").notes.note
+        self.assertIn("bins=50", note)
+
+    def test_isi_note_contains_n_intervals(self):
+        self.tool.isi(bins=50)
+        note = self.f.data.get("SP_ISI").notes.note
+        self.assertIn("n_intervals=", note)
+
+
+class TestNMToolSpikeRaster(unittest.TestCase):
+    """raster() convenience method."""
+
+    def setUp(self):
+        self.tool = NMToolSpike()
+        self.data = [_sine_data(name="recA%d" % i, freq=100.0) for i in range(3)]
+        _run(self.tool, self.data)
+
+    def test_returns_tuple_of_two_lists(self):
+        result = self.tool.raster()
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+
+    def test_times_list_length_equals_epoch_count(self):
+        times_list, _ = self.tool.raster()
+        self.assertEqual(len(times_list), 3)
+
+    def test_labels_list_length_equals_epoch_count(self):
+        _, labels = self.tool.raster()
+        self.assertEqual(len(labels), 3)
+
+    def test_labels_match_epoch_names(self):
+        _, labels = self.tool.raster()
+        self.assertEqual(labels, ["recA0", "recA1", "recA2"])
+
+    def test_times_are_numpy_arrays(self):
+        times_list, _ = self.tool.raster()
+        for times in times_list:
+            self.assertIsInstance(times, np.ndarray)
+
+    def test_times_match_internal_spike_times(self):
+        times_list, _ = self.tool.raster()
+        for a, b in zip(times_list, self.tool._spike_times):
+            np.testing.assert_array_equal(a, b)
+
+    def test_raises_before_run(self):
+        tool2 = NMToolSpike()
+        with self.assertRaises(RuntimeError):
+            tool2.raster()
+
+
+class TestNMToolSpikeConfig(unittest.TestCase):
+    """NMToolSpikeConfig schema, defaults, validation, and TOML round-trip."""
+
+    def setUp(self):
+        self.cfg = NMToolSpikeConfig()
+
+    def test_defaults(self):
+        self.assertEqual(self.cfg.ylevel, 0.0)
+        self.assertEqual(self.cfg.func_name, "level+")
+        self.assertFalse(self.cfg.results_to_history)
+        self.assertTrue(self.cfg.results_to_cache)
+        self.assertTrue(self.cfg.results_to_numpy)
+
+    def test_ylevel_set(self):
+        self.cfg.ylevel = -10.0
+        self.assertEqual(self.cfg.ylevel, -10.0)
+
+    def test_ylevel_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.cfg.ylevel = True
+
+    def test_func_name_accepts_valid(self):
+        for v in ("level", "level+", "level-"):
+            self.cfg.func_name = v
+            self.assertEqual(self.cfg.func_name, v)
+
+    def test_func_name_rejects_invalid(self):
+        with self.assertRaises(ValueError):
+            self.cfg.func_name = "peak"
+
+    def test_results_to_history_set(self):
+        self.cfg.results_to_history = True
+        self.assertTrue(self.cfg.results_to_history)
+
+    def test_results_to_history_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.cfg.results_to_history = 1
+
+    def test_results_to_cache_set(self):
+        self.cfg.results_to_cache = False
+        self.assertFalse(self.cfg.results_to_cache)
+
+    def test_results_to_numpy_set(self):
+        self.cfg.results_to_numpy = False
+        self.assertFalse(self.cfg.results_to_numpy)
+
+    def test_unknown_key_raises(self):
+        with self.assertRaises(AttributeError):
+            self.cfg.nonexistent = 1
+
+    def test_to_dict_contains_all_keys(self):
+        d = self.cfg.to_dict()
+        for key in ("ylevel", "func_name", "overwrite", "results_to_history",
+                    "results_to_cache", "results_to_numpy"):
+            self.assertIn(key, d)
+
+    def test_to_dict_type_header(self):
+        d = self.cfg.to_dict()
+        self.assertEqual(d["pyneuromatic"]["type"], "spike_config")
+
+    def test_from_dict_round_trip(self):
+        self.cfg.ylevel = -5.0
+        self.cfg.func_name = "level-"
+        self.cfg.results_to_history = True
+        d = self.cfg.to_dict()
+        cfg2 = NMToolSpikeConfig.from_dict(d)
+        self.assertEqual(cfg2, self.cfg)
+
+    def test_tool_has_config(self):
+        tool = NMToolSpike()
+        self.assertIsInstance(tool.config, NMToolSpikeConfig)
+
+
+class TestNMToolSpikeRegistry(unittest.TestCase):
+    """spike is registered in the tool registry."""
+
+    def test_registry_returns_nmtoolspike(self):
+        from pyneuromatic.core.nm_tool_registry import get_global_registry, reset_global_registry
+        reset_global_registry()
+        registry = get_global_registry()
+        tool = registry.load("spike")
+        self.assertIsInstance(tool, NMToolSpike)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `NMToolSpike` for action potential detection via threshold crossings
  (`find_level_crossings()`). Per-epoch spike times written as `SP_{epoch}`
  arrays in a `Spike_` subfolder; `SP_count` array records spike counts.
- Add `NMToolSpikeConfig` with `ylevel`, `func_name`, `overwrite`, and
  `results_to_history/cache/numpy` flags.
- Add `pst()` and `isi()` methods for post-detection histogram computation
  (`SP_PST`, `SP_ISI` arrays).
- Add `raster()` convenience method returning `(spike_times, epoch_names)`
  for raster plotting.
- All output arrays carry provenance notes
  (e.g. `NMSpike(source=..., ylevel=..., func_name=..., n=...)`).
- Extract subfolder creation into `NMToolFolderContainer.get_or_create(base,
  overwrite)` — shared utility used by both `NMToolSpike` and `NMToolStats`.
- Register spike tool in `NMToolRegistry`.

## Test plan

- [ ] `tests/test_analysis/test_nm_tool_spike.py` — 94 tests covering
  detection, subfolder naming, PST/ISI histograms, raster, notes, overwrite,
  config, cache, and registry
- [ ] `tests/test_analysis/test_nm_tool_folder.py` — 13 tests for
  `NMToolFolderContainer.get_or_create()`
- [ ] `python3 -m pytest -q` — full suite passes (2573 tests)

Closes #254 
