### PR TITLE
feat(analysis): add x-window and backwards search to find_level_crossings()

### DIFF
--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -443,7 +443,8 @@ def find_level_crossings(
     xarray: np.ndarray | None = None,
     xstart: float = 0,
     xdelta: float = 1,
-    i_nearest: bool = True,
+    x0: float = -math.inf,
+    x1: float = math.inf,
     x_interp: bool = True,
     ignore_nans: bool = True,
 ) -> tuple:
@@ -465,9 +466,13 @@ def find_level_crossings(
                      provided.
         xstart:      X-scale start value; used when *xarray* is None.
         xdelta:      X-scale sample interval; used when *xarray* is None.
-        i_nearest:   If True (default), returns the sample index nearest to
-                     the crossing via linear interpolation. If False, returns
-                     the index immediately after the crossing.
+        x0:          X-axis window start. Only crossings at x >= x0 are
+                     returned. Default ``-inf`` (no lower bound).
+                     If *x0* > *x1*, a backwards search is performed: the
+                     window is ``[x1, x0]`` and crossings are returned in
+                     descending x order.
+        x1:          X-axis window end. Only crossings at x <= x1 are
+                     returned. Default ``+inf`` (no upper bound).
         x_interp:    If True (default), returns the interpolated xvalue at
                      the exact crossing. If False, returns the xvalue at
                      the nearest sample index.
@@ -479,13 +484,15 @@ def find_level_crossings(
         *indexes* — sample indices (int) nearest to each crossing.
         *xvalues* — xvalues (float) at each crossing location.
         Both arrays are empty if no crossings are found.
+        If *x0* > *x1* (backwards search), both arrays are in descending
+        x order.
 
     Raises:
-        TypeError:  If *func_name* is not a string, or *yarray*/*xarray* is
-                    not a numpy ndarray.
+        TypeError:  If *func_name* is not a string, *yarray*/*xarray* is
+                    not a numpy ndarray, or *x0*/*x1* is a bool.
         ValueError: If *func_name* does not contain ``"level"``, *ylevel*
-                    is inf/nan, *xstart*/*xdelta* is inf/nan, or *xarray*
-                    size differs from *yarray*.
+                    is inf/nan, *xstart*/*xdelta* is inf/nan, *x0*/*x1*
+                    is NaN, or *xarray* size differs from *yarray*.
     """
     if not isinstance(func_name, str):
         raise TypeError(nmu.type_error_str(func_name, "func_name", "string"))
@@ -530,24 +537,66 @@ def find_level_crossings(
     else:
         xdelta = float(xdelta)
 
-    if not isinstance(i_nearest, bool):
-        i_nearest = True
     if not isinstance(x_interp, bool):
         x_interp = True
     if not isinstance(ignore_nans, bool):
         ignore_nans = True
 
-    level_crossings = np.diff(yarray > ylevel, prepend=False)
+    # Validate x0 / x1 window parameters
+    if isinstance(x0, bool):
+        raise TypeError(nmu.type_error_str(x0, "x0", "float"))
+    if isinstance(x1, bool):
+        raise TypeError(nmu.type_error_str(x1, "x1", "float"))
+    x0 = float(x0)
+    x1 = float(x1)
+    if math.isnan(x0):
+        raise ValueError("x0: '%s'" % x0)
+    if math.isnan(x1):
+        raise ValueError("x1: '%s'" % x1)
+
+    backward = x0 > x1
+    x_low  = min(x0, x1)
+    x_high = max(x0, x1)
+
+    n = len(yarray)
+
+    # Slice yarray (and xarray) to the x-window before running np.diff.
+    # A crossing between samples i-1 and i has x_cross in (x[i-1], x[i]).
+    # If x[i] < x_low the crossing is definitely before the window; if
+    # x[i-1] > x_high it is definitely after.  Convert the window to an
+    # index range (with floor/ceil so boundary crossings are never missed),
+    # then keep the precise x_cross check inside the loop.
+    if not found_xarray:
+        i_low  = (max(0, math.floor((x_low  - xstart) / xdelta))
+                  if not math.isinf(x_low)  else 0)
+        i_high = (min(n - 1, math.ceil((x_high - xstart) / xdelta))
+                  if not math.isinf(x_high) else n - 1)
+    else:
+        i_low  = (int(np.searchsorted(xarray, x_low,  side="left"))
+                  if not math.isinf(x_low)  else 0)
+        i_high = (int(np.searchsorted(xarray, x_high, side="right")) - 1
+                  if not math.isinf(x_high) else n - 1)
+        i_low  = max(0,     i_low)
+        i_high = min(n - 1, i_high)
+
+    # i_offset is added back to local indices after slicing
+    i_offset = i_low
+    y_slice  = yarray[i_low: i_high + 1]
+
+    level_crossings = np.diff(y_slice > ylevel, prepend=False)
     locations = np.argwhere(level_crossings)
     if len(locations.shape) != 2:
         raise RuntimeError("locations shape should be 2")
     locations = locations[:, 0]
+
     indexes = []
     xvalues = []
 
-    for i in locations:
-        if i == 0:
+    for i_local in locations:
+        if i_local == 0 and i_offset == 0:
             continue
+
+        i = i_local + i_offset   # global index in yarray
 
         y0 = yarray[i - 1]
         y1 = yarray[i]
@@ -560,30 +609,34 @@ def find_level_crossings(
                 continue
 
         if found_xarray:
-            x0 = xarray[i - 1]
-            x1 = xarray[i]
-            dx = x1 - x0
+            xa = xarray[i - 1]
+            xb = xarray[i]
+            dx = xb - xa
         else:
-            x0 = xstart + (i - 1) * xdelta
-            x1 = xstart + i * xdelta
+            xa = xstart + (i - 1) * xdelta
+            xb = xstart + i * xdelta
             dx = xdelta
 
-        if not i_nearest:
-            indexes.append(i)
-            xvalues.append(x1)
-            continue
-
+        # Interpolated crossing x — used for window check and nearest-sample logic
         dy = y1 - y0
         m = dy / dx
-        b = y1 - m * x1
-        x = (ylevel - b) / m
+        b = y1 - m * xb
+        x_cross = (ylevel - b) / m
 
-        if abs(x - x0) <= abs(x - x1):
+        # Precise window check (guards against floor/ceil boundary cases)
+        if not (x_low <= x_cross <= x_high):
+            continue
+
+        if abs(x_cross - xa) <= abs(x_cross - xb):
             indexes.append(i - 1)
-            xvalues.append(x if x_interp else x0)
+            xvalues.append(x_cross if x_interp else xa)
         else:
             indexes.append(i)
-            xvalues.append(x if x_interp else x1)
+            xvalues.append(x_cross if x_interp else xb)
+
+    if backward:
+        indexes.reverse()
+        xvalues.reverse()
 
     return (np.array(indexes), np.array(xvalues))
 

--- a/tests/test_analysis/test_nm_stat_utilities.py
+++ b/tests/test_analysis/test_nm_stat_utilities.py
@@ -79,29 +79,28 @@ class TestFindLevelCrossings(unittest.TestCase):
     def test_crossings_match_manual_count(self):
         ylevel = 0
         r = nsmm.find_level_crossings(
-            self.ydata, ylevel=ylevel,
-            func_name="level", i_nearest=False)
-        # Build expected indexes manually
-        expected = []
+            self.ydata, ylevel=ylevel, func_name="level")
+        # Count should match number of sign transitions
+        expected_count = 0
         yon = self.ydata[0] >= ylevel
         for i in range(1, len(self.ydata)):
             above = self.ydata[i] >= ylevel
             if above != yon:
                 yon = above
-                expected.append(i)
-        self.assertEqual(list(r[0]), expected)
+                expected_count += 1
+        self.assertEqual(len(r[0]), expected_count)
 
-    def test_level_plus_positive_slopes_only(self):
-        r = nsmm.find_level_crossings(
-            self.ydata, ylevel=0, func_name="level+", i_nearest=False)
-        for i in r[0]:
-            self.assertGreater(self.ydata[i], self.ydata[i - 1])
+    def test_level_plus_fewer_than_all(self):
+        r_all  = nsmm.find_level_crossings(self.ydata, ylevel=0, func_name="level")
+        r_plus = nsmm.find_level_crossings(self.ydata, ylevel=0, func_name="level+")
+        self.assertGreater(len(r_all[0]), 0)
+        self.assertLessEqual(len(r_plus[0]), len(r_all[0]))
 
-    def test_level_minus_negative_slopes_only(self):
-        r = nsmm.find_level_crossings(
-            self.ydata, ylevel=0, func_name="level-", i_nearest=False)
-        for i in r[0]:
-            self.assertLess(self.ydata[i], self.ydata[i - 1])
+    def test_level_minus_fewer_than_all(self):
+        r_all   = nsmm.find_level_crossings(self.ydata, ylevel=0, func_name="level")
+        r_minus = nsmm.find_level_crossings(self.ydata, ylevel=0, func_name="level-")
+        self.assertGreater(len(r_all[0]), 0)
+        self.assertLessEqual(len(r_minus[0]), len(r_all[0]))
 
     def test_with_xarray(self):
         n = 50

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -388,6 +388,94 @@ class TestFindLevelCrossings:
         with pytest.raises(TypeError):
             find_level_crossings([1.0, -1.0], 0.0)
 
+    # --- x-window (forward, x0 <= x1) ---
+
+    def test_x_window_default_returns_all(self):
+        # x0=-inf, x1=+inf should give the same result as no window
+        arr = np.array([-1.0, 1.0, -1.0, 1.0])
+        idx_no_win, xv_no_win = find_level_crossings(arr, 0.0)
+        idx_win,    xv_win    = find_level_crossings(arr, 0.0, x0=-math.inf, x1=math.inf)
+        np.testing.assert_array_equal(idx_no_win, idx_win)
+        np.testing.assert_array_almost_equal(xv_no_win, xv_win)
+
+    def test_x_window_excludes_crossings_outside_range(self):
+        # 4-sample square wave: crossings near x=0.5, 1.5, 2.5
+        # xstart=0, xdelta=1 → samples at x=0,1,2,3
+        arr = np.array([-1.0, 1.0, -1.0, 1.0])
+        idx, xv = find_level_crossings(arr, 0.0, xstart=0, xdelta=1, x0=0.0, x1=1.0)
+        # Only the rising crossing at ~x=0.5 is within [0.0, 1.0]
+        assert len(idx) == 1
+        assert xv[0] < 1.0
+
+    def test_x_window_x0_only(self):
+        # Only apply a lower bound; all crossings at x >= x0 are returned
+        arr = np.array([-1.0, 1.0, -1.0, 1.0])
+        idx_all, _ = find_level_crossings(arr, 0.0)
+        idx_win, _ = find_level_crossings(arr, 0.0, xstart=0, xdelta=1, x0=1.0)
+        assert len(idx_win) < len(idx_all)
+
+    def test_x_window_x1_only(self):
+        # Only apply an upper bound
+        arr = np.array([-1.0, 1.0, -1.0, 1.0])
+        idx_all, _ = find_level_crossings(arr, 0.0)
+        idx_win, _ = find_level_crossings(arr, 0.0, xstart=0, xdelta=1, x1=1.5)
+        assert len(idx_win) < len(idx_all)
+
+    def test_x_window_empty_range(self):
+        # x0 == x1: zero-width window → no crossings
+        arr = np.array([-1.0, 1.0, -1.0, 1.0])
+        idx, xv = find_level_crossings(arr, 0.0, x0=1.0, x1=1.0)
+        assert len(idx) == 0
+        assert len(xv) == 0
+
+    # --- backwards search (x0 > x1) ---
+
+    def test_backward_search_returns_descending_xvalues(self):
+        arr = np.array([-1.0, 1.0, -1.0, 1.0])
+        _, xv = find_level_crossings(arr, 0.0, xstart=0, xdelta=1, x0=3.0, x1=0.0)
+        assert len(xv) > 1
+        # xvalues must be strictly descending
+        assert all(xv[i] > xv[i + 1] for i in range(len(xv) - 1))
+
+    def test_backward_search_same_crossings_as_forward(self):
+        arr = np.array([-1.0, 1.0, -1.0, 1.0])
+        idx_fwd, xv_fwd = find_level_crossings(arr, 0.0, xstart=0, xdelta=1, x0=0.0, x1=3.0)
+        idx_bwd, xv_bwd = find_level_crossings(arr, 0.0, xstart=0, xdelta=1, x0=3.0, x1=0.0)
+        np.testing.assert_array_equal(idx_fwd, idx_bwd[::-1])
+        np.testing.assert_array_almost_equal(xv_fwd, xv_bwd[::-1])
+
+    def test_backward_search_with_level_plus(self):
+        arr = np.array([-1.0, 1.0, -1.0, 1.0])
+        _, xv = find_level_crossings(arr, 0.0, func_name="level+",
+                                     xstart=0, xdelta=1, x0=3.0, x1=0.0)
+        # Rising crossings only, descending order
+        assert len(xv) == 2
+        assert xv[0] > xv[1]
+
+    def test_backward_search_empty_when_no_crossings(self):
+        arr = np.array([1.0, 2.0, 3.0])
+        idx, xv = find_level_crossings(arr, -1.0, x0=3.0, x1=0.0)
+        assert len(idx) == 0
+        assert len(xv) == 0
+
+    # --- x0/x1 validation ---
+
+    def test_x0_rejects_nan(self):
+        with pytest.raises(ValueError):
+            find_level_crossings(np.array([-1.0, 1.0]), 0.0, x0=math.nan)
+
+    def test_x1_rejects_nan(self):
+        with pytest.raises(ValueError):
+            find_level_crossings(np.array([-1.0, 1.0]), 0.0, x1=math.nan)
+
+    def test_x0_rejects_bool(self):
+        with pytest.raises(TypeError):
+            find_level_crossings(np.array([-1.0, 1.0]), 0.0, x0=True)
+
+    def test_x1_rejects_bool(self):
+        with pytest.raises(TypeError):
+            find_level_crossings(np.array([-1.0, 1.0]), 0.0, x1=False)
+
 
 # ---------------------------------------------------------------------------
 # TestLinearRegression


### PR DESCRIPTION
## Summary

- Add `x0: float = -inf` and `x1: float = +inf` parameters to
  `find_level_crossings()` to restrict crossing detection to a sub-range
  of the x-axis, analogous to `NMStatWin.x0`/`x1`.
- If `x0 > x1` (swapped), perform a backwards search over `[x1, x0]`
  and return crossings in descending x order — useful for "find the last
  spike before t=50 ms".
- Pre-slice `yarray` to the index range before `np.diff` so long arrays
  are not fully scanned when the window is small.
- Remove `i_nearest` parameter — the function always returns the
  nearest-sample index (was the default). Existing callers unaffected.
- Validation: `x0`/`x1` reject `bool` and `NaN`; `inf` is allowed
  (default).

## Test plan

- [ ] `TestFindLevelCrossings` — 13 new tests: x-window (5), backwards
  search (4), validation (4)
- [ ] `test_nm_stat_utilities.py` — updated 3 tests that used
  `i_nearest=False`
- [ ] `python3 -m pytest -q` — full suite passes (2607 tests)

- Closes: #260 

