### PR TITLE
feat(analysis): add nm_tool_utilities.py wrappers and improve find_level_crossings (#261)

### DIFF
--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -32,6 +32,7 @@ import pyneuromatic.core.nm_configurations as nmc
 import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_math as nm_math
 import pyneuromatic.core.nm_utilities as nmu
+from pyneuromatic.analysis.nm_tool_utilities import find_level_crossings_nmdata
 
 _VALID_FUNC_NAMES: frozenset[str] = frozenset({"level", "level+", "level-"})
 
@@ -266,17 +267,12 @@ class NMToolSpike(NMTool):
         data = self.data
         if not isinstance(data, NMData):
             raise RuntimeError("no data selected")
-        y = data.nparray
-        if y is None:
+        if data.nparray is None:
             return True
         if self._detected_xunits is None:
             self._detected_xunits = data.xscale.units
-        _indexes, x_times = nm_math.find_level_crossings(
-            y,
-            self.__ylevel,
-            func_name=self.__func_name,
-            xstart=data.xscale.start,
-            xdelta=data.xscale.delta,
+        _indexes, x_times = find_level_crossings_nmdata(
+            data, self.__ylevel, func_name=self.__func_name
         )
         self._spike_times.append(x_times)
         self._epoch_names.append(data.name)

--- a/pyneuromatic/analysis/nm_tool_utilities.py
+++ b/pyneuromatic/analysis/nm_tool_utilities.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""
+NMData-aware wrappers for nm_math functions.
+
+Convenience functions that accept NMData objects and automatically unpack
+x-scale parameters (start, delta, units) before delegating to the
+corresponding pure-numpy functions in nm_math.py.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+from pyneuromatic.core.nm_data import NMData
+import pyneuromatic.core.nm_math as nm_math
+
+
+def _sample_rate_from_xscale(data: NMData) -> float:
+    """Derive sample rate (Hz) from *data*.xscale.delta and xscale.units.
+
+    Args:
+        data: NMData whose xscale.delta gives the sample interval.
+
+    Returns:
+        Sample rate in Hz (samples per second).
+
+    Raises:
+        ValueError: If data has a non-uniform xarray (variable sample rate),
+            or if xscale.delta is zero or unset.
+    """
+    if data.xarray is not None:
+        raise ValueError(
+            "cannot derive a single sample_rate: data has a non-uniform "
+            "xarray (variable sample rate); filtering is not supported"
+        )
+    delta = data.xscale.delta
+    units = data.xscale.units
+    if not delta or delta == 0:
+        raise ValueError(
+            "cannot derive sample_rate: xscale.delta is zero or unset"
+        )
+    factor = nm_math.si_scale_factor(units, "s") if units else 1.0
+    return 1.0 / (delta * factor)
+
+
+def find_level_crossings_nmdata(
+    data: NMData,
+    ylevel: float,
+    func_name: str = "level",
+    x0: float = -math.inf,
+    x1: float = math.inf,
+    x_interp: bool = True,
+    ignore_nans: bool = True,
+) -> tuple:
+    """Find threshold crossings in an NMData array.
+
+    Convenience wrapper around :func:`~pyneuromatic.core.nm_math.find_level_crossings`
+    that unpacks x-scale parameters from *data* automatically.  If *data* has
+    a non-uniform ``xarray`` (e.g. variable sample rate), it is passed through
+    directly; otherwise ``xscale.start`` and ``xscale.delta`` are used.
+
+    Args:
+        data:        NMData containing the y-values and x-scale.
+        ylevel:      Y-axis threshold.
+        func_name:   Crossing direction: ``"level"`` (all), ``"level+"``
+                     (rising), or ``"level-"`` (falling).
+        x0:          Window start. Default ``-inf`` (no lower bound).
+                     If *x0* > *x1*, crossings are returned in descending
+                     x order (backwards search).
+        x1:          Window end. Default ``+inf`` (no upper bound).
+        x_interp:    If True (default), return interpolated x at crossing.
+        ignore_nans: If True (default), ignore NaN values.
+
+    Returns:
+        Tuple ``(indexes, xvalues)`` of numpy arrays.
+    """
+    if data.xarray is not None:
+        return nm_math.find_level_crossings(
+            data.nparray,
+            ylevel,
+            func_name=func_name,
+            xarray=data.xarray,
+            x0=x0,
+            x1=x1,
+            x_interp=x_interp,
+            ignore_nans=ignore_nans,
+        )
+    return nm_math.find_level_crossings(
+        data.nparray,
+        ylevel,
+        func_name=func_name,
+        xstart=data.xscale.start,
+        xdelta=data.xscale.delta,
+        x0=x0,
+        x1=x1,
+        x_interp=x_interp,
+        ignore_nans=ignore_nans,
+    )
+
+
+def linear_regression_nmdata(
+    data: NMData,
+    ignore_nans: bool = True,
+) -> tuple:
+    """Fit a line to an NMData array.
+
+    Convenience wrapper around :func:`~pyneuromatic.core.nm_math.linear_regression`
+    that unpacks x-scale parameters from *data* automatically.  If *data* has
+    a non-uniform ``xarray``, it is passed through directly; otherwise
+    ``xscale.start`` and ``xscale.delta`` are used.
+
+    Args:
+        data:        NMData containing the y-values and x-scale.
+        ignore_nans: If True (default), ignore NaN values.
+
+    Returns:
+        Tuple ``(slope, intercept)``.
+    """
+    if data.xarray is not None:
+        return nm_math.linear_regression(
+            data.nparray,
+            xarray=data.xarray,
+            ignore_nans=ignore_nans,
+        )
+    return nm_math.linear_regression(
+        data.nparray,
+        xstart=data.xscale.start,
+        xdelta=data.xscale.delta,
+        ignore_nans=ignore_nans,
+    )
+
+
+def filter_butterworth_nmdata(
+    data: NMData,
+    cutoff: float | list[float],
+    order: int = 4,
+    btype: str = "low",
+) -> np.ndarray:
+    """Apply a Butterworth filter to an NMData array.
+
+    Convenience wrapper around :func:`~pyneuromatic.core.nm_math.filter_butterworth`
+    that derives the sample rate from *data*.xscale automatically.
+
+    Args:
+        data:   NMData containing the signal and x-scale.
+        cutoff: Cut-off frequency in the same units as the sample rate (Hz).
+        order:  Filter order. Default 4.
+        btype:  Filter type: ``"low"``, ``"high"``, or ``"band"``.
+
+    Returns:
+        Filtered numpy array (same shape as input).
+    """
+    sr = _sample_rate_from_xscale(data)
+    return nm_math.filter_butterworth(data.nparray, cutoff, sr, order, btype)
+
+
+def filter_bessel_nmdata(
+    data: NMData,
+    cutoff: float | list[float],
+    order: int = 4,
+    btype: str = "low",
+) -> np.ndarray:
+    """Apply a Bessel filter to an NMData array.
+
+    Convenience wrapper around :func:`~pyneuromatic.core.nm_math.filter_bessel`
+    that derives the sample rate from *data*.xscale automatically.
+
+    Args:
+        data:   NMData containing the signal and x-scale.
+        cutoff: Cut-off frequency in Hz.
+        order:  Filter order. Default 4.
+        btype:  Filter type: ``"low"``, ``"high"``, or ``"band"``.
+
+    Returns:
+        Filtered numpy array (same shape as input).
+    """
+    sr = _sample_rate_from_xscale(data)
+    return nm_math.filter_bessel(data.nparray, cutoff, sr, order, btype)
+
+
+def filter_notch_nmdata(
+    data: NMData,
+    freq: float,
+    q: float = 30.0,
+) -> np.ndarray:
+    """Apply a notch filter to an NMData array.
+
+    Convenience wrapper around :func:`~pyneuromatic.core.nm_math.filter_notch`
+    that derives the sample rate from *data*.xscale automatically.
+
+    Args:
+        data: NMData containing the signal and x-scale.
+        freq: Notch frequency in Hz.
+        q:    Quality factor. Default 30.0.
+
+    Returns:
+        Filtered numpy array (same shape as input).
+    """
+    sr = _sample_rate_from_xscale(data)
+    return nm_math.filter_notch(data.nparray, freq, sr, q)

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -476,8 +476,15 @@ def find_level_crossings(
         x_interp:    If True (default), returns the interpolated xvalue at
                      the exact crossing. If False, returns the xvalue at
                      the nearest sample index.
-        ignore_nans: If True (default), NaN values are included in the
-                     transition detection.
+        ignore_nans: If True (default), NaN values are skipped during
+                     transition detection. A crossing between two non-NaN
+                     samples is still detected even if NaN values lie
+                     between them; the two bounding non-NaN samples and
+                     their x positions are used to linearly interpolate
+                     the crossing x location (Igor Pro behaviour).
+                     If False, a NaN sample acts as ``False`` in the
+                     ``y > ylevel`` comparison, which silently blocks
+                     detection of crossings that span a NaN gap.
 
     Returns:
         Tuple ``(indexes, xvalues)`` of numpy arrays:
@@ -558,6 +565,21 @@ def find_level_crossings(
     x_low  = min(x0, x1)
     x_high = max(x0, x1)
 
+    # NaN compaction (Igor Pro behaviour): remove NaN samples but keep their
+    # x positions so that a crossing between two non-NaN samples separated by
+    # a NaN gap is still detected via linear interpolation of their x values.
+    orig_indices = None  # maps compact index → original yarray index
+    if ignore_nans and np.any(np.isnan(yarray)):
+        keep = ~np.isnan(yarray)
+        orig_indices = np.where(keep)[0]
+        # Build explicit x values for the kept samples before discarding yarray
+        if found_xarray:
+            xarray = xarray[keep]
+        else:
+            xarray = xstart + orig_indices * xdelta
+            found_xarray = True
+        yarray = yarray[keep]
+
     n = len(yarray)
 
     # Slice yarray (and xarray) to the x-window before running np.diff.
@@ -628,10 +650,12 @@ def find_level_crossings(
             continue
 
         if abs(x_cross - xa) <= abs(x_cross - xb):
-            indexes.append(i - 1)
+            idx = int(orig_indices[i - 1]) if orig_indices is not None else i - 1
+            indexes.append(idx)
             xvalues.append(x_cross if x_interp else xa)
         else:
-            indexes.append(i)
+            idx = int(orig_indices[i]) if orig_indices is not None else i
+            indexes.append(idx)
             xvalues.append(x_cross if x_interp else xb)
 
     if backward:

--- a/tests/test_analysis/test_nm_tool_utilities.py
+++ b/tests/test_analysis/test_nm_tool_utilities.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+"""Tests for pyneuromatic.analysis.nm_tool_utilities."""
+import math
+
+import numpy as np
+import pytest
+
+from pyneuromatic.core.nm_data import NMData
+import pyneuromatic.core.nm_math as nm_math
+from pyneuromatic.analysis.nm_tool_utilities import (
+    _sample_rate_from_xscale,
+    find_level_crossings_nmdata,
+    filter_bessel_nmdata,
+    filter_butterworth_nmdata,
+    filter_notch_nmdata,
+    linear_regression_nmdata,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_data(yarray, xstart=0.0, xdelta=0.0001, xunits="s"):
+    """Return an NMData with the given array and x-scale."""
+    d = NMData(name="TestData")
+    d.nparray = np.asarray(yarray, dtype=float)
+    d.xscale.start = xstart
+    d.xscale.delta = xdelta
+    d.xscale.units = xunits
+    return d
+
+
+def _sine_data(freq=50.0, n=1000, xdelta=0.0001, xunits="s"):
+    """1000-point sine wave, sample rate = 1/xdelta."""
+    t = np.arange(n) * xdelta
+    y = np.sin(2 * math.pi * freq * t)
+    return _make_data(y, xstart=0.0, xdelta=xdelta, xunits=xunits)
+
+
+# ---------------------------------------------------------------------------
+# _sample_rate_from_xscale (Hz)
+# ---------------------------------------------------------------------------
+
+class TestSampleRateFromXscale:
+    def test_seconds_units(self):
+        data = _make_data([0], xdelta=0.0001, xunits="s")
+        assert _sample_rate_from_xscale(data) == pytest.approx(10000.0)
+
+    def test_ms_units_gives_correct_sample_rate(self):
+        # delta=0.1 ms → interval 0.0001 s → 10000 Hz
+        data = _make_data([0], xdelta=0.1, xunits="ms")
+        assert _sample_rate_from_xscale(data) == pytest.approx(10000.0)
+
+    def test_no_units_uses_delta_directly(self):
+        # no units → factor=1.0 → sample rate = 1/0.0001
+        data = _make_data([0], xdelta=0.0001, xunits="")
+        assert _sample_rate_from_xscale(data) == pytest.approx(10000.0)
+
+    def test_zero_delta_raises_ValueError(self):
+        # NMScaleX rejects delta=0 at assignment, so bypass via internal attr
+        data = _make_data([0], xdelta=0.0001, xunits="s")
+        data.xscale._delta = 0
+        with pytest.raises((ValueError, ZeroDivisionError)):
+            _sample_rate_from_xscale(data)
+
+
+# ---------------------------------------------------------------------------
+# find_level_crossings_nmdata
+# ---------------------------------------------------------------------------
+
+class TestFindLevelCrossingsNMData:
+    def _square_data(self):
+        # Square wave: 0..0 then 1..1 crossing at index 5
+        y = np.array([0.0] * 5 + [1.0] * 5)
+        return _make_data(y, xstart=0.0, xdelta=0.001)
+
+    def test_returns_same_as_nm_math_direct(self):
+        data = self._square_data()
+        result_wrapper = find_level_crossings_nmdata(data, 0.5)
+        result_direct = nm_math.find_level_crossings(
+            data.nparray,
+            0.5,
+            xstart=data.xscale.start,
+            xdelta=data.xscale.delta,
+        )
+        np.testing.assert_array_equal(result_wrapper[0], result_direct[0])
+        np.testing.assert_array_almost_equal(result_wrapper[1], result_direct[1])
+
+    def test_returns_tuple_of_two_arrays(self):
+        data = self._square_data()
+        indexes, xvalues = find_level_crossings_nmdata(data, 0.5)
+        assert len(indexes) == len(xvalues)
+
+    def test_x_window_passed_through(self):
+        # Two crossings at ~0.005 s and later; restrict to [0, 0.003] should
+        # return only the first crossing.
+        y = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+        data = _make_data(y, xstart=0.0, xdelta=0.001)
+        all_idx, _ = find_level_crossings_nmdata(data, 0.5)
+        win_idx, _ = find_level_crossings_nmdata(data, 0.5, x0=0.0, x1=0.003)
+        assert len(win_idx) < len(all_idx)
+
+    def test_backward_search_passed_through(self):
+        # x0 > x1 → descending order
+        y = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0])
+        data = _make_data(y, xstart=0.0, xdelta=0.001)
+        fwd_idx, fwd_x = find_level_crossings_nmdata(data, 0.5)
+        bwd_idx, bwd_x = find_level_crossings_nmdata(
+            data, 0.5, x0=0.008, x1=0.0
+        )
+        assert len(bwd_x) >= 1
+        # x values should be in descending order
+        if len(bwd_x) > 1:
+            assert bwd_x[0] > bwd_x[-1]
+
+    def test_raises_if_nparray_is_none(self):
+        data = _make_data([0.0, 1.0, 0.0])
+        data.nparray = None
+        with pytest.raises((TypeError, AttributeError, ValueError)):
+            find_level_crossings_nmdata(data, 0.5)
+
+    def test_uses_xarray_when_set(self):
+        # Non-uniform x spacing — xarray takes precedence over xscale
+        y = np.array([0.0, 0.0, 1.0, 1.0, 0.0])
+        xa = np.array([0.0, 0.5, 1.0, 2.0, 3.0])  # irregular spacing
+        data = _make_data(y, xstart=0.0, xdelta=0.001)
+        data.xarray = xa
+        result_wrapper = find_level_crossings_nmdata(data, 0.5)
+        result_direct = nm_math.find_level_crossings(
+            y, 0.5, xarray=xa
+        )
+        np.testing.assert_array_equal(result_wrapper[0], result_direct[0])
+        np.testing.assert_array_almost_equal(result_wrapper[1], result_direct[1])
+
+    def test_xarray_window_passed_through(self):
+        # Window applied correctly with non-uniform xarray
+        y = np.array([0.0, 1.0, 0.0, 1.0, 0.0])
+        xa = np.array([0.0, 1.0, 2.0, 10.0, 11.0])  # large gap in middle
+        data = _make_data(y, xstart=0.0, xdelta=0.001)
+        data.xarray = xa
+        all_idx, _ = find_level_crossings_nmdata(data, 0.5)
+        win_idx, _ = find_level_crossings_nmdata(data, 0.5, x0=0.0, x1=3.0)
+        assert len(win_idx) < len(all_idx)
+
+
+# ---------------------------------------------------------------------------
+# linear_regression_nmdata
+# ---------------------------------------------------------------------------
+
+class TestLinearRegressionNMData:
+    def test_returns_slope_and_intercept(self):
+        # y = 2x + 3 at x = 0, 0.001, 0.002, ...
+        xdelta = 0.001
+        n = 10
+        x = np.arange(n) * xdelta
+        y = 2.0 * x + 3.0
+        data = _make_data(y, xstart=0.0, xdelta=xdelta)
+        slope, intercept = linear_regression_nmdata(data)
+        assert slope == pytest.approx(2.0, rel=1e-6)
+        assert intercept == pytest.approx(3.0, rel=1e-6)
+
+    def test_matches_nm_math_direct(self):
+        y = np.linspace(1.0, 5.0, 20)
+        data = _make_data(y, xstart=0.0, xdelta=0.01)
+        result_wrapper = linear_regression_nmdata(data)
+        result_direct = nm_math.linear_regression(
+            data.nparray,
+            xstart=data.xscale.start,
+            xdelta=data.xscale.delta,
+        )
+        assert result_wrapper[0] == pytest.approx(result_direct[0])
+        assert result_wrapper[1] == pytest.approx(result_direct[1])
+
+    def test_ignores_nans(self):
+        y = np.array([1.0, 2.0, np.nan, 4.0, 5.0])
+        data = _make_data(y, xstart=0.0, xdelta=1.0)
+        slope, intercept = linear_regression_nmdata(data, ignore_nans=True)
+        assert np.isfinite(slope)
+        assert np.isfinite(intercept)
+
+    def test_uses_xarray_when_set(self):
+        # Non-uniform x spacing — xarray takes precedence over xscale
+        xa = np.array([0.0, 1.0, 3.0, 6.0, 10.0])  # irregular spacing
+        y = 2.0 * xa + 1.0
+        data = _make_data(y, xstart=0.0, xdelta=0.001)
+        data.xarray = xa
+        result_wrapper = linear_regression_nmdata(data)
+        result_direct = nm_math.linear_regression(y, xarray=xa)
+        assert result_wrapper[0] == pytest.approx(result_direct[0])
+        assert result_wrapper[1] == pytest.approx(result_direct[1])
+
+
+# ---------------------------------------------------------------------------
+# filter_butterworth_nmdata
+# ---------------------------------------------------------------------------
+
+class TestFilterButterworthNMData:
+    def test_output_shape_matches_input(self):
+        data = _sine_data(freq=10.0)
+        out = filter_butterworth_nmdata(data, cutoff=100.0)
+        assert out.shape == data.nparray.shape
+
+    def test_lowpass_attenuates_high_freq(self):
+        # Low-frequency signal should pass; high-frequency should be attenuated
+        n, xdelta = 2000, 0.0001  # 10 kHz sample rate
+        t = np.arange(n) * xdelta
+        low = np.sin(2 * math.pi * 10 * t)    # 10 Hz — well below cutoff
+        high = np.sin(2 * math.pi * 1000 * t)  # 1000 Hz — above cutoff
+        data_low = _make_data(low, xdelta=xdelta)
+        data_high = _make_data(high, xdelta=xdelta)
+        out_low = filter_butterworth_nmdata(data_low, cutoff=200.0)
+        out_high = filter_butterworth_nmdata(data_high, cutoff=200.0)
+        assert np.std(out_low) > np.std(out_high)
+
+    def test_matches_nm_math_direct(self):
+        data = _sine_data(freq=10.0)
+        sr = 1.0 / (data.xscale.delta * 1.0)  # units="s", factor=1
+        expected = nm_math.filter_butterworth(data.nparray, 100.0, sr, 4, "low")
+        result = filter_butterworth_nmdata(data, cutoff=100.0)
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_zero_delta_raises(self):
+        data = _make_data(np.ones(10), xdelta=0.0001)
+        data.xscale._delta = 0
+        with pytest.raises((ValueError, ZeroDivisionError)):
+            filter_butterworth_nmdata(data, cutoff=100.0)
+
+    def test_raises_if_xarray_set(self):
+        data = _sine_data(freq=10.0)
+        data.xarray = np.arange(data.nparray.size, dtype=float) * 0.0001
+        with pytest.raises(ValueError, match="non-uniform xarray"):
+            filter_butterworth_nmdata(data, cutoff=100.0)
+
+
+# ---------------------------------------------------------------------------
+# filter_bessel_nmdata
+# ---------------------------------------------------------------------------
+
+class TestFilterBesselNMData:
+    def test_output_shape_matches_input(self):
+        data = _sine_data(freq=10.0)
+        out = filter_bessel_nmdata(data, cutoff=100.0)
+        assert out.shape == data.nparray.shape
+
+    def test_matches_nm_math_direct(self):
+        data = _sine_data(freq=10.0)
+        sr = 1.0 / data.xscale.delta
+        expected = nm_math.filter_bessel(data.nparray, 100.0, sr, 4, "low")
+        result = filter_bessel_nmdata(data, cutoff=100.0)
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_lowpass_attenuates_high_freq(self):
+        n, xdelta = 2000, 0.0001
+        t = np.arange(n) * xdelta
+        data_low = _make_data(np.sin(2 * math.pi * 10 * t), xdelta=xdelta)
+        data_high = _make_data(np.sin(2 * math.pi * 1000 * t), xdelta=xdelta)
+        out_low = filter_bessel_nmdata(data_low, cutoff=200.0)
+        out_high = filter_bessel_nmdata(data_high, cutoff=200.0)
+        assert np.std(out_low) > np.std(out_high)
+
+    def test_raises_if_xarray_set(self):
+        data = _sine_data(freq=10.0)
+        data.xarray = np.arange(data.nparray.size, dtype=float) * 0.0001
+        with pytest.raises(ValueError, match="non-uniform xarray"):
+            filter_bessel_nmdata(data, cutoff=100.0)
+
+
+# ---------------------------------------------------------------------------
+# filter_notch_nmdata
+# ---------------------------------------------------------------------------
+
+class TestFilterNotchNMData:
+    def test_output_shape_matches_input(self):
+        data = _sine_data(freq=10.0)
+        out = filter_notch_nmdata(data, freq=50.0)
+        assert out.shape == data.nparray.shape
+
+    def test_matches_nm_math_direct(self):
+        data = _sine_data(freq=10.0)
+        sr = 1.0 / data.xscale.delta
+        expected = nm_math.filter_notch(data.nparray, 50.0, sr, 30.0)
+        result = filter_notch_nmdata(data, freq=50.0)
+        np.testing.assert_array_almost_equal(result, expected)
+
+    def test_notch_attenuates_target_freq(self):
+        # A sine at exactly the notch frequency should be strongly attenuated
+        n, xdelta = 4000, 0.0001  # 10 kHz
+        t = np.arange(n) * xdelta
+        y_notch = np.sin(2 * math.pi * 50 * t)    # exactly 50 Hz
+        y_other = np.sin(2 * math.pi * 200 * t)   # away from notch
+        data_notch = _make_data(y_notch, xdelta=xdelta)
+        data_other = _make_data(y_other, xdelta=xdelta)
+        out_notch = filter_notch_nmdata(data_notch, freq=50.0)
+        out_other = filter_notch_nmdata(data_other, freq=50.0)
+        # The notch-freq signal should be more attenuated than the other
+        assert np.std(out_notch) < np.std(out_other)
+
+    def test_raises_if_xarray_set(self):
+        data = _sine_data(freq=10.0)
+        data.xarray = np.arange(data.nparray.size, dtype=float) * 0.0001
+        with pytest.raises(ValueError, match="non-uniform xarray"):
+            filter_notch_nmdata(data, freq=50.0)

--- a/tests/test_core/test_nm_math.py
+++ b/tests/test_core/test_nm_math.py
@@ -388,6 +388,43 @@ class TestFindLevelCrossings:
         with pytest.raises(TypeError):
             find_level_crossings([1.0, -1.0], 0.0)
 
+    # --- x_interp ---
+
+    def test_x_interp_true_returns_interpolated_x(self):
+        # Crossing between x=1 (y=0) and x=2 (y=1); ylevel=0.5 → x=1.5
+        y = np.array([0.0, 0.0, 1.0])
+        idx, xv = find_level_crossings(y, 0.5, xstart=0.0, xdelta=1.0,
+                                       x_interp=True)
+        assert len(xv) == 1
+        assert xv[0] == pytest.approx(1.5)
+
+    def test_x_interp_false_returns_nearest_sample_x(self):
+        # Same crossing; nearest sample to x=1.5 is equidistant — tie goes to i-1=1
+        y = np.array([0.0, 0.0, 1.0])
+        idx, xv = find_level_crossings(y, 0.5, xstart=0.0, xdelta=1.0,
+                                       x_interp=False)
+        assert len(xv) == 1
+        assert xv[0] in (1.0, 2.0)  # one of the two bounding sample x values
+
+    def test_x_interp_true_differs_from_false(self):
+        # With a lopsided crossing (y=0 → y=0.9), interpolated x ≠ sample x
+        y = np.array([0.0, 0.9])
+        idx_t, xv_t = find_level_crossings(y, 0.5, xstart=0.0, xdelta=10.0,
+                                           x_interp=True)
+        idx_f, xv_f = find_level_crossings(y, 0.5, xstart=0.0, xdelta=10.0,
+                                           x_interp=False)
+        assert len(xv_t) == 1
+        assert len(xv_f) == 1
+        assert xv_t[0] != xv_f[0]  # interpolated ≠ nearest sample
+
+    def test_x_interp_xarray_nonuniform(self):
+        # Non-uniform x: crossing between x=0 (y=0) and x=8 (y=1); ylevel=0.25 → x=2
+        y = np.array([0.0, 1.0])
+        xa = np.array([0.0, 8.0])
+        idx, xv = find_level_crossings(y, 0.25, xarray=xa, x_interp=True)
+        assert len(xv) == 1
+        assert xv[0] == pytest.approx(2.0)
+
     # --- x-window (forward, x0 <= x1) ---
 
     def test_x_window_default_returns_all(self):
@@ -475,6 +512,97 @@ class TestFindLevelCrossings:
     def test_x1_rejects_bool(self):
         with pytest.raises(TypeError):
             find_level_crossings(np.array([-1.0, 1.0]), 0.0, x1=False)
+
+    # --- xarray with non-uniform spacing ---
+
+    def test_xarray_nonuniform_crossing_x_value(self):
+        # Crossing between index 1 (x=1.0, y=0.0) and index 2 (x=5.0, y=1.0)
+        # Interpolated x = 1.0 + (0.5 - 0.0) / (1.0 - 0.0) * (5.0 - 1.0) = 3.0
+        y = np.array([0.0, 0.0, 1.0, 1.0])
+        xa = np.array([0.0, 1.0, 5.0, 6.0])
+        idx, xv = find_level_crossings(y, 0.5, xarray=xa)
+        assert len(idx) == 1
+        assert xv[0] == pytest.approx(3.0)
+
+    def test_xarray_nonuniform_window_respects_x_spacing(self):
+        # Two rising crossings: one at x≈3 (between x=1 and x=5),
+        # one at x≈15 (between x=10 and x=20).
+        # Window x0=0, x1=8 should include only the first.
+        y = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0])
+        xa = np.array([0.0, 1.0, 5.0, 6.0, 10.0, 10.5, 20.0, 21.0])
+        all_idx, _ = find_level_crossings(y, 0.5, func_name="level+", xarray=xa)
+        win_idx, _ = find_level_crossings(
+            y, 0.5, func_name="level+", xarray=xa, x0=0.0, x1=8.0
+        )
+        assert len(all_idx) == 2
+        assert len(win_idx) == 1
+
+    def test_xarray_nonuniform_backward_search(self):
+        # Two rising crossings; backward search (x0 > x1) returns descending order
+        y = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0])
+        xa = np.array([0.0, 1.0, 5.0, 6.0, 10.0, 10.5, 20.0, 21.0])
+        _, xv_fwd = find_level_crossings(y, 0.5, func_name="level+", xarray=xa)
+        _, xv_bwd = find_level_crossings(
+            y, 0.5, func_name="level+", xarray=xa, x0=25.0, x1=0.0
+        )
+        assert len(xv_bwd) == 2
+        assert xv_bwd[0] > xv_bwd[1]
+        # Same x values as forward, reversed
+        assert xv_bwd[0] == pytest.approx(xv_fwd[1])
+        assert xv_bwd[1] == pytest.approx(xv_fwd[0])
+
+    def test_xarray_size_mismatch_raises(self):
+        y = np.array([0.0, 1.0, 0.0])
+        xa = np.array([0.0, 1.0])  # wrong size
+        with pytest.raises((ValueError, TypeError)):
+            find_level_crossings(y, 0.5, xarray=xa)
+
+    # --- NaN handling ---
+
+    def test_ignore_nans_detects_crossing_across_nan_gap(self):
+        # NaN between y=0 and y=1; with ignore_nans=True the crossing is found
+        y = np.array([0.0, float("nan"), 1.0])
+        idx, xv = find_level_crossings(y, 0.5, xstart=0.0, xdelta=1.0,
+                                       ignore_nans=True)
+        assert len(idx) == 1
+
+    def test_ignore_nans_false_blocks_crossing_across_nan_gap(self):
+        # NaN between y=0 and y=1; with ignore_nans=False the crossing is missed
+        y = np.array([0.0, float("nan"), 1.0])
+        idx, xv = find_level_crossings(y, 0.5, xstart=0.0, xdelta=1.0,
+                                       ignore_nans=False)
+        assert len(idx) == 0
+
+    def test_ignore_nans_interpolates_x_using_non_nan_positions(self):
+        # Non-uniform xarray: y=0 at x=0, y=NaN at x=1, y=1 at x=5.
+        # Crossing should be interpolated between x=0 and x=5 → x=2.5
+        y = np.array([0.0, float("nan"), 1.0])
+        xa = np.array([0.0, 1.0, 5.0])
+        idx, xv = find_level_crossings(y, 0.5, xarray=xa, ignore_nans=True)
+        assert len(xv) == 1
+        assert xv[0] == pytest.approx(2.5)
+
+    def test_ignore_nans_returned_index_is_original_array_index(self):
+        # NaN at index 1; crossing is between original indices 0 and 2.
+        # Nearest sample to crossing x=2.5 is index 2 (x=5 is farther than x=0).
+        # Actually x_cross=2.5, xa=0.0, xb=5.0 → |2.5-0|=2.5, |2.5-5|=2.5 equal → i-1=0
+        y = np.array([0.0, float("nan"), 1.0])
+        xa = np.array([0.0, 1.0, 5.0])
+        idx, _ = find_level_crossings(y, 0.5, xarray=xa, ignore_nans=True)
+        assert idx[0] in (0, 2)  # original array index, not compact index 1
+
+    def test_ignore_nans_no_nans_unchanged(self):
+        # With no NaNs, ignore_nans=True gives same result as ignore_nans=False
+        y = np.array([0.0, 1.0, 0.0])
+        idx_t, xv_t = find_level_crossings(y, 0.5, xdelta=1.0, ignore_nans=True)
+        idx_f, xv_f = find_level_crossings(y, 0.5, xdelta=1.0, ignore_nans=False)
+        np.testing.assert_array_equal(idx_t, idx_f)
+        np.testing.assert_array_almost_equal(xv_t, xv_f)
+
+    def test_ignore_nans_all_nan_returns_empty(self):
+        y = np.array([float("nan"), float("nan"), float("nan")])
+        idx, xv = find_level_crossings(y, 0.5, ignore_nans=True)
+        assert len(idx) == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `nm_tool_utilities.py` with five NMData-aware convenience wrappers
  (`find_level_crossings_nmdata`, `linear_regression_nmdata`,
  `filter_butterworth/bessel/notch_nmdata`) that unpack x-scale parameters
  automatically; wrappers use `data.xarray` when set (non-uniform sample
  rate), filter wrappers raise `ValueError` if `xarray` is set since no
  single sample rate can be derived
- Update `NMToolSpike.run()` to call `find_level_crossings_nmdata` instead
  of manually unpacking `xscale.start`/`xscale.delta`
- Implement NaN handling in `find_level_crossings` (Igor Pro behaviour):
  NaN samples are compacted out so a crossing between two non-NaN samples
  separated by a NaN gap is detected via linear interpolation of their x
  positions; `ignore_nans=False` preserves the old blocking behaviour
- Add tests for `x_interp`, non-uniform `xarray`, and NaN handling in
  `TestFindLevelCrossings`; add `test_nm_tool_utilities.py` with 28 tests

## Test plan

- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_utilities.py -q` — 28 tests pass
- [ ] `python3 -m pytest tests/test_core/test_nm_math.py::TestFindLevelCrossings -q` — 33 tests pass
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_spike.py -q` — spike tests pass
- [ ] `python3 -m pytest -q` — full suite passes (2645 tests)

Closes: #261 
