### PR TITLE
feat(analysis): add x0, x1, and ignore_nans parameters to NMToolSpike (#264)

### DIFF
--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -20,6 +20,8 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 """
 from __future__ import annotations
 
+import math
+
 import numpy as np
 
 from pyneuromatic.analysis.nm_tool import NMTool
@@ -44,6 +46,12 @@ class NMToolSpikeConfig(NMToolConfig):
         ylevel: Y-axis detection threshold. Default 0.0.
         func_name: Crossing direction — ``"level+"`` (rising, default),
             ``"level-"`` (falling), or ``"level"`` (both).
+        x0: X-axis window start for detection. Default ``-inf`` (no lower
+            bound). If *x0* > *x1*, a backwards search is performed.
+        x1: X-axis window end for detection. Default ``+inf`` (no upper
+            bound).
+        ignore_nans: If True (default), detect crossings across NaN gaps
+            via linear interpolation.
         results_to_history: If True, print spike counts to the history log
             after each run. Default False.
         results_to_cache: If True, save spike times dict to
@@ -57,6 +65,9 @@ class NMToolSpikeConfig(NMToolConfig):
         "ylevel":             {"type": float, "default": 0.0},
         "func_name":          {"type": str,   "default": "level+",
                                "choices": ["level", "level+", "level-"]},
+        "x0":                 {"type": float, "default": -math.inf},
+        "x1":                 {"type": float, "default":  math.inf},
+        "ignore_nans":        {"type": bool,  "default": True},
         "overwrite":          {"type": bool,  "default": True},
         "results_to_history": {"type": bool,  "default": False},
         "results_to_cache":   {"type": bool,  "default": True},
@@ -79,6 +90,10 @@ class NMToolSpike(NMTool):
         ylevel: Y-axis detection threshold. Default 0.0.
         func_name: Crossing direction — ``"level+"`` (rising, default),
             ``"level-"`` (falling), or ``"level"`` (both).
+        x0: X-axis window start. Default ``-inf`` (no lower bound).
+        x1: X-axis window end. Default ``+inf`` (no upper bound).
+        ignore_nans: If True (default), detect crossings across NaN gaps
+            via linear interpolation.
         results_to_history: If True, print spike counts to the history log
             after each run. Default False.
         results_to_cache: If True, save spike times dict to
@@ -93,6 +108,9 @@ class NMToolSpike(NMTool):
 
         self.__ylevel: float = 0.0
         self.__func_name: str = "level+"
+        self.__x0: float = -math.inf
+        self.__x1: float = math.inf
+        self.__ignore_nans: bool = True
         self.__overwrite: bool = True
 
         self.__results_to_history: bool = False
@@ -156,6 +174,58 @@ class NMToolSpike(NMTool):
         self.__func_name = value
         nmh.history("set func_name=%r" % self.__func_name, quiet=quiet)
         nmch.add_nm_command("%s.func_name = %r" % (self._name, self.__func_name))
+
+    @property
+    def x0(self) -> float:
+        """X-axis window start for detection. Default ``-inf`` (no lower bound)."""
+        return self.__x0
+
+    @x0.setter
+    def x0(self, value: float) -> None:
+        self._x0_set(value)
+
+    def _x0_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "x0", "float"))
+        if math.isnan(value):
+            raise ValueError("x0 cannot be NaN")
+        self.__x0 = float(value)
+        nmh.history("set x0=%g" % self.__x0, quiet=quiet)
+        nmch.add_nm_command("%s.x0 = %r" % (self._name, self.__x0))
+
+    @property
+    def x1(self) -> float:
+        """X-axis window end for detection. Default ``+inf`` (no upper bound)."""
+        return self.__x1
+
+    @x1.setter
+    def x1(self, value: float) -> None:
+        self._x1_set(value)
+
+    def _x1_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "x1", "float"))
+        if math.isnan(value):
+            raise ValueError("x1 cannot be NaN")
+        self.__x1 = float(value)
+        nmh.history("set x1=%g" % self.__x1, quiet=quiet)
+        nmch.add_nm_command("%s.x1 = %r" % (self._name, self.__x1))
+
+    @property
+    def ignore_nans(self) -> bool:
+        """If True (default), detect crossings across NaN gaps."""
+        return self.__ignore_nans
+
+    @ignore_nans.setter
+    def ignore_nans(self, value: bool) -> None:
+        self._ignore_nans_set(value)
+
+    def _ignore_nans_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
+        self.__ignore_nans = value
+        nmh.history("set ignore_nans=%s" % value, quiet=quiet)
+        nmch.add_nm_command("%s.ignore_nans = %r" % (self._name, self.__ignore_nans))
 
     @property
     def overwrite(self) -> bool:
@@ -272,7 +342,11 @@ class NMToolSpike(NMTool):
         if self._detected_xunits is None:
             self._detected_xunits = data.xscale.units
         _indexes, x_times = find_level_crossings_nmdata(
-            data, self.__ylevel, func_name=self.__func_name
+            data, self.__ylevel,
+            func_name=self.__func_name,
+            x0=self.__x0,
+            x1=self.__x1,
+            ignore_nans=self.__ignore_nans,
         )
         self._spike_times.append(x_times)
         self._epoch_names.append(data.name)
@@ -331,15 +405,17 @@ class NMToolSpike(NMTool):
             )
             self._add_note(
                 d,
-                "NMSpike(source=%s, ylevel=%g, func_name=%r, n=%d)"
-                % (name, self.__ylevel, self.__func_name, len(times)),
+                "NMSpike(source=%s, ylevel=%g, func_name=%r, x0=%s, x1=%s, n=%d)"
+                % (name, self.__ylevel, self.__func_name,
+                   self.__x0, self.__x1, len(times)),
             )
         counts = np.array([len(t) for t in self._spike_times], dtype=float)
         d_count = f.data.new("SP_count", nparray=counts)
         self._add_note(
             d_count,
-            "NMSpike(ylevel=%g, func_name=%r, n_epochs=%d)"
-            % (self.__ylevel, self.__func_name, len(self._epoch_names)),
+            "NMSpike(ylevel=%g, func_name=%r, x0=%s, x1=%s, n_epochs=%d)"
+            % (self.__ylevel, self.__func_name,
+               self.__x0, self.__x1, len(self._epoch_names)),
         )
         return f
 

--- a/tests/test_analysis/test_nm_tool_spike.py
+++ b/tests/test_analysis/test_nm_tool_spike.py
@@ -80,6 +80,17 @@ class TestNMToolSpikeDefaults(unittest.TestCase):
     def test_func_name_default(self):
         self.assertEqual(self.tool.func_name, "level+")
 
+    def test_x0_default(self):
+        import math
+        self.assertEqual(self.tool.x0, -math.inf)
+
+    def test_x1_default(self):
+        import math
+        self.assertEqual(self.tool.x1, math.inf)
+
+    def test_ignore_nans_default(self):
+        self.assertTrue(self.tool.ignore_nans)
+
     def test_results_to_history_default(self):
         self.assertFalse(self.tool.results_to_history)
 
@@ -129,6 +140,47 @@ class TestNMToolSpikeProperties(unittest.TestCase):
     def test_func_name_rejects_non_string(self):
         with self.assertRaises(TypeError):
             self.tool.func_name = 1
+
+    # x0 / x1
+    def test_x0_accepts_float(self):
+        self.tool.x0 = 0.01
+        self.assertAlmostEqual(self.tool.x0, 0.01)
+
+    def test_x0_accepts_inf(self):
+        import math
+        self.tool.x0 = -math.inf
+        self.assertEqual(self.tool.x0, -math.inf)
+
+    def test_x0_rejects_nan(self):
+        import math
+        with self.assertRaises(ValueError):
+            self.tool.x0 = math.nan
+
+    def test_x0_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.x0 = True
+
+    def test_x1_accepts_float(self):
+        self.tool.x1 = 0.05
+        self.assertAlmostEqual(self.tool.x1, 0.05)
+
+    def test_x1_rejects_nan(self):
+        import math
+        with self.assertRaises(ValueError):
+            self.tool.x1 = math.nan
+
+    def test_x1_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.x1 = False
+
+    # ignore_nans
+    def test_ignore_nans_set_false(self):
+        self.tool.ignore_nans = False
+        self.assertFalse(self.tool.ignore_nans)
+
+    def test_ignore_nans_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.ignore_nans = 1
 
     # results_to_* flags
     def test_results_to_history_set(self):
@@ -187,6 +239,41 @@ class TestNMToolSpikeDetection(unittest.TestCase):
         f = folder.toolfolder.get("Spike_0")
         count_arr = f.data.get("SP_count")
         self.assertEqual(int(count_arr.nparray[0]), 40)
+
+    def test_x0_x1_window_restricts_detection(self):
+        # 200 Hz sine → 20 rising crossings over 0.1 s (1000 samples at 10 kHz).
+        # Restrict to first half (0–0.05 s) → ~10 crossings.
+        d = _sine_data(freq=200.0, n=1000)
+        self.tool.x0 = 0.0
+        self.tool.x1 = 0.05
+        folder = _run(self.tool, [d])
+        f = folder.toolfolder.get("Spike_0")
+        count_full = 20
+        count_win = int(f.data.get("SP_count").nparray[0])
+        self.assertLess(count_win, count_full)
+        self.assertGreater(count_win, 0)
+
+    def test_ignore_nans_true_detects_crossing_across_nan_gap(self):
+        # y=0 at index 0, NaN at index 1, y=1 at index 2 → crossing exists
+        y = np.array([0.0, float("nan"), 1.0])
+        d = NMData(NM, name="recA0", nparray=y,
+                   xscale={"start": 0.0, "delta": _DELTA})
+        self.tool.ylevel = 0.5
+        self.tool.ignore_nans = True
+        folder = _run(self.tool, [d])
+        f = folder.toolfolder.get("Spike_0")
+        self.assertEqual(int(f.data.get("SP_count").nparray[0]), 1)
+
+    def test_ignore_nans_false_blocks_crossing_across_nan_gap(self):
+        # Same data; with ignore_nans=False the NaN blocks the crossing
+        y = np.array([0.0, float("nan"), 1.0])
+        d = NMData(NM, name="recA0", nparray=y,
+                   xscale={"start": 0.0, "delta": _DELTA})
+        self.tool.ylevel = 0.5
+        self.tool.ignore_nans = False
+        folder = _run(self.tool, [d])
+        f = folder.toolfolder.get("Spike_0")
+        self.assertEqual(int(f.data.get("SP_count").nparray[0]), 0)
 
     def test_per_epoch_sp_arrays_created(self):
         data = [_sine_data(name="recA%d" % i) for i in range(3)]
@@ -508,6 +595,16 @@ class TestNMToolSpikeNotes(unittest.TestCase):
     def test_sp_epoch_note_contains_spike_count(self):
         note = self.f.data.get("SP_recA0").notes.note
         self.assertIn("n=", note)
+
+    def test_sp_epoch_note_contains_x0_x1(self):
+        note = self.f.data.get("SP_recA0").notes.note
+        self.assertIn("x0=", note)
+        self.assertIn("x1=", note)
+
+    def test_sp_count_note_contains_x0_x1(self):
+        note = self.f.data.get("SP_count").notes.note
+        self.assertIn("x0=", note)
+        self.assertIn("x1=", note)
 
     def test_sp_count_note_contains_n_epochs(self):
         note = self.f.data.get("SP_count").notes.note


### PR DESCRIPTION
## Summary

- Add `x0` / `x1` window parameters to `NMToolSpike` to restrict spike
  detection to a time range (e.g. exclude a stimulus artefact or search
  only within a known spike window); default `-inf` / `+inf` (no
  restriction)
- Add `ignore_nans` parameter (default `True`): detects crossings across
  NaN gaps via linear interpolation (Igor Pro behaviour); `False` blocks
  detection across NaN gaps
- Both parameters are added to `NMToolSpikeConfig._schema`, exposed as
  validated properties, and passed through to `find_level_crossings_nmdata()`
  in `run()`
- `x0` / `x1` included in output notes on `SP_` epoch arrays and
  `SP_count`

## Test plan

- [ ] Defaults: `x0=-inf`, `x1=+inf`, `ignore_nans=True`
- [ ] Property validation: float/int accepted, bool/NaN rejected, ±inf
  accepted for `x0`/`x1`
- [ ] Window detection: restricted `x0`/`x1` returns fewer spikes than
  full-array detection
- [ ] `ignore_nans=True` detects crossing across NaN gap; `False` blocks it
- [ ] Note content: `x0=` and `x1=` present in epoch and count notes
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_spike.py -q`
  — 111 tests pass
- [ ] `python3 -m pytest -q` — full suite passes

Closes: #264