### PR TITLE
feat(analysis): update pst() with x0/x1 window and output_mode parameter (#266)

### DIFF
--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -482,8 +482,9 @@ class NMToolSpike(NMTool):
     def pst(
         self,
         bins: int = 100,
-        tstart: float | None = None,
-        tend: float | None = None,
+        x0: float | None = None,
+        x1: float | None = None,
+        output_mode: str = "count",
     ) -> NMData | None:
         """Compute a peri-stimulus time (PST) histogram from spike times.
 
@@ -494,17 +495,33 @@ class NMToolSpike(NMTool):
 
         Args:
             bins: Number of histogram bins. Default 100.
-            tstart: Lower edge of the first bin (inclusive). Default None
+            x0: Lower edge of the first bin (inclusive). Default None
                 (use minimum spike time).
-            tend: Upper edge of the last bin (exclusive). Default None
+            x1: Upper edge of the last bin (exclusive). Default None
                 (use maximum spike time).
+            output_mode: Controls the y-axis values:
+
+                * ``"count"`` (default) — raw spike count per bin.
+                * ``"rate"`` — mean firing rate in Hz:
+                  ``count / (n_epochs × bin_width)``.
+                * ``"probability"`` — fraction of epochs with a spike in
+                  each bin: ``count / n_epochs`` (values in ``[0, 1]``).
 
         Returns:
             The new ``SP_PST`` NMData, or None if no spikes were detected.
 
         Raises:
             RuntimeError: If called before :meth:`run_all`.
+            ValueError: If *output_mode* is not ``"count"``, ``"rate"``,
+                or ``"probability"``.
         """
+        _VALID_MODES = ("count", "rate", "probability")
+        output_mode = output_mode.lower()
+        if output_mode not in _VALID_MODES:
+            raise ValueError(
+                "output_mode must be one of %s, got %r"
+                % (list(_VALID_MODES), output_mode)
+            )
         if self._toolfolder is None:
             raise RuntimeError(
                 "NMToolSpike.pst: no spike data — run detection first"
@@ -515,28 +532,38 @@ class NMToolSpike(NMTool):
         if len(all_times) == 0:
             return None
         xrange: tuple[float, float] | None = None
-        if tstart is not None or tend is not None:
-            lo = float(tstart) if tstart is not None else float(all_times.min())
-            hi = float(tend) if tend is not None else float(all_times.max())
+        if x0 is not None or x1 is not None:
+            lo = float(x0) if x0 is not None else float(all_times.min())
+            hi = float(x1) if x1 is not None else float(all_times.max())
             xrange = (lo, hi)
         result = nm_math.histogram(all_times, bins=bins, xrange=xrange)
         counts, edges = result["counts"], result["edges"]
         delta = float(edges[1] - edges[0])
+        n_epochs = len(self._spike_times)
+        if output_mode == "rate":
+            ydata = counts.astype(float) / (n_epochs * delta)
+            ylabel = "Spike rate (Hz)"
+        elif output_mode == "probability":
+            ydata = counts.astype(float) / n_epochs
+            ylabel = "Spike probability"
+        else:
+            ydata = counts.astype(float)
+            ylabel = "Spike count"
         d = self._toolfolder.data.new(
             "SP_PST",
-            nparray=counts.astype(float),
+            nparray=ydata,
             xscale={
                 "start": float(edges[0]),
                 "delta": delta,
                 "label": "Time",
                 "units": self._detected_xunits,
             },
-            yscale={"label": "Spike count"},
+            yscale={"label": ylabel},
         )
         self._add_note(
             d,
-            "NMSpike.pst(bins=%d, tstart=%s, tend=%s, n_spikes=%d)"
-            % (bins, tstart, tend, int(counts.sum())),
+            "NMSpike.pst(bins=%d, x0=%s, x1=%s, output_mode=%r, n_epochs=%d, n_spikes=%d)"
+            % (bins, x0, x1, output_mode, n_epochs, int(counts.sum())),
         )
         return d
 

--- a/tests/test_analysis/test_nm_tool_spike.py
+++ b/tests/test_analysis/test_nm_tool_spike.py
@@ -402,10 +402,48 @@ class TestNMToolSpikePST(unittest.TestCase):
         expected_delta = (all_times.max() - all_times.min()) / 100
         self.assertAlmostEqual(result.xscale.delta, expected_delta, places=10)
 
-    def test_pst_tstart_tend_restricts_range(self):
-        result = self.tool.pst(bins=50, tstart=0.0, tend=0.05)
+    def test_pst_x0_x1_restricts_range(self):
+        result = self.tool.pst(bins=50, x0=0.0, x1=0.05)
         self.assertIsNotNone(result)
         self.assertAlmostEqual(result.xscale.start, 0.0, places=10)
+
+    def test_pst_output_mode_count_matches_total_spikes(self):
+        f = self.folder.toolfolder.get("Spike_0")
+        total_spikes = int(f.data.get("SP_count").nparray.sum())
+        result = self.tool.pst(bins=50, output_mode="count")
+        self.assertEqual(int(result.nparray.sum()), total_spikes)
+
+    def test_pst_output_mode_rate_yscale_label(self):
+        result = self.tool.pst(bins=50, output_mode="rate")
+        self.assertIn("Hz", result.yscale.label)
+
+    def test_pst_output_mode_rate_values(self):
+        # rate = count / (n_epochs * bin_width); sum over bins * bin_width * n_epochs = total spikes
+        n_epochs = len(self.tool._spike_times)
+        result = self.tool.pst(bins=50, output_mode="rate")
+        bin_width = result.xscale.delta
+        reconstructed = result.nparray.sum() * bin_width * n_epochs
+        f = self.folder.toolfolder.get("Spike_0")
+        total_spikes = float(f.data.get("SP_count").nparray.sum())
+        self.assertAlmostEqual(reconstructed, total_spikes, places=6)
+
+    def test_pst_output_mode_probability_range(self):
+        result = self.tool.pst(bins=50, output_mode="probability")
+        self.assertTrue(np.all(result.nparray >= 0.0))
+        self.assertTrue(np.all(result.nparray <= 1.0))
+
+    def test_pst_output_mode_probability_yscale_label(self):
+        result = self.tool.pst(bins=50, output_mode="probability")
+        self.assertIn("probability", result.yscale.label.lower())
+
+    def test_pst_output_mode_case_insensitive(self):
+        # "Rate" should behave identically to "rate" — yscale label contains "Hz"
+        result = self.tool.pst(bins=50, output_mode="Rate")
+        self.assertIn("Hz", result.yscale.label)
+
+    def test_pst_output_mode_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            self.tool.pst(bins=50, output_mode="density")
 
     def test_pst_returns_none_when_no_spikes(self):
         tool2 = NMToolSpike()
@@ -624,6 +662,18 @@ class TestNMToolSpikeNotes(unittest.TestCase):
         self.tool.pst(bins=50)
         note = self.f.data.get("SP_PST").notes.note
         self.assertIn("n_spikes=", note)
+
+    def test_pst_note_contains_output_mode(self):
+        self.tool.pst(bins=50, output_mode="rate")
+        note = self.f.data.get("SP_PST").notes.note
+        self.assertIn("output_mode=", note)
+        self.assertIn("rate", note)
+
+    def test_pst_note_contains_x0_x1(self):
+        self.tool.pst(bins=50, x0=0.0, x1=0.05)
+        note = self.f.data.get("SP_PST").notes.note
+        self.assertIn("x0=", note)
+        self.assertIn("x1=", note)
 
     def test_isi_note_contains_nmspike_isi(self):
         self.tool.isi(bins=50)


### PR DESCRIPTION
## Summary

- Rename `tstart`/`tend` → `x0`/`x1` in `pst()` for consistency with
  the detection window parameters added in #264
- Add `output_mode` parameter (case-insensitive):
  - `"count"` (default) — raw bin counts, unchanged behaviour
  - `"rate"` — mean firing rate in Hz: `count / (n_epochs × bin_width)`
  - `"probability"` — spike probability per bin: `count / n_epochs`,
    values in [0, 1]
- yscale label updated to reflect mode (`"Spike count"`, `"Spike rate
  (Hz)"`, `"Spike probability"`)
- Note format updated to include `x0=`, `x1=`, `output_mode=`,
  `n_epochs=`

## Test plan

- [ ] `x0`/`x1` window restricts histogram range
- [ ] `output_mode="count"` sum matches total spike count
- [ ] `output_mode="rate"` values reconstruct total spikes via
  `sum × bin_width × n_epochs`
- [ ] `output_mode="probability"` values in [0, 1]
- [ ] yscale labels correct for each mode
- [ ] Case-insensitive: `"Rate"` accepted
- [ ] Invalid mode raises `ValueError`
- [ ] Note contains `output_mode=`, `x0=`, `x1=`
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_spike.py -q`
  — 119 tests pass
- [ ] `python3 -m pytest -q` — full suite passes

Closes: #266