### PR TITLE
feat(analysis): update isi() with x0/x1 spike window, min_isi, and output_mode (#268)

### DIFF
--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -570,56 +570,103 @@ class NMToolSpike(NMTool):
     def isi(
         self,
         bins: int = 100,
+        x0: float | None = None,
+        x1: float | None = None,
+        min_isi: float | None = None,
         max_isi: float | None = None,
+        output_mode: str = "count",
     ) -> NMData | None:
         """Compute an interspike interval (ISI) histogram from spike times.
 
-        Computes ``numpy.diff`` of each epoch's spike times, pools the
-        intervals across all epochs, and writes the histogram as ``SP_ISI``
-        in the current Spike subfolder.  Epochs with fewer than two spikes
-        contribute no intervals.
+        Optionally filters spike times to a window [*x0*, *x1*] before
+        computing intervals. Computes ``numpy.diff`` of each epoch's
+        (filtered) spike times, pools the intervals across all epochs, and
+        writes the histogram as ``SP_ISI`` in the current Spike subfolder.
+        Epochs with fewer than two spikes (after filtering) contribute no
+        intervals.
 
         Args:
-            bins: Number of histogram bins. Default 100.
-            max_isi: Upper bound of the last bin. Default None (use the
-                maximum interval).
+            bins:        Number of histogram bins. Default 100.
+            x0:          Lower bound for filtering spike times before
+                         computing intervals. Default None (no lower bound).
+            x1:          Upper bound for filtering spike times before
+                         computing intervals. Default None (no upper bound).
+            min_isi:     Lower edge of the histogram x-axis. Default None
+                         (use the minimum interval). Useful for excluding
+                         refractory-period artefacts.
+            max_isi:     Upper edge of the histogram x-axis. Default None
+                         (use the maximum interval).
+            output_mode: Controls the y-axis values (case-insensitive):
+
+                         * ``"count"`` (default) — raw interval counts.
+                         * ``"probability"`` — count / total_intervals;
+                           normalised to a probability distribution
+                           (sums to 1.0).
 
         Returns:
-            The new ``SP_ISI`` NMData, or None if fewer than 2 spikes total.
+            The new ``SP_ISI`` NMData, or None if fewer than 2 spikes total
+            (after x0/x1 filtering).
 
         Raises:
             RuntimeError: If called before :meth:`run_all`.
+            ValueError:   If *output_mode* is not ``"count"`` or
+                          ``"probability"``.
         """
+        _VALID_MODES = ("count", "probability")
+        output_mode = output_mode.lower()
+        if output_mode not in _VALID_MODES:
+            raise ValueError(
+                "output_mode must be one of %s, got %r"
+                % (list(_VALID_MODES), output_mode)
+            )
         if self._toolfolder is None:
             raise RuntimeError(
                 "NMToolSpike.isi: no spike data — run detection first"
             )
-        intervals = [
-            np.diff(t) for t in self._spike_times if len(t) >= 2
-        ]
+        spike_times = self._spike_times
+        if x0 is not None or x1 is not None:
+            lo = float(x0) if x0 is not None else -math.inf
+            hi = float(x1) if x1 is not None else math.inf
+            spike_times = [t[(t >= lo) & (t <= hi)] for t in spike_times]
+        intervals = [np.diff(t) for t in spike_times if len(t) >= 2]
         if not intervals:
             return None
         all_isis = np.concatenate(intervals)
-        xrange: tuple[float, float] | None = (
-            (0.0, float(max_isi)) if max_isi is not None else None
-        )
+        lo_isi = float(min_isi) if min_isi is not None else None
+        hi_isi = float(max_isi) if max_isi is not None else None
+        if lo_isi is not None or hi_isi is not None:
+            xrange: tuple[float, float] | None = (
+                lo_isi if lo_isi is not None else float(all_isis.min()),
+                hi_isi if hi_isi is not None else float(all_isis.max()),
+            )
+        else:
+            xrange = None
         result = nm_math.histogram(all_isis, bins=bins, xrange=xrange)
         counts, edges = result["counts"], result["edges"]
         delta = float(edges[1] - edges[0])
+        n_intervals = int(counts.sum())
+        if output_mode == "probability":
+            total = float(len(all_isis))
+            ydata = counts.astype(float) / total if total > 0 else counts.astype(float)
+            ylabel = "ISI probability"
+        else:
+            ydata = counts.astype(float)
+            ylabel = "Count"
         d = self._toolfolder.data.new(
             "SP_ISI",
-            nparray=counts.astype(float),
+            nparray=ydata,
             xscale={
                 "start": float(edges[0]),
                 "delta": delta,
                 "label": "ISI",
                 "units": self._detected_xunits,
             },
-            yscale={"label": "Count"},
+            yscale={"label": ylabel},
         )
         self._add_note(
             d,
-            "NMSpike.isi(bins=%d, max_isi=%s, n_intervals=%d)"
-            % (bins, max_isi, int(counts.sum())),
+            "NMSpike.isi(bins=%d, x0=%s, x1=%s, min_isi=%s, max_isi=%s, "
+            "output_mode=%r, n_intervals=%d)"
+            % (bins, x0, x1, min_isi, max_isi, output_mode, n_intervals),
         )
         return d

--- a/tests/test_analysis/test_nm_tool_spike.py
+++ b/tests/test_analysis/test_nm_tool_spike.py
@@ -519,6 +519,50 @@ class TestNMToolSpikeISI(unittest.TestCase):
         )
         self.assertEqual(int(result.nparray.sum()), total_intervals)
 
+    def test_isi_x0_x1_filters_spike_times(self):
+        # Restrict to first half of recording; fewer intervals than full range.
+        # Use separate tools/folders so SP_ISI name does not collide.
+        data = [_sine_data(name="recA%d" % i, freq=100.0, n=1000) for i in range(3)]
+        tool_full = NMToolSpike()
+        folder_full = _run(tool_full, data)
+        result_full = tool_full.isi(bins=50)
+        tool_win = NMToolSpike()
+        folder_win = _run(tool_win, data)
+        result_win = tool_win.isi(bins=50, x0=0.0, x1=0.05)
+        self.assertLess(int(result_win.nparray.sum()), int(result_full.nparray.sum()))
+
+    def test_isi_min_isi_sets_lower_bound(self):
+        result = self.tool.isi(bins=50, min_isi=0.001)
+        self.assertIsNotNone(result)
+        self.assertGreaterEqual(result.xscale.start, 0.001)
+
+    def test_isi_output_mode_probability_sums_to_one(self):
+        result = self.tool.isi(bins=50, output_mode="probability")
+        self.assertAlmostEqual(float(result.nparray.sum()), 1.0, places=6)
+
+    def test_isi_output_mode_probability_yscale_label(self):
+        result = self.tool.isi(bins=50, output_mode="probability")
+        self.assertIn("probability", result.yscale.label.lower())
+
+    def test_isi_output_mode_case_insensitive(self):
+        result = self.tool.isi(bins=50, output_mode="Probability")
+        self.assertIn("probability", result.yscale.label.lower())
+
+    def test_isi_output_mode_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            self.tool.isi(bins=50, output_mode="rate")
+
+    def test_isi_note_contains_new_params(self):
+        self.tool.isi(bins=50, x0=0.0, x1=0.08, min_isi=0.001, max_isi=0.05,
+                      output_mode="probability")
+        f = self.folder.toolfolder.get("Spike_0")
+        note = f.data.get("SP_ISI").notes.note
+        self.assertIn("x0=", note)
+        self.assertIn("x1=", note)
+        self.assertIn("min_isi=", note)
+        self.assertIn("max_isi=", note)
+        self.assertIn("output_mode=", note)
+
 
 class TestNMToolSpikeOverwrite(unittest.TestCase):
     """overwrite flag controls subfolder reuse vs. new numbered subfolders."""


### PR DESCRIPTION
## Summary

- Add `x0`/`x1` parameters to filter spike times before computing
  intervals; only spikes within [x0, x1] contribute to the ISI
  computation — consistent with the detection window (#264) and pst()
  update (#266)
- Add `min_isi` as lower histogram bound, symmetric with existing
  `max_isi`; useful for excluding refractory period artefacts (e.g.
  `min_isi=0.001` removes sub-millisecond double-detections)
- Add `output_mode` (case-insensitive):
  - `"count"` (default) — raw interval counts, unchanged behaviour
  - `"probability"` — count / total_intervals, sums to 1.0; useful for
    comparing ISI shapes across recordings with different spike counts
  - `"rate"` excluded — ISI x-axis is interval duration, not time
- yscale label updated (`"Count"` or `"ISI probability"`)
- Note updated to include `x0=`, `x1=`, `min_isi=`, `max_isi=`,
  `output_mode=`

## Test plan

- [ ] `x0`/`x1` window produces fewer intervals than full range
- [ ] `min_isi` sets histogram lower bound
- [ ] `output_mode="probability"` sums to 1.0
- [ ] `output_mode="probability"` yscale label contains "probability"
- [ ] Case-insensitive: `"Probability"` accepted
- [ ] `"rate"` raises `ValueError`
- [ ] Note contains all new parameter names
- [ ] Existing `max_isi`, count, and returns-None tests unchanged
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_spike.py -q`
  — 127 tests pass
- [ ] `python3 -m pytest -q` — full suite passes (2682 tests)

Closes: #268