### PR TITLE
feat(analysis): add NMToolSpike.extract_spike_waveforms()

### DIFF
--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -320,6 +320,7 @@ class NMToolSpike(NMTool):
         """Reset internal state before the run loop."""
         self._spike_times = []
         self._epoch_names = []
+        self._source_data: list[NMData] = []
         self._detected_xunits = None
         self._toolfolder = None
         return True
@@ -350,6 +351,7 @@ class NMToolSpike(NMTool):
         )
         self._spike_times.append(x_times)
         self._epoch_names.append(data.name)
+        self._source_data.append(data)
         return True
 
     def run_finish(self) -> bool:
@@ -475,6 +477,218 @@ class NMToolSpike(NMTool):
                 "NMToolSpike.raster: no spike data — run detection first"
             )
         return list(self._spike_times), list(self._epoch_names)
+
+    def extract_spike_waveforms(
+        self,
+        pre: float,
+        post: float,
+        clip_to_next_spike: bool = False,
+        edge: str = "skip",
+        align: str = "zero",
+    ) -> list[NMData]:
+        """Extract fixed-width waveform snippets around each detected spike.
+
+        For each spike detected during the most recent :meth:`run_all` call,
+        extracts a ``[−pre, +post]`` window of samples from the source epoch
+        array and writes the snippet as a new NMData array (``SPK_{epoch}_{n}``)
+        in the Spike subfolder.
+
+        Args:
+            pre:               Time before spike in source x-units. Must be > 0.
+            post:              Time after spike in source x-units. Must be > 0.
+            clip_to_next_spike: If True, samples in the post window that fall
+                beyond the next spike time are replaced with ``NaN``, so the
+                snippet does not contain data from the next spike's waveform.
+                All snippets remain the same length (``pre + post`` samples).
+                The last spike in each epoch is never clipped.
+            edge:              How to handle spikes whose window extends
+                beyond the recording edge (case-insensitive):
+
+                * ``"skip"`` (default) — omit the spike; no array is written.
+                * ``"pad"``  — write a full-length snippet, filling
+                  out-of-bounds samples with ``NaN``.
+
+            align:             X-axis alignment of output snippets
+                (case-insensitive):
+
+                * ``"zero"`` (default) — x starts at 0 (runs 0 to
+                  ``pre + post``).
+                * ``"spike"`` — x=0 at the threshold crossing (runs
+                  ``−pre`` to ``+post``).
+                * ``"source"`` — x values preserved from the source
+                  recording; no shift is applied.
+
+        Returns:
+            List of newly created NMData arrays, one per non-skipped spike
+            across all processed epochs.
+
+        Raises:
+            RuntimeError: If called before :meth:`run_all`.
+            ValueError:   If *pre* or *post* <= 0, or *edge* is not
+                          ``"skip"`` or ``"pad"``.
+            ValueError:   If *align* is not ``"zero"``, ``"spike"``, or
+                          ``"source"``.
+            TypeError:    If *pre*, *post*, or *clip_to_next_spike* have
+                          wrong types.
+        """
+        _VALID_EDGES = ("skip", "pad")
+        edge = edge.lower()
+        if edge not in _VALID_EDGES:
+            raise ValueError(
+                "edge must be one of %s, got %r" % (list(_VALID_EDGES), edge)
+            )
+        if isinstance(pre, bool) or not isinstance(pre, (int, float)):
+            raise TypeError(nmu.type_error_str(pre, "pre", "float"))
+        if pre <= 0:
+            raise ValueError("pre must be > 0, got %g" % pre)
+        if isinstance(post, bool) or not isinstance(post, (int, float)):
+            raise TypeError(nmu.type_error_str(post, "post", "float"))
+        if post <= 0:
+            raise ValueError("post must be > 0, got %g" % post)
+        if not isinstance(clip_to_next_spike, bool):
+            raise TypeError(
+                nmu.type_error_str(clip_to_next_spike, "clip_to_next_spike", "boolean")
+            )
+        _VALID_ALIGNS = ("zero", "spike", "source")
+        if not isinstance(align, str):
+            raise TypeError(nmu.type_error_str(align, "align", "str"))
+        align = align.lower()
+        if align not in _VALID_ALIGNS:
+            raise ValueError(
+                "align must be one of %s, got %r" % (list(_VALID_ALIGNS), align)
+            )
+        if not self._epoch_names:
+            raise RuntimeError(
+                "NMToolSpike.extract_spike_waveforms: no spike data — run detection first"
+            )
+        if self._toolfolder is None:
+            self._toolfolder = self._make_toolfolder()
+
+        output: list[NMData] = []
+
+        for epoch_name, spike_times_arr, source in zip(
+            self._epoch_names, self._spike_times, self._source_data
+        ):
+            ydata = source.nparray
+            if ydata is None:
+                continue
+            n_total = ydata.size
+
+            # Sample interval for converting pre/post to sample counts
+            if source.xarray is not None and len(source.xarray) >= 2:
+                delta_for_samples = float(np.median(np.diff(source.xarray)))
+            else:
+                delta_for_samples = float(source.xscale.delta)
+
+            pre_samples = int(round(pre / abs(delta_for_samples)))
+
+            post_samples = max(int(round(post / abs(delta_for_samples))), 1)
+
+            for n, spike_x in enumerate(spike_times_arr):
+                # Nearest sample index to spike
+                i_spike = source.get_xindex(spike_x, clip=False)
+                if i_spike is None:
+                    continue
+
+                i0 = i_spike - pre_samples
+                i1 = i_spike + post_samples
+
+                # Edge handling: build full-length y snippet (and x if needed)
+                use_xarray = source.xarray is not None
+                if i0 < 0 or i1 > n_total:
+                    if edge == "skip":
+                        continue
+                    # "pad": full-length NaN array, fill valid region
+                    snippet = np.full(pre_samples + post_samples, np.nan)
+                    src_start = max(i0, 0)
+                    src_end   = min(i1, n_total)
+                    dst_start = src_start - i0
+                    dst_end   = dst_start + (src_end - src_start)
+                    snippet[dst_start:dst_end] = ydata[src_start:src_end]
+                    n_padded = (pre_samples + post_samples) - (src_end - src_start)
+                    if use_xarray:
+                        # Extrapolate out-of-bounds x-values using delta
+                        x_snippet = np.full(pre_samples + post_samples, np.nan)
+                        x_snippet[dst_start:dst_end] = source.xarray[src_start:src_end]
+                        # fill left pad by stepping backwards from first valid x
+                        if dst_start > 0:
+                            x0_valid = source.xarray[src_start]
+                            for k in range(dst_start - 1, -1, -1):
+                                x_snippet[k] = x0_valid - (dst_start - k) * delta_for_samples
+                        # fill right pad by stepping forwards from last valid x
+                        if dst_end < len(x_snippet):
+                            x1_valid = source.xarray[src_end - 1]
+                            for k in range(dst_end, len(x_snippet)):
+                                x_snippet[k] = x1_valid + (k - dst_end + 1) * delta_for_samples
+                else:
+                    snippet = ydata[i0:i1].copy()
+                    n_padded = 0
+                    if use_xarray:
+                        x_snippet = source.xarray[i0:i1].copy()
+
+                # clip_to_next_spike: NaN-fill samples beyond next spike time
+                n_nan_clipped = 0
+                if clip_to_next_spike and n + 1 < len(spike_times_arr):
+                    next_interval = float(spike_times_arr[n + 1]) - float(spike_x)
+                    clip_samples = int(round(next_interval / abs(delta_for_samples)))
+                    clip_samples = max(clip_samples, 1)
+                    if clip_samples < post_samples:
+                        snippet = snippet.copy()
+                        snippet[pre_samples + clip_samples:] = np.nan
+                        n_nan_clipped = post_samples - clip_samples
+
+                # Build output x-scale or xarray
+                if use_xarray:
+                    if align == "spike":
+                        x_snippet = x_snippet - float(spike_x)
+                    elif align == "zero":
+                        x_snippet = x_snippet - float(x_snippet[0])
+                    # align == "source": no shift
+                    out_xscale = {
+                        "label": source.xscale.label,
+                        "units": source.xscale.units,
+                    }
+                else:
+                    x_snippet = None
+                    if align == "spike":
+                        xstart = -float(pre)
+                    elif align == "zero":
+                        xstart = 0.0
+                    else:  # "source"
+                        xstart = float(source.xscale.start) + i0 * float(source.xscale.delta)
+                    out_xscale = {
+                        "start": xstart,
+                        "delta": float(source.xscale.delta),
+                        "label": source.xscale.label,
+                        "units": source.xscale.units,
+                    }
+                out_yscale = {
+                    "label": source.yscale.label,
+                    "units": source.yscale.units,
+                }
+                array_name = "SPK_%s_%d" % (epoch_name, n)
+                d = self._toolfolder.data.new(
+                    array_name,
+                    nparray=snippet,
+                    xarray=x_snippet,
+                    xscale=out_xscale,
+                    yscale=out_yscale,
+                )
+                note = (
+                    "NMSpike.extract_spike_waveforms(source=%s, spike_x=%.6g, "
+                    "pre=%g, post=%g, clip_to_next_spike=%s, edge=%r, align=%s"
+                    % (epoch_name, float(spike_x), pre, post,
+                       clip_to_next_spike, edge, align)
+                )
+                if n_padded:
+                    note += ", n_padded=%d" % n_padded
+                if n_nan_clipped:
+                    note += ", n_nan_clipped=%d" % n_nan_clipped
+                note += ")"
+                self._add_note(d, note)
+                output.append(d)
+
+        return output
 
     # ------------------------------------------------------------------
     # Histogram methods (called after run_all)

--- a/pyneuromatic/core/nm_data.py
+++ b/pyneuromatic/core/nm_data.py
@@ -517,6 +517,7 @@ class NMDataContainer(NMObjectContainer):
         name: str | None = None,
         select: bool = False,
         nparray: numpy.ndarray | None = None,
+        xarray: numpy.ndarray | None = None,
         xscale: dict | None = None,
         yscale: dict | None = None,
         quiet: bool = nmc.QUIET
@@ -528,6 +529,7 @@ class NMDataContainer(NMObjectContainer):
             parent=self._parent,
             name=actual_name,
             nparray=nparray,
+            xarray=xarray,
             xscale=xscale,
             yscale=yscale,
         )

--- a/tests/test_analysis/test_nm_tool_spike.py
+++ b/tests/test_analysis/test_nm_tool_spike.py
@@ -564,6 +564,388 @@ class TestNMToolSpikeISI(unittest.TestCase):
         self.assertIn("output_mode=", note)
 
 
+class TestNMToolSpikeExtractSpikeWaveforms(unittest.TestCase):
+    """extract_spike_waveforms() extracts waveform snippets around detected spikes."""
+
+    # 100 Hz sine, 1000 samples at 10 kHz → 10 rising crossings.
+    # Spikes near samples 0, 100, 200, ..., 900.
+    # pre=post=0.003 s (30 samples) leaves comfortable margin.
+    _PRE  = 0.003
+    _POST = 0.003
+
+    def setUp(self):
+        self.tool = NMToolSpike()
+        self.data = _sine_data(name="recA0", freq=100.0, n=1000)
+        self.folder = _run(self.tool, [self.data])
+
+    # --- guards ---
+
+    def test_raises_before_run(self):
+        with self.assertRaises(RuntimeError):
+            NMToolSpike().extract_spike_waveforms(self._PRE, self._POST)
+
+    def test_raises_for_zero_pre(self):
+        with self.assertRaises(ValueError):
+            self.tool.extract_spike_waveforms(0.0, self._POST)
+
+    def test_raises_for_negative_pre(self):
+        with self.assertRaises(ValueError):
+            self.tool.extract_spike_waveforms(-0.001, self._POST)
+
+    def test_raises_for_zero_post(self):
+        with self.assertRaises(ValueError):
+            self.tool.extract_spike_waveforms(self._PRE, 0.0)
+
+    def test_raises_for_bool_pre(self):
+        with self.assertRaises(TypeError):
+            self.tool.extract_spike_waveforms(True, self._POST)
+
+    def test_raises_for_invalid_edge(self):
+        with self.assertRaises(ValueError):
+            self.tool.extract_spike_waveforms(self._PRE, self._POST, edge="truncate")
+
+    def test_raises_for_non_str_align(self):
+        with self.assertRaises(TypeError):
+            self.tool.extract_spike_waveforms(self._PRE, self._POST, align=1)
+
+    def test_raises_for_invalid_align(self):
+        with self.assertRaises(ValueError):
+            self.tool.extract_spike_waveforms(self._PRE, self._POST, align="center")
+
+    # --- basic output ---
+
+    def test_returns_list(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertIsInstance(result, list)
+
+    def test_arrays_written_to_subfolder(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertGreater(len(result), 0)
+        f = self.folder.toolfolder.get("Spike_0")
+        self.assertIn(result[0].name, f.data)
+
+    def test_array_name_format(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        names = [d.name for d in result]
+        for i, name in enumerate(names):
+            self.assertTrue(name.startswith("SPK_recA0_"))
+
+    def test_snippet_length(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        pre_samples  = int(round(self._PRE  / _DELTA))
+        post_samples = int(round(self._POST / _DELTA))
+        for d in result:
+            self.assertEqual(len(d.nparray), pre_samples + post_samples)
+
+    # --- xscale ---
+
+    def test_xscale_start_zero_by_default(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertAlmostEqual(result[0].xscale.start, 0.0, places=10)
+
+    def test_xscale_start_equals_minus_pre_when_align_spike(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST, align="spike")
+        self.assertAlmostEqual(result[0].xscale.start, -self._PRE, places=10)
+
+    def test_xscale_start_source_preserves_recording_time(self):
+        # align="source": xscale.start should reflect the original recording time
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST, align="source")
+        for d in result:
+            # start must be >= source xscale.start (snippet begins inside recording)
+            self.assertGreaterEqual(d.xscale.start, self.data.xscale.start)
+
+    def test_align_case_insensitive(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST, align="Zero")
+        self.assertIsInstance(result, list)
+
+    def test_xscale_delta_matches_source(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertAlmostEqual(result[0].xscale.delta, self.data.xscale.delta)
+
+    def test_xscale_units_match_source(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertEqual(result[0].xscale.units, self.data.xscale.units)
+
+    def test_yscale_copied_from_source(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertEqual(result[0].yscale.label, self.data.yscale.label)
+        self.assertEqual(result[0].yscale.units, self.data.yscale.units)
+
+    # --- edge handling ---
+
+    def test_edge_skip_omits_spikes_near_start(self):
+        # Large pre so spikes near the start of recording are skipped
+        result_small = self.tool.extract_spike_waveforms(self._PRE, self._POST, edge="skip")
+        # Use a fresh tool to avoid name collision in the same subfolder
+        tool2 = NMToolSpike()
+        _run(tool2, [_sine_data(name="recA0", freq=100.0, n=1000)])
+        result_large = tool2.extract_spike_waveforms(0.05, self._POST, edge="skip")
+        # Large pre skips more spikes
+        self.assertLess(len(result_large), len(result_small))
+
+    def test_edge_pad_returns_full_length_snippets(self):
+        pre_samples  = int(round(0.05 / _DELTA))
+        post_samples = int(round(self._POST / _DELTA))
+        result = self.tool.extract_spike_waveforms(0.05, self._POST, edge="pad")
+        for d in result:
+            self.assertEqual(len(d.nparray), pre_samples + post_samples)
+
+    def test_edge_pad_fills_out_of_bounds_with_nan(self):
+        # Use a large pre so the first spike's snippet definitely extends before index 0
+        result = self.tool.extract_spike_waveforms(0.05, self._POST, edge="pad")
+        # At least one snippet should contain NaN (from padding)
+        has_nan = any(np.any(np.isnan(d.nparray)) for d in result)
+        self.assertTrue(has_nan)
+
+    def test_edge_case_insensitive(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST, edge="skip")
+        self.assertIsInstance(result, list)
+
+    # --- clip_to_next_spike ---
+
+    def test_clip_to_next_spike_same_length_as_unclipped(self):
+        # Snippets should always be the same length regardless of clipping
+        # 100 Hz → ISI ≈ 0.01 s; post=0.02 s > ISI so NaN-clipping applies
+        result_clip = self.tool.extract_spike_waveforms(
+            self._PRE, 0.02, clip_to_next_spike=True
+        )
+        tool2 = NMToolSpike()
+        _run(tool2, [_sine_data(name="recA0", freq=100.0, n=1000)])
+        result_full = tool2.extract_spike_waveforms(
+            self._PRE, 0.02, clip_to_next_spike=False
+        )
+        self.assertEqual(len(result_clip), len(result_full))
+        pre_samples  = int(round(self._PRE / _DELTA))
+        post_samples = int(round(0.02 / _DELTA))
+        expected_len = pre_samples + post_samples
+        for d in result_clip:
+            self.assertEqual(len(d.nparray), expected_len)
+        for d in result_full:
+            self.assertEqual(len(d.nparray), expected_len)
+
+    def test_clip_to_next_spike_nans_beyond_next_spike(self):
+        # 100 Hz → ISI ≈ 0.01 s; post=0.02 s > ISI → tail of snippet is NaN
+        result = self.tool.extract_spike_waveforms(
+            self._PRE, 0.02, clip_to_next_spike=True
+        )
+        # Non-last spikes should have NaN in the clipped tail
+        has_nan = any(np.any(np.isnan(d.nparray)) for d in result[:-1])
+        self.assertTrue(has_nan)
+
+    def test_clip_to_next_spike_last_has_no_nan(self):
+        # Last spike is never clipped, so no NaN from clipping
+        # Use post small enough that it stays within bounds
+        result = self.tool.extract_spike_waveforms(
+            self._PRE, self._POST, clip_to_next_spike=True
+        )
+        self.assertGreater(len(result), 0)
+        last = result[-1]
+        self.assertFalse(np.any(np.isnan(last.nparray)))
+
+    # --- no spikes ---
+
+    def test_no_spikes_returns_empty_list(self):
+        tool2 = NMToolSpike()
+        y = np.ones(500) * 5.0
+        d = NMData(NM, name="flat", nparray=y,
+                   xscale={"start": 0.0, "delta": _DELTA})
+        _run(tool2, [d])
+        result = tool2.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertEqual(result, [])
+
+    # --- notes ---
+
+    def test_note_contains_source_epoch(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        note = result[0].notes.note
+        self.assertIn("recA0", note)
+
+    def test_note_contains_spike_x(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        note = result[0].notes.note
+        self.assertIn("spike_x=", note)
+
+    def test_note_contains_pre_post(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        note = result[0].notes.note
+        self.assertIn("pre=", note)
+        self.assertIn("post=", note)
+
+    def test_note_contains_align(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        note = result[0].notes.note
+        self.assertIn("align=", note)
+
+    # --- xarray source ---
+
+    def test_xarray_source_sets_xarray_on_snippet(self):
+        # Source with non-uniform xarray → snippet should have xarray, not xscale
+        n = 1000
+        t = np.cumsum(np.ones(n) * _DELTA)  # uniform but stored as xarray
+        t[500:] += 0.001  # introduce a gap to make it non-uniform
+        y = np.sin(2 * np.pi * 100.0 * np.arange(n) * _DELTA)
+        data_xa = NMData(NM, name="recA0", nparray=y,
+                         xscale={"label": "Time", "units": "s"})
+        data_xa.xarray = t
+        tool_xa = NMToolSpike()
+        _run(tool_xa, [data_xa])
+        result = tool_xa.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertGreater(len(result), 0)
+        for d in result:
+            self.assertIsNotNone(d.xarray)
+            self.assertEqual(len(d.xarray), len(d.nparray))
+
+    def test_xarray_source_align_zero_starts_at_zero(self):
+        n = 1000
+        t = np.arange(n, dtype=float) * _DELTA
+        y = np.sin(2 * np.pi * 100.0 * t)
+        data_xa = NMData(NM, name="recA0", nparray=y,
+                         xscale={"label": "Time", "units": "s"})
+        data_xa.xarray = t
+        tool_xa = NMToolSpike()
+        _run(tool_xa, [data_xa])
+        result = tool_xa.extract_spike_waveforms(self._PRE, self._POST, align="zero")
+        self.assertGreater(len(result), 0)
+        self.assertAlmostEqual(result[0].xarray[0], 0.0, places=10)
+
+    def test_xarray_source_align_spike_zero_at_spike(self):
+        n = 1000
+        t = np.arange(n, dtype=float) * _DELTA
+        y = np.sin(2 * np.pi * 100.0 * t)
+        data_xa = NMData(NM, name="recA0", nparray=y,
+                         xscale={"label": "Time", "units": "s"})
+        data_xa.xarray = t
+        tool_xa = NMToolSpike()
+        _run(tool_xa, [data_xa])
+        result = tool_xa.extract_spike_waveforms(self._PRE, self._POST, align="spike")
+        self.assertGreater(len(result), 0)
+        pre_samples = int(round(self._PRE / _DELTA))
+        # x at the spike sample should be within one delta of 0
+        self.assertLess(abs(result[0].xarray[pre_samples]), _DELTA)
+
+    # --- non-uniform xarray ---
+
+    def _make_nonuniform_data(self, name="recA0"):
+        """Signal with two segments at different sample rates.
+
+        Samples 0-499: delta = _DELTA     (10 kHz)
+        Samples 500-999: delta = _DELTA*2 (5 kHz)
+        A threshold crossing is placed in each segment (samples 200 and 700).
+        """
+        n1, n2 = 500, 500
+        t1 = np.arange(n1, dtype=float) * _DELTA
+        t2 = t1[-1] + _DELTA + np.arange(1, n2 + 1, dtype=float) * (_DELTA * 2)
+        t = np.concatenate([t1, t2])
+        y = np.zeros(len(t))
+        y[200] = 1.0   # rising crossing near sample 200 (10 kHz region)
+        y[700] = 1.0   # rising crossing near sample 700 (5 kHz region)
+        d = NMData(NM, name=name, nparray=y,
+                   xscale={"label": "Time", "units": "s"})
+        d.xarray = t
+        return d, t
+
+    def test_nonuniform_xarray_snippet_matches_source_slice(self):
+        # Snippet xarray values must exactly equal the corresponding
+        # slice of the source xarray (before alignment shift).
+        data_nu, t = self._make_nonuniform_data()
+        tool_nu = NMToolSpike()
+        _run(tool_nu, [data_nu])
+        # Use align="zero" so shift is x_snippet[0]; we can recover the
+        # original slice by adding back the first source x value.
+        result = tool_nu.extract_spike_waveforms(self._PRE, self._POST,
+                                                 align="zero")
+        self.assertGreater(len(result), 0)
+        for d in result:
+            # Key property: spacing pattern should match source spacing
+            src_diffs = np.diff(t)
+            snip_diffs = np.diff(d.xarray)
+            # All snippet intervals must appear somewhere in source intervals
+            for interval in snip_diffs:
+                self.assertTrue(
+                    np.any(np.isclose(src_diffs, interval, rtol=1e-9)),
+                    msg="interval %g not found in source xarray diffs" % interval,
+                )
+
+    def test_nonuniform_xarray_diffs_not_all_equal(self):
+        # Verify the snippet xarray is genuinely non-uniform when the spike
+        # spans the boundary between the two sample-rate regions.
+        # Place spike exactly at sample 499 (boundary) with large pre+post.
+        n1, n2 = 500, 500
+        t1 = np.arange(n1, dtype=float) * _DELTA
+        t2 = t1[-1] + _DELTA + np.arange(1, n2 + 1, dtype=float) * (_DELTA * 2)
+        t = np.concatenate([t1, t2])
+        y = np.zeros(len(t))
+        y[499] = 1.0   # crossing at boundary
+        data_bd = NMData(NM, name="recA0", nparray=y,
+                         xscale={"label": "Time", "units": "s"})
+        data_bd.xarray = t
+        tool_bd = NMToolSpike()
+        _run(tool_bd, [data_bd])
+        # pre=0.003 s (30 samples at 10 kHz) → straddles the boundary
+        result = tool_bd.extract_spike_waveforms(0.003, 0.003)
+        self.assertGreater(len(result), 0)
+        diffs = np.diff(result[0].xarray)
+        # Should contain both _DELTA and _DELTA*2 intervals
+        has_fine   = np.any(np.isclose(diffs, _DELTA,     rtol=1e-9))
+        has_coarse = np.any(np.isclose(diffs, _DELTA * 2, rtol=1e-9))
+        self.assertTrue(has_fine,   "expected fine intervals (_DELTA) in snippet")
+        self.assertTrue(has_coarse, "expected coarse intervals (_DELTA*2) in snippet")
+
+    def test_nonuniform_xarray_align_zero_starts_zero(self):
+        data_nu, _ = self._make_nonuniform_data()
+        tool_nu = NMToolSpike()
+        _run(tool_nu, [data_nu])
+        result = tool_nu.extract_spike_waveforms(self._PRE, self._POST, align="zero")
+        self.assertGreater(len(result), 0)
+        for d in result:
+            self.assertAlmostEqual(d.xarray[0], 0.0, places=10)
+
+    def test_nonuniform_xarray_align_spike_near_zero(self):
+        data_nu, t = self._make_nonuniform_data()
+        tool_nu = NMToolSpike()
+        _run(tool_nu, [data_nu])
+        result = tool_nu.extract_spike_waveforms(self._PRE, self._POST, align="spike")
+        self.assertGreater(len(result), 0)
+        median_delta = float(np.median(np.diff(t)))
+        pre_s = int(round(self._PRE / abs(median_delta)))
+        for d in result:
+            # x at the spike sample index should be within one median delta of 0
+            self.assertLess(abs(d.xarray[pre_s]), median_delta)
+
+    def test_nonuniform_xarray_align_source_preserves_values(self):
+        data_nu, t = self._make_nonuniform_data()
+        tool_nu = NMToolSpike()
+        _run(tool_nu, [data_nu])
+        result = tool_nu.extract_spike_waveforms(self._PRE, self._POST, align="source")
+        self.assertGreater(len(result), 0)
+        for d in result:
+            # xarray values must all appear in the source xarray
+            for xval in d.xarray:
+                self.assertTrue(
+                    np.any(np.isclose(t, xval, rtol=1e-9)),
+                    msg="x value %g not found in source xarray" % xval,
+                )
+
+    def test_align_source_xscale_start_in_recording_range(self):
+        # align="source" with uniform xscale: start reflects original position
+        result = self.tool.extract_spike_waveforms(
+            self._PRE, self._POST, align="source"
+        )
+        self.assertGreater(len(result), 0)
+        for d in result:
+            self.assertGreaterEqual(d.xscale.start, self.data.xscale.start)
+
+    # --- results_to_numpy=False ---
+
+    def test_works_when_results_to_numpy_false(self):
+        tool2 = NMToolSpike()
+        tool2.results_to_numpy = False
+        folder2 = _run(tool2, [_sine_data(name="recA0", freq=100.0)])
+        result = tool2.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertIsInstance(result, list)
+        self.assertGreater(len(result), 0)
+
+
 class TestNMToolSpikeOverwrite(unittest.TestCase):
     """overwrite flag controls subfolder reuse vs. new numbered subfolders."""
 

--- a/tests/test_core/test_nm_data.py
+++ b/tests/test_core/test_nm_data.py
@@ -214,6 +214,35 @@ class NMDataTest(unittest.TestCase):
         c0.sets.add("set0", dnlist0[0])
         self.assertTrue(c0_copy == c0)
 
+class TestNMDataContainerNew(unittest.TestCase):
+    """Tests for NMDataContainer.new()."""
+
+    def setUp(self):
+        from pyneuromatic.core.nm_folder import NMFolder
+        self.folder = NMFolder(parent=NM, name="TestFolder")
+
+    def test_new_returns_nmdata(self):
+        d = self.folder.data.new("wave0", nparray=NPARRAY0)
+        self.assertIsInstance(d, NMData)
+
+    def test_new_accepts_xarray(self):
+        xa = numpy.linspace(0.0, 0.003, len(NPARRAY0))
+        d = self.folder.data.new("wave0", nparray=NPARRAY0, xarray=xa)
+        self.assertIsInstance(d, NMData)
+        numpy.testing.assert_array_equal(d.xarray, xa)
+
+    def test_new_xarray_none_by_default(self):
+        d = self.folder.data.new("wave0", nparray=NPARRAY0)
+        self.assertIsNone(d.xarray)
+
+    def test_new_xarray_and_xscale_coexist(self):
+        xa = numpy.linspace(0.0, 0.003, len(NPARRAY0))
+        d = self.folder.data.new("wave0", nparray=NPARRAY0,
+                                 xarray=xa, xscale=XSCALE0)
+        numpy.testing.assert_array_equal(d.xarray, xa)
+        self.assertEqual(d.xscale.units, XSCALE0["units"])
+
+
 class TestNMDataNotes(unittest.TestCase):
     """Tests for NMData notes integration with NMNotes."""
 


### PR DESCRIPTION
## Summary

- Adds extract_spike_waveforms(pre, post, clip_to_next_spike, edge, align) to NMToolSpike for extracting waveform snippets around detected spikes into SPK_ NMData arrays in the Spike subfolder
- clip_to_next_spike=True NaN-fills samples beyond the next spike so all snippets remain the same length and can be stacked into a 2D matrix
- align controls x-axis: "zero" (default, x starts at 0), "spike" (x=0 at threshold crossing), "source" (original recording time preserved)
- Sources with non-uniform xarray produce snippets with a matching xarray slice; uniform sources use xscale
- Extends NMDataContainer.new() to accept xarray parameter, consistent with the NMData constructor

## Test plan

-  TestNMToolSpikeExtractSpikeWaveforms — 41 tests covering guards, snippet length, xscale/yscale, edge handling, clip_to_next_spike, all three align modes, uniform and non-uniform xarray sources
-  TestNMDataContainerNew — 4 tests for NMDataContainer.new() xarray parameter
-  Full test suite passes (python3 -m pytest -q)

Closes: #270