### PR TITLE
feat(analysis): dataseries support in NMToolFolder, per-channel subfolders for extract_spike_waveforms

### DIFF
--- a/pyneuromatic/analysis/nm_tool_folder.py
+++ b/pyneuromatic/analysis/nm_tool_folder.py
@@ -21,7 +21,8 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 from __future__ import annotations
 import copy
 
-from pyneuromatic.core.nm_data import NMDataContainer
+from pyneuromatic.core.nm_data import NMData, NMDataContainer
+from pyneuromatic.core.nm_dataseries import NMDataSeries, NMDataSeriesContainer
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_object_container import NMObjectContainer
 import pyneuromatic.core.nm_configurations as nmc
@@ -37,6 +38,7 @@ class NMToolFolder(NMObject):
     _DEEPCOPY_SPECIAL_ATTRS: frozenset[str] = NMObject._DEEPCOPY_SPECIAL_ATTRS | frozenset({
         "_NMToolFolder__data_container",
         "_NMToolFolder__dataseries_container",
+        "_NMToolFolder__dataseries",
     })
 
     def __init__(
@@ -47,7 +49,7 @@ class NMToolFolder(NMObject):
         super().__init__(parent=parent, name=name)
 
         self.__data_container: NMDataContainer = NMDataContainer(parent=self)
-        self.__dataseries_container: NMDataContainer | None = None
+        self.__dataseries: NMDataSeriesContainer = NMDataSeriesContainer(parent=self)
 
     # override
     def __eq__(
@@ -106,14 +108,14 @@ class NMToolFolder(NMObject):
         else:
             result._NMToolFolder__data_container = NMDataContainer(parent=result)
 
-        # __dataseries_container: deep copy and update parent
-        if self._NMToolFolder__dataseries_container is not None:
-            result._NMToolFolder__dataseries_container = copy.deepcopy(
-                self._NMToolFolder__dataseries_container, memo
+        # __dataseries: deep copy and update parent
+        if self._NMToolFolder__dataseries is not None:
+            result._NMToolFolder__dataseries = copy.deepcopy(
+                self._NMToolFolder__dataseries, memo
             )
-            result._NMToolFolder__dataseries_container._parent = result
+            result._NMToolFolder__dataseries._parent = result
         else:
-            result._NMToolFolder__dataseries_container = None
+            result._NMToolFolder__dataseries = NMDataSeriesContainer(parent=result)
 
         return result
 
@@ -130,8 +132,80 @@ class NMToolFolder(NMObject):
         return self.__data_container
 
     @property
-    def dataseries(self) -> NMDataContainer | None:
-        return self.__dataseries_container
+    def dataseries(self) -> NMDataSeriesContainer:
+        return self.__dataseries
+
+    def build_dataseries(
+        self,
+        prefix: str,
+        matches: dict[tuple[str, int], NMData],
+    ) -> NMDataSeries | None:
+        """Build or extend an :class:`~pyneuromatic.core.nm_dataseries.NMDataSeries`
+        from an explicit matches mapping.
+
+        Creates the dataseries if it does not yet exist, then creates any
+        channels and epochs not already present, and links each NMData to its
+        channel and epoch.  Already-linked data is silently skipped so this
+        method is safe to call on an existing dataseries.
+
+        Modelled on :meth:`~pyneuromatic.core.nm_folder.NMFolder.build_dataseries`.
+
+        Args:
+            prefix:  Dataseries name (e.g. ``"SPK_"``).
+            matches: Mapping of ``(channel_char, epoch_num) -> NMData``.
+                Channel chars must be single uppercase letters (e.g. ``"A"``);
+                epoch numbers are zero-based integers.
+
+        Returns:
+            The :class:`~pyneuromatic.core.nm_dataseries.NMDataSeries` (new or
+            updated), or ``None`` if *matches* is empty.
+        """
+        if not matches:
+            return None
+
+        is_new = prefix not in self.__dataseries
+        if is_new:
+            ds = self.__dataseries.new(name=prefix, quiet=True)
+            if ds is None:
+                return None
+            channel_map: dict[str, object] = {}
+            epoch_map: dict[int, object] = {}
+        else:
+            ds = self.__dataseries.get(prefix)
+            channel_map = {
+                ch_name: ds.channels.get(ch_name) for ch_name in ds.channels
+            }
+            epoch_map = {}
+            for ep_name in ds.epochs:
+                try:
+                    epoch_map[int(ep_name[1:])] = ds.epochs.get(ep_name)
+                except (ValueError, IndexError):
+                    pass
+
+        channel_chars = sorted(set(ch for ch, _ in matches.keys()))
+        epoch_nums = sorted(set(ep for _, ep in matches.keys()))
+
+        for ch_char in channel_chars:
+            if ch_char not in channel_map:
+                ch = ds.channels.new(quiet=True)
+                if ch is not None:
+                    channel_map[ch_char] = ch
+
+        for ep_num in epoch_nums:
+            if ep_num not in epoch_map:
+                ep = ds.epochs.new(quiet=True)
+                if ep is not None:
+                    epoch_map[ep_num] = ep
+
+        for (ch_char, ep_num), data in matches.items():
+            ch = channel_map.get(ch_char)
+            ep = epoch_map.get(ep_num)
+            if ch is not None and data not in ch.data:
+                ch.data.append(data)
+            if ep is not None and data not in ep.data:
+                ep.data.append(data)
+
+        return ds
 
 
 class NMToolFolderContainer(NMObjectContainer):

--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -120,6 +120,7 @@ class NMToolSpike(NMTool):
         # Internal run state — reset by run_init()
         self._spike_times: list[np.ndarray] = []
         self._epoch_names: list[str] = []
+        self._channel_chars: list[str] = []
         self._detected_xunits: str | None = None
         self._toolfolder: NMToolFolder | None = None
 
@@ -320,6 +321,7 @@ class NMToolSpike(NMTool):
         """Reset internal state before the run loop."""
         self._spike_times = []
         self._epoch_names = []
+        self._channel_chars = []
         self._source_data: list[NMData] = []
         self._detected_xunits = None
         self._toolfolder = None
@@ -349,8 +351,10 @@ class NMToolSpike(NMTool):
             x1=self.__x1,
             ignore_nans=self.__ignore_nans,
         )
+        ch_char = self.channel.name if self.channel is not None else "A"
         self._spike_times.append(x_times)
         self._epoch_names.append(data.name)
+        self._channel_chars.append(ch_char)
         self._source_data.append(data)
         return True
 
@@ -397,7 +401,8 @@ class NMToolSpike(NMTool):
         """
         if not isinstance(self.folder, NMFolder):
             return None
-        self._toolfolder = self._make_toolfolder()
+        ch = self._channel_chars[0] if self._channel_chars else "A"
+        self._toolfolder = self._make_toolfolder(ch)
         f = self._toolfolder
         for name, times in zip(self._epoch_names, self._spike_times):
             d = f.data.new(
@@ -436,13 +441,22 @@ class NMToolSpike(NMTool):
         for name, times in zip(self._epoch_names, self._spike_times):
             nmh.history("spike: %s: %d spike(s)" % (name, len(times)))
 
-    def _make_toolfolder(self) -> NMToolFolder:
-        """Return the target ``spike_{dataseries}_{channel}_N`` subfolder."""
+    def _make_toolfolder(self, channel_name: str | None = None) -> NMToolFolder:
+        """Return the target ``Spike_{dataseries}_{channel}_N`` subfolder.
+
+        Args:
+            channel_name: Channel name to use in the subfolder name.  If
+                ``None``, falls back to ``self.channel.name`` (used by the
+                normal results path).
+        """
         parts = ["Spike"]
         if self.dataseries is not None:
             parts.append(self.dataseries.name)
-        if self.channel is not None:
-            parts.append(self.channel.name)
+        ch = channel_name if channel_name is not None else (
+            self.channel.name if self.channel is not None else None
+        )
+        if ch is not None:
+            parts.append(ch)
         base = "_".join(parts)
         return self.folder.toolfolder.get_or_create(base, overwrite=self.__overwrite)
 
@@ -490,7 +504,7 @@ class NMToolSpike(NMTool):
 
         For each spike detected during the most recent :meth:`run_all` call,
         extracts a ``[−pre, +post]`` window of samples from the source epoch
-        array and writes the snippet as a new NMData array (``SPK_{epoch}_{n}``)
+        array and writes the snippet as a new NMData array (``SPK_{ch}{n}``)
         in the Spike subfolder.
 
         Args:
@@ -561,13 +575,18 @@ class NMToolSpike(NMTool):
             raise RuntimeError(
                 "NMToolSpike.extract_spike_waveforms: no spike data — run detection first"
             )
-        if self._toolfolder is None:
-            self._toolfolder = self._make_toolfolder()
 
         output: list[NMData] = []
 
-        for epoch_name, spike_times_arr, source in zip(
-            self._epoch_names, self._spike_times, self._source_data
+        # Per-channel toolfolder, spike counter, and matches
+        ch_toolfolders: dict[str, NMToolFolder] = {}
+        channel_counters: dict[str, int] = {}
+        # per-channel matches for build_dataseries: ch_char -> {(ch, ep): NMData}
+        ch_matches: dict[str, dict[tuple[str, int], NMData]] = {}
+
+        for epoch_name, spike_times_arr, source, ch_char in zip(
+            self._epoch_names, self._spike_times, self._source_data,
+            self._channel_chars
         ):
             ydata = source.nparray
             if ydata is None:
@@ -666,14 +685,21 @@ class NMToolSpike(NMTool):
                     "label": source.yscale.label,
                     "units": source.yscale.units,
                 }
-                array_name = "SPK_%s_%d" % (epoch_name, n)
-                d = self._toolfolder.data.new(
+                if ch_char not in ch_toolfolders:
+                    ch_toolfolders[ch_char] = self._make_toolfolder(ch_char)
+                    ch_matches[ch_char] = {}
+                tf = ch_toolfolders[ch_char]
+                spike_n = channel_counters.get(ch_char, 0)
+                channel_counters[ch_char] = spike_n + 1
+                array_name = "SPK_%s%d" % (ch_char, spike_n)
+                d = tf.data.new(
                     array_name,
                     nparray=snippet,
                     xarray=x_snippet,
                     xscale=out_xscale,
                     yscale=out_yscale,
                 )
+                ch_matches[ch_char][ch_char, spike_n] = d
                 note = (
                     "NMSpike.extract_spike_waveforms(source=%s, spike_x=%.6g, "
                     "pre=%g, post=%g, clip_to_next_spike=%s, edge=%r, align=%s"
@@ -688,6 +714,8 @@ class NMToolSpike(NMTool):
                 self._add_note(d, note)
                 output.append(d)
 
+        for ch_char, tf in ch_toolfolders.items():
+            tf.build_dataseries("SPK_", ch_matches[ch_char])
         return output
 
     # ------------------------------------------------------------------

--- a/tests/test_analysis/test_nm_tool_spike.py
+++ b/tests/test_analysis/test_nm_tool_spike.py
@@ -220,7 +220,7 @@ class TestNMToolSpikeDetection(unittest.TestCase):
         d = _sine_data(freq=200.0, n=1000)
         folder = _run(self.tool, [d])
         tf = folder.toolfolder
-        f = tf.get("Spike_0")
+        f = tf.get("Spike_A_0")
         count_arr = f.data.get("SP_count")
         self.assertEqual(int(count_arr.nparray[0]), 20)
 
@@ -228,7 +228,7 @@ class TestNMToolSpikeDetection(unittest.TestCase):
         self.tool.func_name = "level-"
         d = _sine_data(freq=200.0, n=1000)
         folder = _run(self.tool, [d])
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         count_arr = f.data.get("SP_count")
         self.assertEqual(int(count_arr.nparray[0]), 20)
 
@@ -236,7 +236,7 @@ class TestNMToolSpikeDetection(unittest.TestCase):
         self.tool.func_name = "level"
         d = _sine_data(freq=200.0, n=1000)
         folder = _run(self.tool, [d])
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         count_arr = f.data.get("SP_count")
         self.assertEqual(int(count_arr.nparray[0]), 40)
 
@@ -247,7 +247,7 @@ class TestNMToolSpikeDetection(unittest.TestCase):
         self.tool.x0 = 0.0
         self.tool.x1 = 0.05
         folder = _run(self.tool, [d])
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         count_full = 20
         count_win = int(f.data.get("SP_count").nparray[0])
         self.assertLess(count_win, count_full)
@@ -261,7 +261,7 @@ class TestNMToolSpikeDetection(unittest.TestCase):
         self.tool.ylevel = 0.5
         self.tool.ignore_nans = True
         folder = _run(self.tool, [d])
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         self.assertEqual(int(f.data.get("SP_count").nparray[0]), 1)
 
     def test_ignore_nans_false_blocks_crossing_across_nan_gap(self):
@@ -272,26 +272,26 @@ class TestNMToolSpikeDetection(unittest.TestCase):
         self.tool.ylevel = 0.5
         self.tool.ignore_nans = False
         folder = _run(self.tool, [d])
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         self.assertEqual(int(f.data.get("SP_count").nparray[0]), 0)
 
     def test_per_epoch_sp_arrays_created(self):
         data = [_sine_data(name="recA%d" % i) for i in range(3)]
         folder = _run(self.tool, data)
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         for i in range(3):
             self.assertIn("SP_recA%d" % i, f.data)
 
     def test_sp_count_length_equals_epoch_count(self):
         data = [_sine_data(name="recA%d" % i) for i in range(5)]
         folder = _run(self.tool, data)
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         self.assertEqual(len(f.data.get("SP_count").nparray), 5)
 
     def test_sp_count_matches_sp_array_lengths(self):
         data = [_sine_data(name="recA%d" % i, freq=100.0 * (i + 1)) for i in range(3)]
         folder = _run(self.tool, data)
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         counts = f.data.get("SP_count").nparray
         for i, d in enumerate(data):
             times = f.data.get("SP_recA%d" % i).nparray
@@ -303,7 +303,7 @@ class TestNMToolSpikeDetection(unittest.TestCase):
         d = NMData(NM, name="flat", nparray=y,
                    xscale={"start": 0.0, "delta": _DELTA})
         folder = _run(self.tool, [d])
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         self.assertEqual(int(f.data.get("SP_count").nparray[0]), 0)
         self.assertEqual(len(f.data.get("SP_flat").nparray), 0)
 
@@ -318,7 +318,7 @@ class TestNMToolSpikeDetection(unittest.TestCase):
     def test_sp_times_are_floats(self):
         d = _sine_data(freq=100.0)
         folder = _run(self.tool, [d])
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         times = f.data.get("SP_recordA0").nparray
         self.assertEqual(times.dtype.kind, "f")
 
@@ -348,13 +348,13 @@ class TestNMToolSpikeSubfolderNaming(unittest.TestCase):
     def test_no_dataseries_no_channel(self):
         folder = NMFolder(NM, name="F")
         self._run_with_selection(folder)
-        self.assertIn("Spike_0", folder.toolfolder)
+        self.assertIn("Spike_A_0", folder.toolfolder)
 
     def test_with_dataseries(self):
         folder = NMFolder(NM, name="F")
         ds = NMDataSeries(NM, name="Record")
         self._run_with_selection(folder, dataseries=ds)
-        self.assertIn("Spike_Record_0", folder.toolfolder)
+        self.assertIn("Spike_Record_A_0", folder.toolfolder)
 
     def test_with_dataseries_and_channel(self):
         folder = NMFolder(NM, name="F")
@@ -370,8 +370,8 @@ class TestNMToolSpikeSubfolderNaming(unittest.TestCase):
         self.tool = NMToolSpike()
         self.tool.overwrite = False
         self._run_with_selection(folder)
-        self.assertIn("Spike_0", folder.toolfolder)
-        self.assertIn("Spike_1", folder.toolfolder)
+        self.assertIn("Spike_A_0", folder.toolfolder)
+        self.assertIn("Spike_A_1", folder.toolfolder)
 
 
 class TestNMToolSpikePST(unittest.TestCase):
@@ -391,7 +391,7 @@ class TestNMToolSpikePST(unittest.TestCase):
         self.assertEqual(len(result.nparray), 50)
 
     def test_pst_total_counts_equals_total_spikes(self):
-        f = self.folder.toolfolder.get("Spike_0")
+        f = self.folder.toolfolder.get("Spike_A_0")
         total_spikes = int(f.data.get("SP_count").nparray.sum())
         result = self.tool.pst(bins=50)
         self.assertEqual(int(result.nparray.sum()), total_spikes)
@@ -408,7 +408,7 @@ class TestNMToolSpikePST(unittest.TestCase):
         self.assertAlmostEqual(result.xscale.start, 0.0, places=10)
 
     def test_pst_output_mode_count_matches_total_spikes(self):
-        f = self.folder.toolfolder.get("Spike_0")
+        f = self.folder.toolfolder.get("Spike_A_0")
         total_spikes = int(f.data.get("SP_count").nparray.sum())
         result = self.tool.pst(bins=50, output_mode="count")
         self.assertEqual(int(result.nparray.sum()), total_spikes)
@@ -423,7 +423,7 @@ class TestNMToolSpikePST(unittest.TestCase):
         result = self.tool.pst(bins=50, output_mode="rate")
         bin_width = result.xscale.delta
         reconstructed = result.nparray.sum() * bin_width * n_epochs
-        f = self.folder.toolfolder.get("Spike_0")
+        f = self.folder.toolfolder.get("Spike_A_0")
         total_spikes = float(f.data.get("SP_count").nparray.sum())
         self.assertAlmostEqual(reconstructed, total_spikes, places=6)
 
@@ -461,7 +461,7 @@ class TestNMToolSpikePST(unittest.TestCase):
 
     def test_pst_written_to_subfolder(self):
         self.tool.pst(bins=50)
-        f = self.folder.toolfolder.get("Spike_0")
+        f = self.folder.toolfolder.get("Spike_A_0")
         self.assertIn("SP_PST", f.data)
 
 
@@ -508,7 +508,7 @@ class TestNMToolSpikeISI(unittest.TestCase):
 
     def test_isi_written_to_subfolder(self):
         self.tool.isi(bins=50)
-        f = self.folder.toolfolder.get("Spike_0")
+        f = self.folder.toolfolder.get("Spike_A_0")
         self.assertIn("SP_ISI", f.data)
 
     def test_isi_total_intervals_correct(self):
@@ -555,7 +555,7 @@ class TestNMToolSpikeISI(unittest.TestCase):
     def test_isi_note_contains_new_params(self):
         self.tool.isi(bins=50, x0=0.0, x1=0.08, min_isi=0.001, max_isi=0.05,
                       output_mode="probability")
-        f = self.folder.toolfolder.get("Spike_0")
+        f = self.folder.toolfolder.get("Spike_A_0")
         note = f.data.get("SP_ISI").notes.note
         self.assertIn("x0=", note)
         self.assertIn("x1=", note)
@@ -621,14 +621,15 @@ class TestNMToolSpikeExtractSpikeWaveforms(unittest.TestCase):
     def test_arrays_written_to_subfolder(self):
         result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
         self.assertGreater(len(result), 0)
-        f = self.folder.toolfolder.get("Spike_0")
+        f = self.folder.toolfolder.get("Spike_A_0")
         self.assertIn(result[0].name, f.data)
 
     def test_array_name_format(self):
+        # Names follow {prefix}{channel}{epoch} pattern: SPK_A0, SPK_A1, ...
         result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
         names = [d.name for d in result]
         for i, name in enumerate(names):
-            self.assertTrue(name.startswith("SPK_recA0_"))
+            self.assertEqual(name, "SPK_A%d" % i)
 
     def test_snippet_length(self):
         result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
@@ -935,6 +936,59 @@ class TestNMToolSpikeExtractSpikeWaveforms(unittest.TestCase):
         for d in result:
             self.assertGreaterEqual(d.xscale.start, self.data.xscale.start)
 
+    # --- build_dataseries ---
+
+    def test_build_dataseries_called_automatically(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        self.assertGreater(len(result), 0)
+        f = self.folder.toolfolder.get("Spike_A_0")
+        # dataseries should be populated after extract_spike_waveforms
+        self.assertGreater(len(list(f.dataseries.keys())), 0)
+
+    def test_build_dataseries_prefix_is_SPK(self):
+        self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        f = self.folder.toolfolder.get("Spike_A_0")
+        self.assertIn("SPK_", f.dataseries)
+
+    def test_build_dataseries_has_channel_A(self):
+        self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        f = self.folder.toolfolder.get("Spike_A_0")
+        ds = f.dataseries.get("SPK_")
+        self.assertIsNotNone(ds)
+        self.assertIn("A", ds.channels)
+
+    def test_build_dataseries_epoch_count_matches_snippets(self):
+        result = self.tool.extract_spike_waveforms(self._PRE, self._POST)
+        f = self.folder.toolfolder.get("Spike_A_0")
+        ds = f.dataseries.get("SPK_")
+        self.assertEqual(len(list(ds.epochs.keys())), len(result))
+
+    def test_two_channels_create_separate_subfolders(self):
+        # Two epochs from different channels: recA0 (ch A) and recB0 (ch B).
+        # Use new_dataseries so channel objects exist, then pass proper targets.
+        folder = NMFolder(NM, name="TwoChFolder")
+        folder.new_dataseries("rec", n_channels=2, n_epochs=1,
+                              n_points=1000, dx=_DELTA)
+        ds = folder.dataseries.get("rec")
+        dA = folder.data.get("recA0")
+        dB = folder.data.get("recB0")
+        # Overwrite with sine data
+        dA.nparray = np.sin(2 * np.pi * 100.0 * np.arange(1000) * _DELTA)
+        dB.nparray = np.sin(2 * np.pi * 100.0 * np.arange(1000) * _DELTA)
+        chA = ds.channels.get("A")
+        chB = ds.channels.get("B")
+        ep = ds.epochs.get("E0")
+        targets = [
+            {"folder": folder, "dataseries": ds, "channel": chA, "epoch": ep, "data": dA},
+            {"folder": folder, "dataseries": ds, "channel": chB, "epoch": ep, "data": dB},
+        ]
+        tool2 = NMToolSpike()
+        tool2.run_all(targets)
+        tool2.extract_spike_waveforms(self._PRE, self._POST)
+        tf_keys = list(folder.toolfolder.keys())
+        self.assertIn("Spike_rec_A_0", tf_keys)
+        self.assertIn("Spike_rec_B_0", tf_keys)
+
     # --- results_to_numpy=False ---
 
     def test_works_when_results_to_numpy_false(self):
@@ -961,25 +1015,25 @@ class TestNMToolSpikeOverwrite(unittest.TestCase):
         with self.assertRaises(TypeError):
             NMToolSpike().overwrite = 1
 
-    def test_overwrite_true_creates_Spike_0(self):
+    def test_overwrite_true_creates_Spike_A_0(self):
         tool = NMToolSpike()
         folder = NMFolder(NM, name="F")
         self._run_once(tool, folder)
-        self.assertIn("Spike_0", folder.toolfolder)
+        self.assertIn("Spike_A_0", folder.toolfolder)
 
-    def test_overwrite_true_reuses_Spike_0_on_second_run(self):
+    def test_overwrite_true_reuses_Spike_A_0_on_second_run(self):
         tool = NMToolSpike()
         folder = NMFolder(NM, name="F")
         self._run_once(tool, folder)
         self._run_once(tool, folder)
-        self.assertIn("Spike_0", folder.toolfolder)
-        self.assertNotIn("Spike_1", folder.toolfolder)
+        self.assertIn("Spike_A_0", folder.toolfolder)
+        self.assertNotIn("Spike_A_1", folder.toolfolder)
 
     def test_overwrite_true_replaces_sp_arrays(self):
         tool = NMToolSpike()
         folder = NMFolder(NM, name="F")
         self._run_once(tool, folder, freq=100.0)
-        f = folder.toolfolder.get("Spike_0")
+        f = folder.toolfolder.get("Spike_A_0")
         count_first = int(f.data.get("SP_count").nparray[0])
         # Run again with different freq — different spike count
         tool2 = NMToolSpike()
@@ -995,8 +1049,8 @@ class TestNMToolSpikeOverwrite(unittest.TestCase):
         tool2 = NMToolSpike()
         tool2.overwrite = False
         self._run_once(tool2, folder)
-        self.assertIn("Spike_0", folder.toolfolder)
-        self.assertIn("Spike_1", folder.toolfolder)
+        self.assertIn("Spike_A_0", folder.toolfolder)
+        self.assertIn("Spike_A_1", folder.toolfolder)
 
     def test_config_overwrite_default(self):
         cfg = NMToolSpikeConfig()
@@ -1038,7 +1092,7 @@ class TestNMToolSpikeNotes(unittest.TestCase):
         self.tool.func_name = "level+"
         data = [_sine_data(name="recA%d" % i, freq=100.0) for i in range(2)]
         self.folder = _run(self.tool, data)
-        self.f = self.folder.toolfolder.get("Spike_0")
+        self.f = self.folder.toolfolder.get("Spike_A_0")
 
     def test_sp_epoch_note_contains_nmspike(self):
         note = self.f.data.get("SP_recA0").notes.note


### PR DESCRIPTION
## Summary

- NMToolFolder: replaces the placeholder NMDataContainer with a proper NMDataSeriesContainer; adds build_dataseries(prefix, matches) so callers can register arrays as an NMDataSeries by passing a {(ch_char, ep_num): NMData} dict directly (no scanning needed)
- NMToolSpike.extract_spike_waveforms(): renames output arrays from SPK_{epoch}_{n} → SPK_{ch}{n} (standard channel+epoch pattern); creates a separate toolfolder per channel (e.g. Spike_A_0, Spike_B_0); calls build_dataseries() automatically after extraction so results are immediately accessible via the dataseries API
- Subfolder name always includes the channel char — no backward-compatibility branching

## Test plan

-  All 173 NMToolSpike tests pass
-  New tests cover: build_dataseries called automatically, correct prefix, channel A present, epoch count matches snippets
-  New test: two-channel run creates separate subfolders (Spike_A_0, Spike_B_0)
-  Full suite (2732 tests) passes

Closes #272