### PR TITLE
feat(analysis): shared NMTool._make_toolfolder() with consistent subfolder naming

### DIFF
--- a/pyneuromatic/analysis/nm_tool.py
+++ b/pyneuromatic/analysis/nm_tool.py
@@ -30,6 +30,7 @@ from pyneuromatic.core.nm_channel import NMChannel
 from pyneuromatic.core.nm_epoch import NMEpoch
 from pyneuromatic.core.nm_manager import HIERARCHY_SELECT_KEYS
 from pyneuromatic.analysis.nm_tool_config import NMToolConfig
+from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
 
 
 class NMTool:
@@ -181,6 +182,32 @@ class NMTool:
     def run_finish(self) -> bool:
         """Called once after run loop. Override in subclass."""
         return True
+
+    def _make_toolfolder(
+        self,
+        prefix: str,
+        overwrite: bool = False,
+    ) -> NMToolFolder:
+        """Return the target ``{prefix}_{dataseries}_{channel}_{epoch_set}_N`` subfolder.
+
+        Assembles the name from ``self.dataseries``, ``self.channel``, and
+        ``run_keys["epoch"]`` (when present).
+
+        Args:
+            prefix: Tool-specific prefix, e.g. ``"Spike"`` or ``"Stats"``.
+            overwrite: If True, clear and reuse ``{base}_0``; otherwise pick
+                the next unused ``{base}_N``.
+        """
+        parts = [prefix]
+        if self.dataseries is not None:
+            parts.append(self.dataseries.name)
+        if self.channel is not None:
+            parts.append(self.channel.name)
+        epoch_set = self._run_meta.get("run_keys", {}).get("epoch")
+        if epoch_set:
+            parts.append(epoch_set)
+        base = "_".join(parts)
+        return self.folder.toolfolder.get_or_create(base, overwrite=overwrite)
 
     def run_all(
         self,

--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -27,6 +27,7 @@ import numpy as np
 from pyneuromatic.analysis.nm_tool import NMTool
 from pyneuromatic.analysis.nm_tool_config import NMToolConfig
 from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
+from pyneuromatic.core.nm_channel import NMChannel
 from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_folder import NMFolder
 import pyneuromatic.core.nm_command_history as nmch
@@ -402,7 +403,8 @@ class NMToolSpike(NMTool):
         if not isinstance(self.folder, NMFolder):
             return None
         ch = self._channel_chars[0] if self._channel_chars else "A"
-        self._toolfolder = self._make_toolfolder(ch)
+        self._select["channel"] = NMChannel(name=ch)
+        self._toolfolder = self._make_toolfolder("Spike", overwrite=self.__overwrite)
         f = self._toolfolder
         for name, times in zip(self._epoch_names, self._spike_times):
             d = f.data.new(
@@ -440,25 +442,6 @@ class NMToolSpike(NMTool):
         """Print spike counts to the history log."""
         for name, times in zip(self._epoch_names, self._spike_times):
             nmh.history("spike: %s: %d spike(s)" % (name, len(times)))
-
-    def _make_toolfolder(self, channel_name: str | None = None) -> NMToolFolder:
-        """Return the target ``Spike_{dataseries}_{channel}_N`` subfolder.
-
-        Args:
-            channel_name: Channel name to use in the subfolder name.  If
-                ``None``, falls back to ``self.channel.name`` (used by the
-                normal results path).
-        """
-        parts = ["Spike"]
-        if self.dataseries is not None:
-            parts.append(self.dataseries.name)
-        ch = channel_name if channel_name is not None else (
-            self.channel.name if self.channel is not None else None
-        )
-        if ch is not None:
-            parts.append(ch)
-        base = "_".join(parts)
-        return self.folder.toolfolder.get_or_create(base, overwrite=self.__overwrite)
 
     # ------------------------------------------------------------------
     # Convenience methods (called after run_all)
@@ -686,7 +669,8 @@ class NMToolSpike(NMTool):
                     "units": source.yscale.units,
                 }
                 if ch_char not in ch_toolfolders:
-                    ch_toolfolders[ch_char] = self._make_toolfolder(ch_char)
+                    self._select["channel"] = NMChannel(name=ch_char)
+                    ch_toolfolders[ch_char] = self._make_toolfolder("Spike", overwrite=self.__overwrite)
                     ch_matches[ch_char] = {}
                 tf = ch_toolfolders[ch_char]
                 spike_n = channel_counters.get(ch_char, 0)

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -501,10 +501,14 @@ class NMToolStats(NMTool):
     def _results_to_numpy(self) -> NMToolFolder | None:
         """Write results as ST_ NMData arrays in a new NMToolFolder.
 
-        Creates a new folder named ``stats_{dataseries}_0``,
-        ``stats_{dataseries}_1``, … (first unused name) under the current
-        folder's toolfolder, then writes one NMData array per numeric result
-        key per window/func combination.  Array naming rules:
+        Creates a subfolder named ``Stats_{dataseries}_{channel}_{epoch_set}_N``
+        (first unused N) under the current folder's toolfolder.  Components are
+        omitted when not set; epoch set is included only when present in
+        ``run_keys``.  Examples: ``Stats_0``, ``Stats_Record_A_0``,
+        ``Stats_Record_A_Set1_0``.
+
+        Writes one NMData array per numeric result key per window/func
+        combination.  Array naming rules:
 
         * Primary stat value (``"s"`` key): ``ST_{w}_{func}_y``
           e.g. ``ST_w0_mean_y``, ``ST_w0_max_y``.
@@ -525,17 +529,7 @@ class NMToolStats(NMTool):
         if not self.__results:
             raise RuntimeError("there are no results to save")
 
-        # Find next unused folder name stats_{dataseries}_{channel}_N, ...
-        tf = self.folder.toolfolder
-        ds = self.dataseries
-        ch = self.channel
-        parts = ["stats"]
-        if ds is not None:
-            parts.append(ds.name)
-        if ch is not None:
-            parts.append(ch.name)
-        base = "_".join(parts)
-        f = tf.get_or_create(base, overwrite=self.__overwrite)
+        f = self._make_toolfolder("Stats", overwrite=self.__overwrite)
 
         for wname, vlist in self.__results.items():
             # vlist: list of lists, one inner list per data array

--- a/tests/test_analysis/test_nm_tool.py
+++ b/tests/test_analysis/test_nm_tool.py
@@ -16,6 +16,7 @@ from pyneuromatic.core.nm_channel import NMChannel
 from pyneuromatic.core.nm_epoch import NMEpoch
 from pyneuromatic.analysis.nm_tool import NMTool
 from pyneuromatic.analysis.nm_tool_config import NMToolConfig
+from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
 
 QUIET = True
 
@@ -760,6 +761,83 @@ class TestNMManagerRunConfig(unittest.TestCase):
         # After reset, run_config is None so epoch_set should be None
         self.nm.run_tool()
         self.assertEqual(captured.get("run_keys"), {})
+
+
+class TestNMToolMakeToolfolder(unittest.TestCase):
+    """Tests for NMTool._make_toolfolder()."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=QUIET)
+        assert self.nm.folders is not None
+        self.folder = self.nm.folders.new("folder0")
+        assert isinstance(self.folder, NMFolder)
+        self.tool = NMTool()
+        self.tool._select["folder"] = self.folder
+
+    def test_returns_nmtoolfolder(self):
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertIsInstance(tf, NMToolFolder)
+
+    def test_prefix_only_name(self):
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertEqual(tf.name, "Stats_0")
+
+    def test_prefix_with_dataseries(self):
+        ds = self.folder.dataseries.new("Record")
+        self.tool._select["dataseries"] = ds
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertEqual(tf.name, "Stats_Record_0")
+
+    def test_prefix_with_channel(self):
+        self.tool._select["channel"] = NMChannel(name="A")
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertEqual(tf.name, "Stats_A_0")
+
+    def test_prefix_with_dataseries_and_channel(self):
+        ds = self.folder.dataseries.new("Record")
+        self.tool._select["dataseries"] = ds
+        self.tool._select["channel"] = NMChannel(name="A")
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertEqual(tf.name, "Stats_Record_A_0")
+
+    def test_epoch_set_included_when_present(self):
+        ds = self.folder.dataseries.new("Record")
+        self.tool._select["dataseries"] = ds
+        self.tool._select["channel"] = NMChannel(name="A")
+        self.tool._run_meta = {"run_keys": {"epoch": "Set1"}}
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertEqual(tf.name, "Stats_Record_A_Set1_0")
+
+    def test_epoch_set_all_included(self):
+        self.tool._run_meta = {"run_keys": {"epoch": "All"}}
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertEqual(tf.name, "Stats_All_0")
+
+    def test_epoch_set_omitted_when_empty_string(self):
+        self.tool._run_meta = {"run_keys": {"epoch": ""}}
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertEqual(tf.name, "Stats_0")
+
+    def test_epoch_set_omitted_when_not_in_run_keys(self):
+        self.tool._run_meta = {"run_keys": {}}
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertEqual(tf.name, "Stats_0")
+
+    def test_second_call_increments_n(self):
+        self.tool._make_toolfolder("Stats")
+        tf = self.tool._make_toolfolder("Stats")
+        self.assertEqual(tf.name, "Stats_1")
+
+    def test_overwrite_reuses_n0(self):
+        self.tool._make_toolfolder("Stats", overwrite=True)
+        tf = self.tool._make_toolfolder("Stats", overwrite=True)
+        self.assertEqual(tf.name, "Stats_0")
+
+    def test_different_prefixes_are_independent(self):
+        tf_stats = self.tool._make_toolfolder("Stats")
+        tf_spike = self.tool._make_toolfolder("Spike")
+        self.assertEqual(tf_stats.name, "Stats_0")
+        self.assertEqual(tf_spike.name, "Spike_0")
 
 
 class TestNMToolConfigProperty(unittest.TestCase):

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -165,21 +165,21 @@ class TestNMToolStats(unittest.TestCase):
         self.assertIsInstance(f, NMToolFolder)
 
     def test_results_to_numpy_folder_named_stats_0_no_dataseries(self):
-        # No dataseries selected → fallback name "stats_0"
+        # No dataseries selected → fallback name "Stats_0"
         self._setup_folder()
         self._run_compute()
         f = self.tool._results_to_numpy()
-        self.assertEqual(f.name, "stats_0")
+        self.assertEqual(f.name, "Stats_0")
 
     def test_results_to_numpy_second_run_named_stats_1_no_dataseries(self):
-        # Second run with no dataseries → "stats_1"
+        # Second run with no dataseries → "Stats_1"
         self._setup_folder()
         self._run_compute()
         self.tool._results_to_numpy()
         self.tool._NMToolStats__results.clear()
         self._run_compute()
         f = self.tool._results_to_numpy()
-        self.assertEqual(f.name, "stats_1")
+        self.assertEqual(f.name, "Stats_1")
 
     def test_results_to_numpy_folder_named_with_dataseries(self):
         # Dataseries selected → name uses dataseries name
@@ -189,10 +189,10 @@ class TestNMToolStats(unittest.TestCase):
         self.tool._select["dataseries"] = ds
         self._run_compute()
         f = self.tool._results_to_numpy()
-        self.assertEqual(f.name, "stats_Record_0")
+        self.assertEqual(f.name, "Stats_Record_0")
 
     def test_results_to_numpy_folder_named_with_dataseries_and_channel(self):
-        # Dataseries + channel → stats_{ds}_{ch}_N
+        # Dataseries + channel → Stats_{ds}_{ch}_N
         from pyneuromatic.core.nm_dataseries import NMDataSeries
         from pyneuromatic.core.nm_channel import NMChannel
         self._setup_folder()
@@ -200,16 +200,16 @@ class TestNMToolStats(unittest.TestCase):
         self.tool._select["channel"] = NMChannel(name="A")
         self._run_compute()
         f = self.tool._results_to_numpy()
-        self.assertEqual(f.name, "stats_Record_A_0")
+        self.assertEqual(f.name, "Stats_Record_A_0")
 
     def test_results_to_numpy_folder_named_channel_only(self):
-        # Channel but no dataseries → stats_{ch}_N
+        # Channel but no dataseries → Stats_{ch}_N
         from pyneuromatic.core.nm_channel import NMChannel
         self._setup_folder()
         self.tool._select["channel"] = NMChannel(name="B")
         self._run_compute()
         f = self.tool._results_to_numpy()
-        self.assertEqual(f.name, "stats_B_0")
+        self.assertEqual(f.name, "Stats_B_0")
 
     def test_results_to_numpy_creates_data_array(self):
         self._setup_folder()


### PR DESCRIPTION
## Summary

- NMTool._make_toolfolder(prefix, overwrite=False) added to the base class — assembles {prefix}_{dataseries}_{channel}_{epoch_set}_N from self.dataseries, self.channel, and run_keys["epoch"] (included when present, omitted when empty). All three context items read from self — no override parameters.
- NMToolSpike: removes local _make_toolfolder() override; call sites temporarily set self._select["channel"] to an NMChannel before calling the base method, consistent with how dataseries and epoch set are handled
- NMToolStats: replaces 10-line name-building block with a single _make_toolfolder("Stats", ...) call; fixes capitalisation (stats_Record_A_0 → Stats_Record_A_0)
- Subfolder name always includes the trailing _N counter regardless of overwrite flag, for consistency 

## Test plan

-  New TestNMToolMakeToolfolder class (12 tests): prefix-only, with dataseries, with channel, with both, epoch set included/omitted, "All" included, empty string omitted, N incrementing, overwrite=True reuse, independent prefixes
-  Stats tests updated to expect Stats_* capitalisation
-  Full suite (2732 tests) passes

Closes #275