### PR TITLE
refactor(analysis): replace _toolfolder guards with _spike_times checks in NMToolSpike

### DIFF
--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -462,7 +462,7 @@ class NMToolSpike(NMTool):
         Raises:
             RuntimeError: If called before :meth:`run_all`.
         """
-        if self._toolfolder is None and not self._epoch_names:
+        if not self._epoch_names:
             raise RuntimeError(
                 "NMToolSpike.raster: no spike data — run detection first"
             )
@@ -734,12 +734,10 @@ class NMToolSpike(NMTool):
                 "output_mode must be one of %s, got %r"
                 % (list(_VALID_MODES), output_mode)
             )
-        if self._toolfolder is None:
+        if not self._spike_times:
             raise RuntimeError(
                 "NMToolSpike.pst: no spike data — run detection first"
             )
-        if not self._spike_times:
-            return None
         all_times = np.concatenate(self._spike_times)
         if len(all_times) == 0:
             return None
@@ -761,6 +759,8 @@ class NMToolSpike(NMTool):
         else:
             ydata = counts.astype(float)
             ylabel = "Spike count"
+        if self._toolfolder is None:
+            self._toolfolder = self._make_toolfolder("Spike", overwrite=self.__overwrite)
         d = self._toolfolder.data.new(
             "SP_PST",
             nparray=ydata,
@@ -831,7 +831,7 @@ class NMToolSpike(NMTool):
                 "output_mode must be one of %s, got %r"
                 % (list(_VALID_MODES), output_mode)
             )
-        if self._toolfolder is None:
+        if not self._spike_times:
             raise RuntimeError(
                 "NMToolSpike.isi: no spike data — run detection first"
             )
@@ -864,6 +864,8 @@ class NMToolSpike(NMTool):
         else:
             ydata = counts.astype(float)
             ylabel = "Count"
+        if self._toolfolder is None:
+            self._toolfolder = self._make_toolfolder("Spike", overwrite=self.__overwrite)
         d = self._toolfolder.data.new(
             "SP_ISI",
             nparray=ydata,


### PR DESCRIPTION
## Summary

- raster(): replace self._toolfolder is None and not self._epoch_names guard with not self._epoch_names — the toolfolder state is irrelevant to whether raster data is available
- pst() and isi(): replace self._toolfolder is None guard with not self._spike_times; create toolfolder on demand before writing output

## Motivation

- _toolfolder is set inside _results_to_numpy(), not run(), so testing it as a proxy for "detection has run" was fragile. When results_to_numpy=False, _toolfolder remains None even after a successful spike detection, causing pst() and isi() to silently return nothing despite having valid spike times in _spike_times.

## Test plan

-  pytest tests/test_analysis/test_nm_tool_spike.py -q — all spike tests pass
-  pytest -q — full suite clean

Closes #281