### PR TITLE
feat(core): extend run_values() and run_tool() to support NMToolFolder targets

### DIFF
--- a/pyneuromatic/analysis/nm_tool.py
+++ b/pyneuromatic/analysis/nm_tool.py
@@ -102,6 +102,12 @@ class NMTool:
         return v if isinstance(v, NMEpoch) else None
 
     @property
+    def toolfolder(self) -> NMToolFolder | None:
+        """Get the currently selected toolfolder (set when running in toolfolder mode)."""
+        v = self._select.get("toolfolder")
+        return v if isinstance(v, NMToolFolder) else None
+
+    @property
     def select_values(self) -> dict[str, NMObject | None]:
         """Get the current selection as a dictionary of NMObjects."""
         return self._select.copy()
@@ -154,17 +160,18 @@ class NMTool:
     def _update_run_meta(self, target: dict) -> None:
         """Update run_meta lists with unique names from a single target dict.
 
-        Called once per target during run_all(). Tracks folder, dataseries,
-        channel, and epoch names (not data).
+        Called once per target during run_all(). Tracks folder, toolfolder,
+        dataseries, channel, and epoch names (not data).
 
         Args:
             target: Selection dict mapping tier names to NMObjects.
         """
         for tier, meta_key in (
-            ("folder",     "folders"),
-            ("dataseries", "dataseries"),
-            ("channel",    "channels"),
-            ("epoch",      "epochs"),
+            ("folder",      "folders"),
+            ("toolfolder",  "toolfolders"),
+            ("dataseries",  "dataseries"),
+            ("channel",     "channels"),
+            ("epoch",       "epochs"),
         ):
             obj = target.get(tier)
             if isinstance(obj, NMObject) and obj.name not in self._run_meta[meta_key]:
@@ -244,6 +251,7 @@ class NMTool:
             "date": datetime.datetime.now().isoformat(" ", "seconds"),
             "run_keys": dict(run_keys) if run_keys else {},
             "folders": [],
+            "toolfolders": [],
             "dataseries": [],
             "channels": [],
             "epochs": [],

--- a/pyneuromatic/analysis/nm_tool_folder.py
+++ b/pyneuromatic/analysis/nm_tool_folder.py
@@ -243,6 +243,11 @@ class NMToolFolderContainer(NMObjectContainer):
         name = self._newkey(name)
         f = NMToolFolder(parent=self, name=name)
         if super()._add(f, select=select, quiet=quiet):
+            if not select and len(self) == 1:
+                # Base class auto-selects the first entry, but toolfolder
+                # selection switches the data/dataseries/channel/epoch context,
+                # so don't auto-select unless the caller explicitly asked.
+                self._selected_name_set(None)
             return f
         return None
 

--- a/pyneuromatic/core/nm_manager.py
+++ b/pyneuromatic/core/nm_manager.py
@@ -39,13 +39,15 @@ from pyneuromatic.core.nm_tool_registry import get_global_registry, NMToolRegist
 from pyneuromatic.core.nm_workspace import NMWorkspace, NMWorkspaceManager
 import pyneuromatic.core.nm_utilities as nmu
 
+from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
+
 if TYPE_CHECKING:
     from pyneuromatic.analysis.nm_tool import NMTool
 
 nm = None  # holds Manager, accessed via console
 
 # Hierarchy tier selection keys (folder down to epoch)
-HIERARCHY_SELECT_KEYS = ("folder", "data", "dataseries", "channel", "epoch")
+HIERARCHY_SELECT_KEYS = ("folder", "toolfolder", "data", "dataseries", "channel", "epoch")
 
 # Run target constants (consistent with RunMode in NMObjectContainer)
 RUN_SELECTED = "selected"
@@ -71,12 +73,19 @@ NMManager (NMObject, root)
 def _split_targets_by_channel(
     targets: list[dict],
 ) -> list[list[dict]]:
-    """Group run targets by (folder, dataseries, channel) for dataseries mode.
+    """Group run targets by channel (or toolfolder) for per-channel tool calls.
 
-    Dataseries-mode targets (those with a ``"channel"`` key) are split into
-    one group per unique ``(folder, dataseries, channel)`` combination,
-    preserving the order of first encounter.  Data-mode targets (no
-    ``"channel"`` key) are collected into a single group appended last.
+    Targets are split into groups, each passed as a single ``tool.run_all()``
+    call, in this priority order:
+
+    1. Toolfolder+dataseries targets (``"toolfolder"`` and ``"channel"`` keys):
+       one group per ``(folder, toolfolder, dataseries, channel)`` combination.
+    2. Toolfolder+data targets (``"toolfolder"`` key, no ``"channel"``):
+       one group per ``(folder, toolfolder)`` combination.
+    3. Basic dataseries targets (``"channel"`` key, no ``"toolfolder"``):
+       one group per ``(folder, dataseries, channel)`` combination.
+    4. Basic data targets (neither ``"toolfolder"`` nor ``"channel"``):
+       collected into a single group appended last.
 
     Args:
         targets: Flat list of target dicts as returned by
@@ -86,17 +95,33 @@ def _split_targets_by_channel(
         List of target-dict groups, each suitable for a single
         ``tool.run_all()`` call.
     """
+    tf_ds_groups: dict[tuple, list[dict]] = {}
+    tf_data_groups: dict[tuple, list[dict]] = {}
     ds_groups: dict[tuple, list[dict]] = {}
     data_targets: list[dict] = []
     for t in targets:
-        if "channel" in t:
+        if "toolfolder" in t:
+            if "channel" in t:
+                key = (
+                    id(t.get("folder")),
+                    id(t.get("toolfolder")),
+                    id(t.get("dataseries")),
+                    id(t.get("channel")),
+                )
+                tf_ds_groups.setdefault(key, []).append(t)
+            else:
+                key = (id(t.get("folder")), id(t.get("toolfolder")))
+                tf_data_groups.setdefault(key, []).append(t)
+        elif "channel" in t:
             key = (id(t.get("folder")), id(t.get("dataseries")), id(t.get("channel")))
-            if key not in ds_groups:
-                ds_groups[key] = []
-            ds_groups[key].append(t)
+            ds_groups.setdefault(key, []).append(t)
         else:
             data_targets.append(t)
-    groups: list[list[dict]] = list(ds_groups.values())
+    groups: list[list[dict]] = (
+        list(tf_ds_groups.values())
+        + list(tf_data_groups.values())
+        + list(ds_groups.values())
+    )
     if data_targets:
         groups.append(data_targets)
     return groups
@@ -335,11 +360,17 @@ class NMManager(NMObject):
         if not isinstance(f, NMFolder):
             return
 
-        # Data and DataSeries are siblings at folder tier
-        yield ("data", f.data, f.data.selected_value)
+        # Toolfolder is resolved first — it acts as a context switch.
+        # When a toolfolder is selected, data/dataseries/channel/epoch
+        # draw from its containers instead of the folder's.
+        tf = f.toolfolders.selected_value
+        yield ("toolfolder", f.toolfolders, tf)
 
-        ds = f.dataseries.selected_value
-        yield ("dataseries", f.dataseries, ds)
+        ctx = tf if isinstance(tf, NMToolFolder) else f
+        yield ("data", ctx.data, ctx.data.selected_value)
+
+        ds = ctx.dataseries.selected_value
+        yield ("dataseries", ctx.dataseries, ds)
 
         if not isinstance(ds, NMDataSeries):
             return
@@ -350,7 +381,30 @@ class NMManager(NMObject):
 
     @property
     def select_values(self) -> dict[str, NMObject | None]:
-        """Get the currently selected object at each hierarchy tier."""
+        """Return the currently selected ``NMObject`` at each hierarchy tier.
+
+        Traverses the hierarchy from folder down to epoch, following the
+        selected item at each tier.  Tiers that have no selection, or whose
+        parent tier has no selection, are ``None``.
+
+        Returns a new dict on every call with keys from
+        ``HIERARCHY_SELECT_KEYS``: ``"folder"``, ``"toolfolder"``,
+        ``"data"``, ``"dataseries"``, ``"channel"``, ``"epoch"``.
+
+        ``"toolfolder"`` reflects the selected item in the current folder's
+        toolfolder container and is independent of ``"dataseries"``.
+        ``"channel"`` and ``"epoch"`` depend on ``"dataseries"`` being
+        selected — they are ``None`` if no dataseries is selected.
+
+        Returns:
+            Dict mapping tier name → selected ``NMObject``, or ``None`` if
+            nothing is selected at that tier.
+
+        See Also:
+            :attr:`select_keys` — same result with name strings instead of objects.
+            :attr:`select_keys` (setter) — set selection by name.
+            :meth:`select_value_set` — set selection by object reference.
+        """
         result: dict[str, NMObject | None] = {tier: None for tier in HIERARCHY_SELECT_KEYS}
         for tier, container, value in self._iter_select_hierarchy():
             result[tier] = value
@@ -358,7 +412,35 @@ class NMManager(NMObject):
 
     @property
     def select_keys(self) -> dict[str, str | None]:
-        """Get the names of currently selected objects at each hierarchy tier."""
+        """Return the name of the currently selected object at each hierarchy tier.
+
+        Same traversal as :attr:`select_values` but returns name strings
+        instead of object references.  Unselected tiers are ``None``.
+
+        When no toolfolder is selected, ``"data"``, ``"dataseries"``,
+        ``"channel"``, and ``"epoch"`` reflect the folder's contents::
+
+            nm.select_keys
+            # {"folder": "folder0", "toolfolder": None,
+            #  "data": "RecordA0", "dataseries": "Record",
+            #  "channel": "A", "epoch": "E0"}
+
+        When a toolfolder is selected, those four tiers reflect the
+        toolfolder's contents instead::
+
+            nm.select_keys
+            # {"folder": "folder0", "toolfolder": "Spike_0",
+            #  "data": "SPK_A0", "dataseries": "SPK",
+            #  "channel": "A", "epoch": "E0"}
+
+        Returns:
+            Dict mapping tier name → selected object name string, or ``None``
+            if nothing is selected at that tier.
+
+        See Also:
+            :attr:`select_values` — same result with ``NMObject`` instances.
+            :meth:`select_value_set` — set selection by object reference.
+        """
         result: dict[str, str | None] = {tier: None for tier in HIERARCHY_SELECT_KEYS}
         for tier, container, value in self._iter_select_hierarchy():
             if isinstance(value, NMObject):
@@ -413,12 +495,18 @@ class NMManager(NMObject):
         if not isinstance(f, NMFolder):
             return
 
-        if "data" in select:
-            f.data._selected_name_set(select["data"])
-        if "dataseries" in select:
-            f.dataseries._selected_name_set(select["dataseries"])
+        if "toolfolder" in select:
+            f.toolfolders._selected_name_set(select["toolfolder"])
 
-        ds = f.dataseries.selected_value
+        tf = f.toolfolders.selected_value
+        ctx = tf if isinstance(tf, NMToolFolder) else f
+
+        if "data" in select:
+            ctx.data._selected_name_set(select["data"])
+        if "dataseries" in select:
+            ctx.dataseries._selected_name_set(select["dataseries"])
+
+        ds = ctx.dataseries.selected_value
         if not isinstance(ds, NMDataSeries):
             return
 
@@ -488,13 +576,19 @@ class NMManager(NMObject):
             # Parent is NMFolder directly (skips container)
             current = current._parent
 
+        if isinstance(current, NMToolFolder):
+            select["toolfolder"] = current.name
+            # Parent is NMFolder directly (skips NMToolFolderContainer)
+            current = current._parent
+
         if isinstance(current, NMFolder):
             select["folder"] = current.name
 
         if not select:
             raise ValueError(
                 f"object type '{type(obj).__name__}' is not a recognized "
-                f"hierarchy type (NMFolder, NMData, NMDataSeries, NMChannel, NMEpoch)"
+                f"hierarchy type "
+                f"(NMFolder, NMToolFolder, NMData, NMDataSeries, NMChannel, NMEpoch)"
             )
 
         # Use existing _select_keys_set to apply the selection
@@ -504,6 +598,50 @@ class NMManager(NMObject):
         self,
         dataseries_priority: bool = True
     ) -> list[dict[str, NMObject]]:
+        """Return the current run targets as a flat list of selection dicts.
+
+        Each dict maps hierarchy tier names to the corresponding ``NMObject``
+        instances.  Four target shapes are possible, depending on which run
+        targets are active:
+
+        - **Toolfolder + dataseries** (``"toolfolder"`` and ``"channel"`` keys):
+          ``{"folder", "toolfolder", "dataseries", "channel", "epoch"}`` —
+          produced when a toolfolder has non-empty dataseries run targets and
+          ``dataseries_priority`` is ``True``.
+        - **Toolfolder + data** (``"toolfolder"`` key, no ``"channel"``):
+          ``{"folder", "toolfolder", "data"}`` — produced when a toolfolder
+          has non-empty data run targets (or dataseries run targets are empty /
+          ``dataseries_priority`` is ``False``).
+        - **Dataseries** (``"channel"`` key, no ``"toolfolder"``):
+          ``{"folder", "dataseries", "channel", "epoch"}`` — produced when the
+          folder has non-empty dataseries run targets and ``dataseries_priority``
+          is ``True``.
+        - **Data** (neither ``"toolfolder"`` nor ``"channel"``):
+          ``{"folder", "data"}`` — produced when dataseries run targets are
+          empty or ``dataseries_priority`` is ``False``.
+
+        Toolfolder targets are listed before folder-level targets.  Within
+        each branch, ordering follows the order of first encounter in the
+        respective containers.
+
+        Run targets at each tier are controlled via :meth:`run_keys_set` or by
+        setting ``run_target`` directly on the container (e.g.
+        ``folder.toolfolders.run_target = "all"``).
+
+        Args:
+            dataseries_priority: When ``True`` (default), prefer the dataseries
+                branch over the data branch within both folder-level and
+                toolfolder-level targets.  When ``False``, always use the data
+                branch.
+
+        Returns:
+            Flat list of selection dicts.  Empty if no folders or no run
+            targets are set.
+
+        See Also:
+            :meth:`run_keys` — same result with object names instead of objects.
+            :meth:`run_keys_set` — configure run targets at all tiers at once.
+        """
         elist: list[dict[str, NMObject]] = []
         folders = self.__folders
         if folders is None:
@@ -512,6 +650,33 @@ class NMManager(NMObject):
         for f in flist:
             if not isinstance(f, NMFolder):
                 continue
+
+            # Toolfolder branches — produced whenever toolfolder run targets
+            # are non-empty (set explicitly via run_keys_set or manually).
+            for tf in f.toolfolders.run_targets:
+                if not isinstance(tf, NMToolFolder):
+                    continue
+                tf_dslist = tf.dataseries.run_targets
+                if dataseries_priority and tf_dslist:
+                    # Toolfolder + dataseries mode
+                    for ds in tf_dslist:
+                        if not isinstance(ds, NMDataSeries):
+                            continue
+                        for c in ds.channels.run_targets:
+                            for e in ds.epochs.run_targets:
+                                elist.append({
+                                    "folder": f,
+                                    "toolfolder": tf,
+                                    "dataseries": ds,
+                                    "channel": c,
+                                    "epoch": e,
+                                })
+                else:
+                    # Toolfolder + data mode
+                    for d in tf.data.run_targets:
+                        elist.append({"folder": f, "toolfolder": tf, "data": d})
+
+            # Existing folder-level branches
             dslist = f.dataseries.run_targets
             if dataseries_priority and dslist:
                 for ds in dslist:
@@ -519,25 +684,49 @@ class NMManager(NMObject):
                         continue
                     for c in ds.channels.run_targets:
                         for e in ds.epochs.run_targets:
-                            x: dict[str, NMObject] = {}
-                            x["folder"] = f
-                            x["dataseries"] = ds
-                            x["channel"] = c
-                            x["epoch"] = e
-                            elist.append(x)
+                            elist.append({
+                                "folder": f,
+                                "dataseries": ds,
+                                "channel": c,
+                                "epoch": e,
+                            })
             else:
                 dlist = f.data.run_targets
                 for d in dlist:
-                    x2: dict[str, NMObject] = {}
-                    x2["folder"] = f
-                    x2["data"] = d
-                    elist.append(x2)
+                    elist.append({"folder": f, "data": d})
         return elist
 
     def run_keys(
         self,
         dataseries_priority: bool = True
     ) -> list[dict[str, str]]:
+        """Return the current run targets as a flat list of name dicts.
+
+        Identical to :meth:`run_values` but replaces each ``NMObject`` value
+        with its ``name`` string.  Useful for logging, display, and
+        serialisation without holding object references.
+
+        Example:
+
+            nm.run_keys_set({"folder": "folder0", "data": "all"})
+            for entry in nm.run_keys():
+                print(entry["folder"], entry["data"])
+
+        Args:
+            dataseries_priority: Passed through to :meth:`run_values`.
+                When ``True`` (default), prefer the dataseries branch over
+                the data branch.
+
+        Returns:
+            Flat list of dicts mapping tier names to object name strings.
+            Keys present in each dict match those produced by
+            :meth:`run_values` for the same configuration.
+
+        See Also:
+            :meth:`run_values` — same result with ``NMObject`` instances.
+            :meth:`run_count` — length of this list without building it.
+            :meth:`run_keys_set` — configure run targets at all tiers at once.
+        """
         elist = []
         elist2 = self.run_values(dataseries_priority)
         for e in elist2:
@@ -568,25 +757,54 @@ class NMManager(NMObject):
         run: dict[str, str],
         max_targets: int | None = 1000
     ) -> list[dict[str, str]]:
-        """
-        Set run targets at each hierarchy tier.
+        """Set run targets at each hierarchy tier.
+
+        Four modes are supported depending on which keys are present:
+
+        **Data mode** — target NMData items directly in a folder::
+
+            {"folder": "folder0", "data": "all"}
+            {"folder": "all",     "data": "RecordA0"}
+            {"folder": "set0",    "data": "selected"}
+
+        **Dataseries mode** — target by dataseries / channel / epoch::
+
+            {"folder": "folder0", "dataseries": "Record",
+             "channel": "A",      "epoch": "all"}
+            {"folder": "all",     "dataseries": "selected",
+             "channel": "ChanSet1", "epoch": "group0"}
+
+        **Toolfolder + data mode** — target NMData items inside a tool subfolder::
+
+            {"folder": "folder0", "toolfolder": "Spike_0", "data": "all"}
+            {"folder": "all",     "toolfolder": "all",     "data": "selected"}
+
+        **Toolfolder + dataseries mode** — target a dataseries inside a tool subfolder::
+
+            {"folder": "folder0", "toolfolder": "Spike_0",
+             "dataseries": "SPK_", "channel": "A", "epoch": "all"}
+
+        Values can be ``"selected"`` (current selection), ``"all"`` (every
+        item), a specific object name, or a named set/group defined on the
+        container.  Keys are case-insensitive.
 
         Args:
-            run: Dictionary mapping tier names to target values.
-                    Values can be: "select"/"selected", "all", a specific name,
-                    or a set name.
-                    Must include "folder" and either "data" or "dataseries".
-                    If "dataseries", must also include "channel" and "epoch".
+            run: Dictionary mapping tier names to target values, as shown
+                above.  Must include ``"folder"`` and either ``"data"`` or
+                ``"dataseries"`` (not both).  Dataseries mode additionally
+                requires ``"channel"`` and ``"epoch"``.
             max_targets: Maximum number of resulting targets allowed.
-                        Set to None for unlimited. Default is 1000.
+                Set to ``None`` for unlimited. Default is 1000.
 
         Returns:
-            List of run target dictionaries (same as run_keys())
+            List of run target dictionaries (same as :meth:`run_keys`).
 
         Raises:
-            TypeError: If run is not a dict or values aren't strings
-            KeyError: If a key is not a valid selection tier
-            ValueError: If target count exceeds max_targets
+            TypeError: If *run* is not a dict or any key/value is not a string.
+            KeyError: If a key is not a valid selection tier, a required key is
+                missing, or mutually exclusive keys are combined.
+            ValueError: If the resolved target count exceeds *max_targets*, or
+                a named target does not exist in its container.
         """
         if not isinstance(run, dict):
             raise TypeError(nmu.type_error_str(run, "run", "dictionary"))
@@ -635,20 +853,57 @@ class NMManager(NMObject):
         # Set folder run target (allows select/all/name/set)
         folders.run_target = run["folder"]
 
-        # Data mode - simpler path
-        if "data" in run:
-            # Set data run target for each folder in run_targets
+        # Toolfolder + data mode
+        if "toolfolder" in run and "data" in run:
             for f in folders.run_targets:
-                if isinstance(f, NMFolder):
-                    f.data.run_target = run["data"]
-
+                if not isinstance(f, NMFolder):
+                    continue
+                f.toolfolders.run_target = run["toolfolder"]
+                for tf in f.toolfolders.run_targets:
+                    if isinstance(tf, NMToolFolder):
+                        tf.data.run_target = run["data"]
             result = self.run_keys(dataseries_priority=False)
             self._run_check_max_targets(result, max_targets)
             self.__run_config = dict(run)
             nmch.add_nm_command("run_keys_set(%r)" % (run,))
             return result
 
-        # Dataseries mode - requires dataseries, channel, epoch
+        # Toolfolder + dataseries mode
+        if "toolfolder" in run and "dataseries" in run:
+            if "channel" not in run:
+                raise KeyError("missing run 'channel' key")
+            if "epoch" not in run:
+                raise KeyError("missing run 'epoch' key")
+            for f in folders.run_targets:
+                if not isinstance(f, NMFolder):
+                    continue
+                f.toolfolders.run_target = run["toolfolder"]
+                for tf in f.toolfolders.run_targets:
+                    if not isinstance(tf, NMToolFolder):
+                        continue
+                    tf.dataseries.run_target = run["dataseries"]
+                    for ds in tf.dataseries.run_targets:
+                        if isinstance(ds, NMDataSeries):
+                            ds.channels.run_target = run["channel"]
+                            ds.epochs.run_target = run["epoch"]
+            result = self.run_keys(dataseries_priority=True)
+            self._run_check_max_targets(result, max_targets)
+            self.__run_config = dict(run)
+            nmch.add_nm_command("run_keys_set(%r)" % (run,))
+            return result
+
+        # Basic data mode
+        if "data" in run:
+            for f in folders.run_targets:
+                if isinstance(f, NMFolder):
+                    f.data.run_target = run["data"]
+            result = self.run_keys(dataseries_priority=False)
+            self._run_check_max_targets(result, max_targets)
+            self.__run_config = dict(run)
+            nmch.add_nm_command("run_keys_set(%r)" % (run,))
+            return result
+
+        # Basic dataseries mode - requires dataseries, channel, epoch
         if "dataseries" not in run:
             raise KeyError("missing run 'dataseries' key")
         if "channel" not in run:
@@ -656,7 +911,6 @@ class NMManager(NMObject):
         if "epoch" not in run:
             raise KeyError("missing run 'epoch' key")
 
-        # Set run targets for each folder and dataseries
         for f in folders.run_targets:
             if not isinstance(f, NMFolder):
                 continue
@@ -701,6 +955,17 @@ class NMManager(NMObject):
                     continue
                 ds.channels.run_target = RUN_SELECTED
                 ds.epochs.run_target = RUN_SELECTED
+            f.toolfolders.run_target = RUN_SELECTED
+            for tf in f.toolfolders.values():
+                if not isinstance(tf, NMToolFolder):
+                    continue
+                tf.data.run_target = RUN_SELECTED
+                tf.dataseries.run_target = RUN_SELECTED
+                for ds in tf.dataseries.values():
+                    if not isinstance(ds, NMDataSeries):
+                        continue
+                    ds.channels.run_target = RUN_SELECTED
+                    ds.epochs.run_target = RUN_SELECTED
         self.__run_config = None
         nmch.add_nm_command("run_reset_all()")
         return None

--- a/tests/test_analysis/test_nm_tool.py
+++ b/tests/test_analysis/test_nm_tool.py
@@ -114,6 +114,18 @@ class TestNMToolProperties(unittest.TestCase):
         self.tool._select["epoch"] = self.folder  # Wrong type
         self.assertIsNone(self.tool.epoch)
 
+    def test_toolfolder_property_returns_none_when_empty(self):
+        self.assertIsNone(self.tool.toolfolder)
+
+    def test_toolfolder_property_returns_toolfolder(self):
+        tf = self.folder.toolfolders.new("Spike_0")
+        self.tool._select["toolfolder"] = tf
+        self.assertIs(self.tool.toolfolder, tf)
+
+    def test_toolfolder_property_returns_none_for_wrong_type(self):
+        self.tool._select["toolfolder"] = self.folder  # Wrong type
+        self.assertIsNone(self.tool.toolfolder)
+
 
 class TestNMToolSelectValues(unittest.TestCase):
     """Tests for NMTool select_values property."""
@@ -641,6 +653,27 @@ class TestNMToolRunMeta(unittest.TestCase):
         targets = [self._make_target(self.epoch0)]
         tool.run_all(targets)
         self.assertIn("test_ds", tool.run_meta["dataseries"])
+
+    def test_run_meta_has_toolfolders_key(self):
+        tool = NMTool()
+        tool.run_all([])
+        self.assertIn("toolfolders", tool.run_meta)
+        self.assertIsInstance(tool.run_meta["toolfolders"], list)
+
+    def test_run_meta_toolfolders_accumulates_from_targets(self):
+        tool = NMTool()
+        tf = self.folder.toolfolders.new("Spike_0")
+        target = {**self._make_target(self.epoch0), "toolfolder": tf}
+        tool.run_all([target])
+        self.assertIn("Spike_0", tool.run_meta["toolfolders"])
+
+    def test_run_meta_toolfolders_no_duplicates(self):
+        tool = NMTool()
+        tf = self.folder.toolfolders.new("Spike_0")
+        t0 = {**self._make_target(self.epoch0), "toolfolder": tf}
+        t1 = {**self._make_target(self.epoch1), "toolfolder": tf}
+        tool.run_all([t0, t1])
+        self.assertEqual(tool.run_meta["toolfolders"], ["Spike_0"])
 
     def test_run_meta_accessible_from_run_finish(self):
         captured = {}

--- a/tests/test_analysis/test_nm_tool_folder.py
+++ b/tests/test_analysis/test_nm_tool_folder.py
@@ -20,6 +20,29 @@ def _make_container() -> NMToolFolderContainer:
     return NMToolFolderContainer(parent=NM)
 
 
+class TestNMToolFolderContainerNew(unittest.TestCase):
+    """Tests for NMToolFolderContainer.new()."""
+
+    def test_first_toolfolder_not_auto_selected(self):
+        # Creating the first toolfolder must NOT auto-select it — a selected
+        # toolfolder switches the data/dataseries/channel/epoch context, so
+        # auto-selection would silently redirect normal folder-level workflows.
+        tf = _make_container()
+        tf.new("Spike_0")
+        self.assertIsNone(tf.selected_value)
+
+    def test_new_with_select_true_selects(self):
+        tf = _make_container()
+        f = tf.new("Spike_0", select=True)
+        self.assertIs(tf.selected_value, f)
+
+    def test_second_new_without_select_leaves_selection_unchanged(self):
+        tf = _make_container()
+        tf.new("Spike_0", select=True)
+        tf.new("Spike_1")
+        self.assertEqual(tf.selected_name, "Spike_0")
+
+
 class TestNMToolFolderContainerGetOrCreate(unittest.TestCase):
     """Tests for NMToolFolderContainer.get_or_create()."""
 

--- a/tests/test_core/test_nm_manager.py
+++ b/tests/test_core/test_nm_manager.py
@@ -86,6 +86,8 @@ class NMManagerTestBase(unittest.TestCase):
             f.data.sets.add("set0", self.data_set0)
             f.dataseries.sets.add("set0", ["data", "avg"])
         self.nm.folders.sets.add("set0", ["folder0", "folder1"])
+        self.select_values["toolfolder"] = None
+        self.select_keys["toolfolder"] = None
 
 
 class TestNMManagerInit(NMManagerTestBase):
@@ -124,6 +126,7 @@ class TestNMManagerSelect(NMManagerTestBase):
     def test_select_keys_set_updates_hierarchy(self):
         s1 = {
             "folder": "folder1",
+            "toolfolder": None,
             "data": "data3",
             "dataseries": "data",
             "channel": "A",
@@ -146,6 +149,7 @@ class TestNMManagerSelect(NMManagerTestBase):
         self.nm.select_keys = {"dataseries": "avg"}
         expected = {
             "folder": "folder1",
+            "toolfolder": None,
             "data": "data3",
             "dataseries": "avg",
             "channel": "A",  # First channel in avg dataseries
@@ -189,6 +193,7 @@ class TestNMManagerSelect(NMManagerTestBase):
         self.nm.select_keys = s1
         expected = {
             "folder": "folder1",
+            "toolfolder": None,
             "data": "data3",
             "dataseries": "data",
             "channel": "A",
@@ -210,6 +215,7 @@ class TestNMManagerRunKeys(NMManagerTestBase):
     def test_run_keys_returns_selected_dataseries(self):
         s = self.nm.select_keys.copy()
         s.pop("data")
+        s.pop("toolfolder")
         elist = self.nm.run_keys(dataseries_priority=True)
         self.assertEqual(elist, [s])
 
@@ -218,6 +224,7 @@ class TestNMManagerRunKeys(NMManagerTestBase):
         s.pop("dataseries")
         s.pop("channel")
         s.pop("epoch")
+        s.pop("toolfolder")
         elist = self.nm.run_keys(dataseries_priority=False)
         self.assertEqual(elist, [s])
 
@@ -225,6 +232,7 @@ class TestNMManagerRunKeys(NMManagerTestBase):
         self.nm.run_reset_all()
         s = self.nm.select_keys.copy()
         s.pop("data")
+        s.pop("toolfolder")
         elist = self.nm.run_keys(dataseries_priority=True)
         self.assertEqual(elist, [s])
 
@@ -340,6 +348,7 @@ class TestNMManagerRunKeysSet(NMManagerTestBase):
         elist = self.nm.run_keys_set(e1)
         select = self.nm.select_keys.copy()
         select.pop("data")
+        select.pop("toolfolder")
         self.assertEqual(elist, [select])
 
     def test_channel_all_expands_to_all_channels(self):
@@ -593,6 +602,103 @@ class TestNMManagerSelectValueSet(NMManagerTestBase):
         self.assertEqual(self.nm.select_keys["folder"], "folder0")
         self.assertEqual(self.nm.select_keys["dataseries"], "avg")
         # Channel/epoch should be whatever is selected in "avg" dataseries
+
+    def test_select_toolfolder_sets_folder_and_toolfolder(self):
+        f = self.nm.folders["folder2"]
+        tf = f.toolfolders.new("Spike_0")
+        self.nm.select_value_set(tf)
+        self.assertEqual(self.nm.select_keys["folder"], "folder2")
+        self.assertEqual(self.nm.select_keys["toolfolder"], "Spike_0")
+
+    def test_select_toolfolder_raises_for_wrong_manager(self):
+        other_nm = NMManager(quiet=QUIET)
+        other_folder = other_nm.folders.new("other")
+        other_tf = other_folder.toolfolders.new("Spike_0")
+        with self.assertRaises(ValueError):
+            self.nm.select_value_set(other_tf)
+
+
+class TestNMManagerToolfolderSelect(unittest.TestCase):
+    """Tests for toolfolder in select_keys / select_values / _select_keys_set."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=QUIET)
+        self.folder = self.nm.folders.new("folder0")
+        self.tf = self.folder.toolfolders.new("Spike_0")
+
+    def test_select_keys_includes_toolfolder(self):
+        self.assertIn("toolfolder", self.nm.select_keys)
+
+    def test_toolfolder_not_auto_selected_on_first_create(self):
+        # Creating the first toolfolder must NOT auto-select it — selecting a
+        # toolfolder switches the data/dataseries/channel/epoch context, so
+        # auto-selection would silently redirect normal folder-level workflows.
+        self.assertIsNone(self.nm.select_keys["toolfolder"])
+
+    def test_select_keys_toolfolder_reflects_selected(self):
+        self.nm.select_keys = {"toolfolder": "Spike_0"}
+        self.assertEqual(self.nm.select_keys["toolfolder"], "Spike_0")
+
+    def test_select_keys_toolfolder_none_when_nothing_selected(self):
+        self.folder.toolfolders._selected_name_set(None)
+        self.assertIsNone(self.nm.select_keys["toolfolder"])
+
+    def test_select_values_includes_toolfolder_object(self):
+        self.nm.select_keys = {"toolfolder": "Spike_0"}
+        sv = self.nm.select_values
+        self.assertIs(sv["toolfolder"], self.tf)
+
+    def test_select_keys_set_toolfolder(self):
+        tf2 = self.folder.toolfolders.new("Spike_1")
+        self.nm.select_keys = {"toolfolder": "Spike_1"}
+        self.assertEqual(self.nm.select_keys["toolfolder"], "Spike_1")
+
+    def test_select_keys_set_toolfolder_with_none_clears_selection(self):
+        self.nm.select_keys = {"toolfolder": "Spike_0"}
+        self.nm.select_keys = {"toolfolder": None}
+        self.assertIsNone(self.nm.select_keys["toolfolder"])
+
+    def test_select_keys_set_nonexistent_toolfolder_raises(self):
+        with self.assertRaises(KeyError):
+            self.nm.select_keys = {"toolfolder": "Nonexistent"}
+
+    def test_select_keys_set_data_targets_toolfolder_when_selected(self):
+        self.nm.select_keys = {"toolfolder": "Spike_0"}
+        d = self.tf.data.new("SPK_A0")
+        self.nm.select_keys = {"data": "SPK_A0"}
+        self.assertIs(self.nm.select_values["data"], d)
+        self.assertNotIn("SPK_A0", self.folder.data)
+
+    def test_select_keys_set_dataseries_targets_toolfolder_when_selected(self):
+        self.nm.select_keys = {"toolfolder": "Spike_0"}
+        ds = self.tf.dataseries.new("SPK")
+        self.nm.select_keys = {"dataseries": "SPK"}
+        self.assertIs(self.nm.select_values["dataseries"], ds)
+        self.assertNotIn("SPK", self.folder.dataseries)
+
+    def test_select_keys_set_channel_epoch_from_toolfolder_dataseries(self):
+        self.nm.select_keys = {"toolfolder": "Spike_0"}
+        ds = self.tf.dataseries.new("SPK")
+        ch = ds.channels.new()
+        ep = ds.epochs.new()
+        self.nm.select_keys = {"dataseries": "SPK", "channel": ch.name, "epoch": ep.name}
+        self.assertIs(self.nm.select_values["channel"], ch)
+        self.assertIs(self.nm.select_values["epoch"], ep)
+
+    def test_select_keys_set_data_targets_folder_when_no_toolfolder(self):
+        # toolfolder is None by default; data key refers to folder.data
+        d = self.folder.data.new("RecordA0")
+        self.nm.select_keys = {"data": "RecordA0"}
+        self.assertIs(self.nm.select_values["data"], d)
+
+    def test_select_values_data_reflects_toolfolder_context(self):
+        self.nm.select_keys = {"toolfolder": "Spike_0"}
+        d_folder = self.folder.data.new("RecordA0")
+        d_tf = self.tf.data.new("SPK_A0")
+        self.tf.data._selected_name_set("SPK_A0")
+        sv = self.nm.select_values
+        self.assertIs(sv["data"], d_tf)
+        self.assertIsNot(sv["data"], d_folder)
 
 
 class TestNMManagerCommandHistory(NMManagerTestBase):
@@ -899,6 +1005,182 @@ class TestSplitTargetsByChannel(unittest.TestCase):
         self.assertEqual(len(splits), 2)
         self.assertIn("channel", splits[0][0])
         self.assertNotIn("channel", splits[1][0])
+
+    def _tf_data(self, tf, name):
+        d = self.folder.data.new(name)
+        return {"folder": self.folder, "toolfolder": tf, "data": d}
+
+    def _tf_ds(self, tf, ds, ch, ep):
+        return {"folder": self.folder, "toolfolder": tf, "dataseries": ds,
+                "channel": ch, "epoch": ep}
+
+    def test_toolfolder_data_targets_grouped_per_toolfolder(self):
+        from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
+        tf0 = self.folder.toolfolders.new("tf0")
+        tf1 = self.folder.toolfolders.new("tf1")
+        targets = [self._tf_data(tf0, "a0"), self._tf_data(tf0, "a1"),
+                   self._tf_data(tf1, "b0")]
+        splits = _split_targets_by_channel(targets)
+        self.assertEqual(len(splits), 2)
+        self.assertEqual(len(splits[0]), 2)
+        self.assertEqual(len(splits[1]), 1)
+
+    def test_toolfolder_dataseries_targets_grouped_per_channel(self):
+        from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
+        tf = self.folder.toolfolders.new("tf0")
+        ds = tf.dataseries.new("SPK_")
+        ch_a = ds.channels.new("A")
+        ch_b = ds.channels.new("B")
+        ep = ds.epochs.new("E0")
+        targets = [self._tf_ds(tf, ds, ch_a, ep), self._tf_ds(tf, ds, ch_b, ep)]
+        splits = _split_targets_by_channel(targets)
+        self.assertEqual(len(splits), 2)
+        self.assertIs(splits[0][0]["channel"], ch_a)
+        self.assertIs(splits[1][0]["channel"], ch_b)
+
+    def test_toolfolder_targets_appear_before_basic_data(self):
+        tf = self.folder.toolfolders.new("tf0")
+        targets = [self._d("basic"), self._tf_data(tf, "tf_d")]
+        splits = _split_targets_by_channel(targets)
+        # toolfolder group comes first, basic data group last
+        self.assertIn("toolfolder", splits[0][0])
+        self.assertNotIn("toolfolder", splits[1][0])
+
+
+class TestNMManagerToolfolderRunValues(unittest.TestCase):
+    """Tests for run_values() toolfolder traversal branches."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=QUIET)
+        self.folder = self.nm.folders.new("folder0")
+        self.tf = self.folder.toolfolders.new("Spike_0")
+        self.d0 = self.tf.data.new("SP_A0")
+        self.d1 = self.tf.data.new("SP_A1")
+        self.ds = self.tf.dataseries.new("SPK_")
+        self.ch = self.ds.channels.new("A")
+        self.ep = self.ds.epochs.new("E0")
+
+    def test_no_toolfolder_run_target_produces_no_tf_entries(self):
+        # With no toolfolders created the container is empty → no tf targets
+        nm = NMManager(quiet=QUIET)
+        nm.folders.new("empty_folder")
+        targets = nm.run_values()
+        tf_targets = [t for t in targets if "toolfolder" in t]
+        self.assertEqual(len(tf_targets), 0)
+
+    def test_toolfolder_data_targets_produced(self):
+        self.folder.toolfolders.run_target = "all"
+        self.tf.data.run_target = "all"
+        targets = self.nm.run_values(dataseries_priority=False)
+        tf_targets = [t for t in targets if "toolfolder" in t]
+        self.assertEqual(len(tf_targets), 2)
+        for t in tf_targets:
+            self.assertIs(t["folder"], self.folder)
+            self.assertIs(t["toolfolder"], self.tf)
+            self.assertIn("data", t)
+            self.assertNotIn("channel", t)
+
+    def test_toolfolder_dataseries_targets_produced(self):
+        self.folder.toolfolders.run_target = "all"
+        self.tf.dataseries.run_target = "all"
+        self.ds.channels.run_target = "all"
+        self.ds.epochs.run_target = "all"
+        targets = self.nm.run_values(dataseries_priority=True)
+        tf_ds_targets = [t for t in targets if "toolfolder" in t and "channel" in t]
+        self.assertEqual(len(tf_ds_targets), 1)
+        t = tf_ds_targets[0]
+        self.assertIs(t["folder"], self.folder)
+        self.assertIs(t["toolfolder"], self.tf)
+        self.assertIs(t["dataseries"], self.ds)
+        self.assertIs(t["channel"], self.ch)
+        self.assertIs(t["epoch"], self.ep)
+
+    def test_toolfolder_targets_appear_before_folder_targets(self):
+        self.folder.data.new("rec0")
+        self.folder.data.run_target = "all"
+        self.folder.toolfolders.run_target = "all"
+        self.tf.data.run_target = "all"
+        targets = self.nm.run_values(dataseries_priority=False)
+        first_tf = next(i for i, t in enumerate(targets) if "toolfolder" in t)
+        first_basic = next(i for i, t in enumerate(targets) if "toolfolder" not in t)
+        self.assertLess(first_tf, first_basic)
+
+
+class TestNMManagerToolfolderRunKeysSet(unittest.TestCase):
+    """Tests for run_keys_set() toolfolder+data and toolfolder+dataseries modes."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=QUIET)
+        self.folder = self.nm.folders.new("folder0")
+        self.tf = self.folder.toolfolders.new("Spike_0")
+        self.d0 = self.tf.data.new("SP_A0")
+        self.d1 = self.tf.data.new("SP_A1")
+        self.ds = self.tf.dataseries.new("SPK_")
+        self.ch = self.ds.channels.new("A")
+        self.ep = self.ds.epochs.new("E0")
+
+    def test_toolfolder_data_mode_returns_targets(self):
+        elist = self.nm.run_keys_set({
+            "folder": "all", "toolfolder": "all", "data": "all",
+        })
+        self.assertEqual(len(elist), 2)
+        for e in elist:
+            self.assertIn("toolfolder", e)
+            self.assertIn("data", e)
+            self.assertNotIn("channel", e)
+
+    def test_toolfolder_dataseries_mode_returns_targets(self):
+        elist = self.nm.run_keys_set({
+            "folder": "all", "toolfolder": "all",
+            "dataseries": "all", "channel": "all", "epoch": "all",
+        })
+        self.assertEqual(len(elist), 1)
+        e = elist[0]
+        self.assertIn("toolfolder", e)
+        self.assertIn("channel", e)
+        self.assertEqual(e["toolfolder"], "Spike_0")
+        self.assertEqual(e["channel"], "A")
+
+    def test_toolfolder_data_mode_target_dict_keys(self):
+        elist = self.nm.run_keys_set({
+            "folder": "folder0", "toolfolder": "Spike_0", "data": "SP_A0",
+        })
+        self.assertEqual(len(elist), 1)
+        self.assertEqual(elist[0]["folder"], "folder0")
+        self.assertEqual(elist[0]["toolfolder"], "Spike_0")
+        self.assertEqual(elist[0]["data"], "SP_A0")
+
+    def test_toolfolder_dataseries_requires_channel(self):
+        with self.assertRaises(KeyError):
+            self.nm.run_keys_set({
+                "folder": "folder0", "toolfolder": "Spike_0",
+                "dataseries": "SPK_", "epoch": "all",
+            })
+
+    def test_toolfolder_dataseries_requires_epoch(self):
+        with self.assertRaises(KeyError):
+            self.nm.run_keys_set({
+                "folder": "folder0", "toolfolder": "Spike_0",
+                "dataseries": "SPK_", "channel": "all",
+            })
+
+
+class TestNMManagerToolfolderRunReset(unittest.TestCase):
+    """Tests for run_reset_all() resetting toolfolder run targets."""
+
+    def setUp(self):
+        self.nm = NMManager(quiet=QUIET)
+        self.folder = self.nm.folders.new("folder0")
+        self.tf = self.folder.toolfolders.new("Spike_0")
+        self.tf.data.new("SP_A0")
+
+    def test_run_reset_all_clears_toolfolder_run_target(self):
+        self.folder.toolfolders.run_target = "all"
+        self.tf.data.run_target = "all"
+        self.nm.run_reset_all()
+        # After reset, run_target reverts to "selected" at each tier
+        self.assertEqual(self.folder.toolfolders.run_target, "selected")
+        self.assertEqual(self.tf.data.run_target, "selected")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extends `NMManager` to accept `NMToolFolder` as a run target, adds a
toolfolder context-switch to the selection hierarchy, and prevents accidental
toolfolder auto-selection.

### NMManager (`nm_manager.py`)
- `HIERARCHY_SELECT_KEYS` extended to include `"toolfolder"`
- `run_values()` — two new target shapes: toolfolder+dataseries and toolfolder+data
- `run_keys_set()` — accepts `{"run": "toolfolder"}` (dataseries and data variants)
- `_split_targets_by_channel()` — groups toolfolder targets ahead of folder targets
- `run_reset_all()` — clears toolfolder run targets
- `_iter_select_hierarchy()` — context switch: when a toolfolder is selected,
  `data`/`dataseries`/`channel`/`epoch` resolve from its containers instead of
  the folder's (enables per-epoch display of `SPK_` waveforms in future graph work)
- `_select_keys_set()` — applies the same context switch when setting selection by name
- `select_value_set()` — handles `NMToolFolder` objects
- Full docstrings added to `run_values()`, `run_keys()`, `run_keys_set()`,
  `select_values`, and `select_keys` (with paired no-toolfolder / toolfolder examples)

### NMTool (`nm_tool.py`)
- `toolfolder` property added
- `run_meta` now tracks `"toolfolders"` visited during `run_all()`

### NMToolFolderContainer (`nm_tool_folder.py`)
- `new()` no longer auto-selects the first toolfolder — auto-selection would
  silently redirect the `data`/`dataseries`/`channel`/`epoch` context and break
  normal folder-level workflows; callers must pass `select=True` explicitly

## Test plan
- [ ] `python3 -m pytest tests/test_core/test_nm_manager.py -q`
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool.py -q`
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_folder.py -q`
- [ ] `python3 -m pytest -q`

Closes #273 and #258

