### PR TITLE
refactor(analysis): remove xclip parameter from stats pipeline

### DIFF
--- a/pyneuromatic/analysis/nm_stat_func.py
+++ b/pyneuromatic/analysis/nm_stat_func.py
@@ -179,15 +179,13 @@ class NMStatFunc:
         """
         return "%r" % self._name
 
-    def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
-                bsln_result):
+    def compute(self, data, x0, x1, ignore_nans, run_stat, bsln_result):
         """Execute the stat computation, appending results via run_stat.
 
         Args:
             data: Input data object with x/y arrays.
             x0: Left x-boundary of the main stat window.
             x1: Right x-boundary of the main stat window.
-            xclip: If True, clip data to [x0, x1] before computing.
             ignore_nans: If True, exclude NaN values from computation.
             run_stat: Callable (``NMStatWin._run_stat``) that executes a
                 single stat dict and appends the result to the results list.
@@ -215,11 +213,10 @@ class NMStatFuncBasic(NMStatFunc):
             raise ValueError("func name: '%s'" % name)
         super().__init__(name.lower())
 
-    def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
-                bsln_result):
+    def compute(self, data, x0, x1, ignore_nans, run_stat, bsln_result):
         """Run a single stat call and optionally record the baseline delta."""
         r = run_stat(data, {"name": self._name}, "main",
-                     x0, x1, xclip, ignore_nans)
+                     x0, x1, ignore_nans)
         self._add_ds(r, bsln_result)
 
 
@@ -275,8 +272,7 @@ class NMStatFuncMaxMin(NMStatFunc):
             s += ", n_mean=%r" % self._n_mean
         return s
 
-    def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
-                bsln_result):
+    def compute(self, data, x0, x1, ignore_nans, run_stat, bsln_result):
         """Run the max/min stat; warn if n_mean <= 1 for mean@ variants."""
         func: dict[str, Any] = {"name": self._name}
         if self._n_mean is not None:
@@ -285,7 +281,7 @@ class NMStatFuncMaxMin(NMStatFunc):
             n_mean = self._n_mean if self._n_mean is not None else 0
             if n_mean <= 1:
                 func["warning"] = "not enough data points to compute a mean"
-        r = run_stat(data, func, "main", x0, x1, xclip, ignore_nans)
+        r = run_stat(data, func, "main", x0, x1, ignore_nans)
         self._add_ds(r, bsln_result)
 
 
@@ -324,11 +320,10 @@ class NMStatFuncLevel(NMStatFunc):
     def _params_str(self) -> str:
         return "%r, ylevel=%r" % (self._name, self._ylevel)
 
-    def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
-                bsln_result):
+    def compute(self, data, x0, x1, ignore_nans, run_stat, bsln_result):
         """Find the level crossing at ylevel and optionally add baseline delta."""
         func: dict[str, Any] = {"name": self._name, "ylevel": self._ylevel}
-        r = run_stat(data, func, "main", x0, x1, xclip, ignore_nans)
+        r = run_stat(data, func, "main", x0, x1, ignore_nans)
         self._add_ds(r, bsln_result)
 
 
@@ -380,8 +375,7 @@ class NMStatFuncLevelNstd(NMStatFunc):
                 "level n_std requires baseline 'mean+std' computation"
             )
 
-    def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
-                bsln_result):
+    def compute(self, data, x0, x1, ignore_nans, run_stat, bsln_result):
         """Derive ylevel from the baseline, then find the level crossing."""
         ylevel = math.nan
         if "s" in bsln_result and "std" in bsln_result:
@@ -390,7 +384,7 @@ class NMStatFuncLevelNstd(NMStatFunc):
             if not badvalue(s) and not badvalue(std):
                 ylevel = s + self._n_std * std
         func: dict[str, Any] = {"name": self._name, "ylevel": ylevel}
-        r = run_stat(data, func, "main", x0, x1, xclip, ignore_nans)
+        r = run_stat(data, func, "main", x0, x1, ignore_nans)
         self._add_ds(r, bsln_result)
 
 
@@ -466,8 +460,7 @@ class NMStatFuncRiseTime(NMStatFunc):
                 "peak func '%s' requires baseline 'mean' computation"
                 % self._name)
 
-    def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
-                bsln_result):
+    def compute(self, data, x0, x1, ignore_nans, run_stat, bsln_result):
         """Compute rise time: peak → level at p0% → level at p1%.
 
         Records ``dx = x(p1) - x(p0)`` and optionally the slope between them.
@@ -483,7 +476,7 @@ class NMStatFuncRiseTime(NMStatFunc):
             peak_func = {"name": "min"}
             flevel = {"name": "level-"}
 
-        r = run_stat(data, peak_func, f, x0, x1, xclip, ignore_nans)
+        r = run_stat(data, peak_func, f, x0, x1, ignore_nans)
         ds = self._add_ds(r, bsln_result)
 
         if badvalue(ds):
@@ -493,12 +486,12 @@ class NMStatFuncRiseTime(NMStatFunc):
         peak_x = r["x"]
 
         flevel["ylevel"] = 0.01 * self._p0 * ds
-        r0 = run_stat(data, flevel, f, x0, peak_x, xclip, ignore_nans,
+        r0 = run_stat(data, flevel, f, x0, peak_x, ignore_nans,
                       p0=self._p0)
         r0_error = "x" not in r0 or badvalue(r0["x"])
 
         flevel["ylevel"] = 0.01 * self._p1 * ds
-        r1 = run_stat(data, flevel, f, x0, peak_x, xclip, ignore_nans,
+        r1 = run_stat(data, flevel, f, x0, peak_x, ignore_nans,
                       p1=self._p1)
         r1_error = "x" not in r1 or badvalue(r1["x"])
 
@@ -514,7 +507,7 @@ class NMStatFuncRiseTime(NMStatFunc):
 
         if slope:
             run_stat(data, {"name": "slope"}, f, r0["x"], r1["x"],
-                     xclip, ignore_nans)
+                     ignore_nans)
 
 
 class NMStatFuncFallTime(NMStatFunc):
@@ -590,8 +583,7 @@ class NMStatFuncFallTime(NMStatFunc):
                 "peak func '%s' requires baseline 'mean' computation"
                 % self._name)
 
-    def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
-                bsln_result):
+    def compute(self, data, x0, x1, ignore_nans, run_stat, bsln_result):
         """Compute fall time: peak → level at p0% → level at p1% after peak.
 
         Records ``dx = x(p1) - x(p0)`` and optionally the slope between them.
@@ -607,7 +599,7 @@ class NMStatFuncFallTime(NMStatFunc):
             peak_func = {"name": "min"}
             flevel = {"name": "level+"}  # opposite sign
 
-        r = run_stat(data, peak_func, f, x0, x1, xclip, ignore_nans)
+        r = run_stat(data, peak_func, f, x0, x1, ignore_nans)
         ds = self._add_ds(r, bsln_result)
 
         if badvalue(ds):
@@ -617,14 +609,14 @@ class NMStatFuncFallTime(NMStatFunc):
         peak_x = r["x"]
 
         flevel["ylevel"] = 0.01 * self._p0 * ds
-        r0 = run_stat(data, flevel, f, peak_x, x1, xclip, ignore_nans,
+        r0 = run_stat(data, flevel, f, peak_x, x1, ignore_nans,
                       p0=self._p0)
         r0_error = "x" not in r0 or badvalue(r0["x"])
         if r0_error:
             r0["error"] = "unable to locate p0 level"
 
         flevel["ylevel"] = 0.01 * self._p1 * ds
-        r1 = run_stat(data, flevel, f, peak_x, x1, xclip, ignore_nans,
+        r1 = run_stat(data, flevel, f, peak_x, x1, ignore_nans,
                       p1=self._p1)
         r1_error = "x" not in r1 or badvalue(r1["x"])
 
@@ -639,7 +631,7 @@ class NMStatFuncFallTime(NMStatFunc):
 
         if slope:
             run_stat(data, {"name": "slope"}, f, r0["x"], r1["x"],
-                     xclip, ignore_nans)
+                     ignore_nans)
 
 
 class NMStatFuncDecayTime(NMStatFunc):
@@ -692,8 +684,7 @@ class NMStatFuncDecayTime(NMStatFunc):
                 "peak func '%s' requires baseline 'mean' computation"
                 % self._name)
 
-    def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
-                bsln_result):
+    def compute(self, data, x0, x1, ignore_nans, run_stat, bsln_result):
         """Compute decay time: peak → level at p0% after peak.
 
         Records ``dx = x(p0) - peak_x``.
@@ -708,7 +699,7 @@ class NMStatFuncDecayTime(NMStatFunc):
             peak_func = {"name": "min"}
             flevel = {"name": "level+"}  # opposite sign
 
-        r = run_stat(data, peak_func, f, x0, x1, xclip, ignore_nans)
+        r = run_stat(data, peak_func, f, x0, x1, ignore_nans)
         ds = self._add_ds(r, bsln_result)
 
         if badvalue(ds):
@@ -718,7 +709,7 @@ class NMStatFuncDecayTime(NMStatFunc):
         peak_x = r["x"]
 
         flevel["ylevel"] = 0.01 * self._p0 * ds
-        r0 = run_stat(data, flevel, f, peak_x, x1, xclip, ignore_nans,
+        r0 = run_stat(data, flevel, f, peak_x, x1, ignore_nans,
                       p0=self._p0)
         r0_error = "x" not in r0 or badvalue(r0["x"])
         if r0_error:
@@ -793,8 +784,7 @@ class NMStatFuncFWHM(NMStatFunc):
                 "peak func '%s' requires baseline 'mean' computation"
                 % self._name)
 
-    def compute(self, data, x0, x1, xclip, ignore_nans, run_stat,
-                bsln_result):
+    def compute(self, data, x0, x1, ignore_nans, run_stat, bsln_result):
         """Compute FWHM: peak → level at p0% before peak, level at p1% after.
 
         Records ``dx = x(p1) - x(p0)``.
@@ -807,7 +797,7 @@ class NMStatFuncFWHM(NMStatFunc):
         else:
             peak_func = {"name": "min"}
 
-        r = run_stat(data, peak_func, f, x0, x1, xclip, ignore_nans)
+        r = run_stat(data, peak_func, f, x0, x1, ignore_nans)
 
         # Compute Δs from baseline
         ds = self._add_ds(r, bsln_result)
@@ -832,7 +822,7 @@ class NMStatFuncFWHM(NMStatFunc):
         extra0: dict[str, Any] = {"p0": self._p0}
         if w:
             extra0["warning"] = w
-        r0 = run_stat(data, flevel1, f, x0, peak_x, xclip, ignore_nans,
+        r0 = run_stat(data, flevel1, f, x0, peak_x, ignore_nans,
                       **extra0)
         r0_error = "x" not in r0 or badvalue(r0["x"])
         if r0_error:
@@ -842,7 +832,7 @@ class NMStatFuncFWHM(NMStatFunc):
         extra1: dict[str, Any] = {"p1": self._p1}
         if w:
             extra1["warning"] = w
-        r1 = run_stat(data, flevel2, f, peak_x, x1, xclip, ignore_nans,
+        r1 = run_stat(data, flevel2, f, peak_x, x1, ignore_nans,
                       **extra1)
         r1_error = "x" not in r1 or badvalue(r1["x"])
 

--- a/pyneuromatic/analysis/nm_stat_utilities.py
+++ b/pyneuromatic/analysis/nm_stat_utilities.py
@@ -313,7 +313,6 @@ def stat(
     func: dict,
     x0: float = -math.inf,
     x1: float = math.inf,
-    xclip: bool = False,  # if x0|x1 OOB, clip to data x-scale limits
     ignore_nans: bool = False,
     results: dict | None = None
 ) -> dict:
@@ -339,10 +338,10 @@ def stat(
               no extra keys; returns the sample at x0 or x1 index.
             - count / count_nans / count_infs:
               no extra keys; values come from n, nans, infs in results.
-        x0: Left x-axis bound of the analysis window (default: -inf = start).
-        x1: Right x-axis bound of the analysis window (default: +inf = end).
-        xclip: If True, out-of-bounds x0/x1 are clipped to the data x-scale
-            limits. If False, out-of-bounds values cause an error in results.
+        x0: Left x-axis bound of the analysis window (default: -inf = start of data).
+        x1: Right x-axis bound of the analysis window (default: +inf = end of data).
+            Use -inf/+inf to span the full data range. Finite values that fall
+            outside the data x-scale will return None for i0/i1 (error result).
         ignore_nans: If True, NaN values are excluded from calculations.
         results: Optional dict to populate. Created as empty dict if None.
 
@@ -407,8 +406,8 @@ def stat(
     xunits = data.xscale.units
     yunits = data.yscale.units
 
-    i0 = data.get_xindex(x0, clip=xclip)
-    i1 = data.get_xindex(x1, clip=xclip)
+    i0 = data.get_xindex(x0)
+    i1 = data.get_xindex(x1)
 
     results["i0"] = i0
     results["i1"] = i1

--- a/pyneuromatic/analysis/nm_stat_win.py
+++ b/pyneuromatic/analysis/nm_stat_win.py
@@ -459,8 +459,7 @@ class NMStatWin:
         """List of result dicts from the most recent ``compute()`` call."""
         return self.__results
 
-    def _run_stat(self, data, func, id_str, x0, x1, xclip, ignore_nans,
-                  **extra):
+    def _run_stat(self, data, func, id_str, x0, x1, ignore_nans, **extra):
         """Create a result dict, append it to results, and call stat().
 
         Args:
@@ -470,7 +469,6 @@ class NMStatWin:
                 ``"main"``, or a func name for intermediate pipeline steps).
             x0: Left x-boundary for this stat call.
             x1: Right x-boundary for this stat call.
-            xclip: If True, clip data to [x0, x1].
             ignore_nans: If True, exclude NaN values.
             **extra: Additional key-value pairs stored in the result dict
                 (e.g. ``p0``, ``p1``, ``warning``).
@@ -484,14 +482,12 @@ class NMStatWin:
         r["x0"] = x0
         r["x1"] = x1
         self.__results.append(r)
-        stat(data, func, x0=x0, x1=x1, xclip=xclip,
-             ignore_nans=ignore_nans, results=r)
+        stat(data, func, x0=x0, x1=x1, ignore_nans=ignore_nans, results=r)
         return r
 
     def compute(
         self,
         data: NMData,
-        xclip: bool = False,  # if x0|x1 OOB, clip to data x-scale limits
         ignore_nans: bool = False,
         quiet: bool = nmc.QUIET
     ) -> list:
@@ -503,7 +499,6 @@ class NMStatWin:
 
         Args:
             data: NMData object to analyse.
-            xclip: If True, clip data to [x0, x1] before computing stats.
             ignore_nans: If True, exclude NaN values from computations.
             quiet: If True, suppress history logging.
 
@@ -529,9 +524,6 @@ class NMStatWin:
         if data is None or self.__func is None:
             return self.__results
 
-        if not isinstance(xclip, bool):
-            xclip = False
-
         if not isinstance(ignore_nans, bool):
             ignore_nans = True
 
@@ -541,7 +533,7 @@ class NMStatWin:
             self.__func.validate_baseline(self.__bsln_func.get("name"))
             bsln_result = self._run_stat(
                 data, self.__bsln_func.copy(), "bsln",
-                self.__bsln_x0, self.__bsln_x1, xclip, ignore_nans
+                self.__bsln_x0, self.__bsln_x1, ignore_nans
             )
         elif self.__func.needs_baseline:
             raise RuntimeError(
@@ -549,7 +541,7 @@ class NMStatWin:
             )
 
         self.__func.compute(
-            data, self.__x0, self.__x1, xclip, ignore_nans,
+            data, self.__x0, self.__x1, ignore_nans,
             self._run_stat, bsln_result
         )
 

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -46,8 +46,6 @@ class NMToolStatsConfig(NMToolConfig):
     Parameters:
         ignore_nans: If True, use NaN-ignoring numpy functions (e.g.
             ``np.nanmean``).  Defaults to True.
-        xclip: If True, clip x0/x1 boundaries to the data x-scale limits.
-            Defaults to True.
         results_to_history: If True, print results to history log after run.
             Defaults to False.
         results_to_cache: If True, save results to NMFolder tool-results cache.
@@ -59,7 +57,6 @@ class NMToolStatsConfig(NMToolConfig):
     _TOML_TYPE = "stats_config"
     _schema = {
         "ignore_nans":        {"type": bool, "default": True},
-        "xclip":              {"type": bool, "default": True},
         "overwrite":          {"type": bool, "default": False},
         "results_to_history": {"type": bool, "default": False},
         "results_to_cache":   {"type": bool, "default": True},
@@ -78,7 +75,6 @@ class NMToolStats(NMTool):
 
     Attributes:
         windows: Container of NMStatWin objects (auto-named w0, w1, …).
-        xclip: If True, clip x0/x1 boundaries to the data x-scale limits.
         ignore_nans: If True, use NaN-ignoring numpy functions (e.g.
             ``np.nanmean``).
         results_to_history: If True, print results to history log after run.
@@ -92,11 +88,6 @@ class NMToolStats(NMTool):
 
         self.__win_container = NMStatWinContainer(nm_path="%s.windows" % self._name)
         self.__win_container.new()
-
-        self.__xclip = True
-        # if x0|x1 OOB, clip to data x-scale limits
-        # if x0 = -math.inf, then x0 will be clipped to smallest xvalue
-        # if x1 = math.inf, then x1 will be clipped to largest xvalue
 
         self.__ignore_nans = True
         # NumPy array analysis
@@ -123,35 +114,6 @@ class NMToolStats(NMTool):
     def windows(self) -> NMStatWinContainer:
         """Return the container of NMStatWin objects for this tool."""
         return self.__win_container
-
-    @property
-    def xclip(self) -> bool:
-        """Return True if x0/x1 boundaries are clipped to data x-scale limits."""
-        return self.__xclip
-
-    @xclip.setter
-    def xclip(self, xclip: bool) -> None:
-        return self._xclip_set(xclip)
-
-    def _xclip_set(
-        self,
-        xclip: bool,
-        quiet: bool = nmc.QUIET
-    ) -> None:
-        """Set xclip flag.
-
-        Args:
-            xclip: If True, clip x0/x1 to the data x-scale limits when
-                computing stats windows.
-            quiet: If True, suppress history log output.
-        """
-        if isinstance(xclip, bool):
-            self.__xclip = xclip
-        else:
-            e = nmu.type_error_str(xclip, "xclip", "boolean")
-            raise TypeError(e)
-        nmh.history("set xclip=%s" % xclip, quiet=quiet)
-        nmch.add_nm_command("%s.xclip = %r" % (self._name, self.__xclip))
 
     @property
     def ignore_nans(self) -> bool:
@@ -321,8 +283,7 @@ class NMToolStats(NMTool):
             self.windows.selected_name = w.name
             if not w.on:
                 continue
-            w.compute(self.data, xclip=self.__xclip,
-                      ignore_nans=self.__ignore_nans)
+            w.compute(self.data, ignore_nans=self.__ignore_nans)
             # results saved to w.results
             if not w.results:
                 continue

--- a/tests/test_analysis/test_nm_stat_func.py
+++ b/tests/test_analysis/test_nm_stat_func.py
@@ -97,7 +97,7 @@ class TestNMStatFunc(unittest.TestCase):
     def test_compute_raises_not_implemented(self):
         t = nmsf.NMStatFunc("test")
         with self.assertRaises(NotImplementedError):
-            t.compute(None, 0, 1, False, False, None, {})
+            t.compute(None, 0, 1, False, None, {})
 
 
 # =========================================================================

--- a/tests/test_analysis/test_nm_stat_igor.py
+++ b/tests/test_analysis/test_nm_stat_igor.py
@@ -145,7 +145,7 @@ class TestIgorWaveStats(unittest.TestCase):
 
     def _stat(self, name, **kwargs):
         return nsmm.stat(_DATA, {"name": name}, x0=_X0, x1=_X1,
-                         xclip=True, **kwargs)
+                         **kwargs)
 
     def test_wave_loaded(self):
         self.assertIsNotNone(_DATA)
@@ -217,22 +217,22 @@ class TestIgorWaveStats(unittest.TestCase):
     def test_mean_at_max(self):
         # n_mean=500 determined by matching Igor minAvg/maxAvg to 3 decimal places
         r = nsmm.stat(_DATA, {"name": "mean@max", "n_mean": _N_MEAN},
-                      x0=_X0, x1=_X1, xclip=True)
+                      x0=_X0, x1=_X1)
         self.assertAlmostEqual(r["s"], _IGOR_R0["maxAvg"], places=3)
 
     def test_mean_at_max_location(self):
         r = nsmm.stat(_DATA, {"name": "mean@max", "n_mean": _N_MEAN},
-                      x0=_X0, x1=_X1, xclip=True)
+                      x0=_X0, x1=_X1)
         self.assertAlmostEqual(r["x"], _IGOR_R0["maxAvgLoc"], places=1)
 
     def test_mean_at_min(self):
         r = nsmm.stat(_DATA, {"name": "mean@min", "n_mean": _N_MEAN},
-                      x0=_X0, x1=_X1, xclip=True)
+                      x0=_X0, x1=_X1)
         self.assertAlmostEqual(r["s"], _IGOR_R0["minAvg"], places=3)
 
     def test_mean_at_min_location(self):
         r = nsmm.stat(_DATA, {"name": "mean@min", "n_mean": _N_MEAN},
-                      x0=_X0, x1=_X1, xclip=True)
+                      x0=_X0, x1=_X1)
         self.assertAlmostEqual(r["x"], _IGOR_R0["minAvgLoc"], places=1)
 
     def test_no_nans(self):
@@ -398,7 +398,7 @@ class TestSineWaveRiseTime(unittest.TestCase):
         w.func = win["func"]
         w.x0 = win["x0"]
         w.x1 = win["x1"]
-        return w.compute(_SINE_DATA, xclip=True)
+        return w.compute(_SINE_DATA)
 
     def test_risetime_delta_x(self):
         # TAU/π * (arcsin(0.9) - arcsin(0.1)) ≈ 6.491 ms
@@ -457,7 +457,7 @@ class TestSineWaveFallTime(unittest.TestCase):
         w.func = win["func"]
         w.x0 = win["x0"]
         w.x1 = win["x1"]
-        return w.compute(_SINE_DATA, xclip=True)
+        return w.compute(_SINE_DATA)
 
     def test_falltime_delta_x(self):
         # Same magnitude as rise time (symmetric half-sine) ≈ 6.491 ms
@@ -518,7 +518,7 @@ class TestSineWaveDecayTime(unittest.TestCase):
         w.func = win["func"]
         w.x0 = win["x0"]
         w.x1 = win["x1"]
-        return w.compute(_SINE_DATA, xclip=True)
+        return w.compute(_SINE_DATA)
 
     def test_decaytime_delta_x(self):
         # Time from peak to 36.79% (≈1/e) level ≈ 7.6015 ms (Igor NM value)
@@ -558,7 +558,7 @@ class TestSineWaveFWHM(unittest.TestCase):
         w.func = win["func"]
         w.x0 = win["x0"]
         w.x1 = win["x1"]
-        return w.compute(_SINE_DATA, xclip=True)
+        return w.compute(_SINE_DATA)
 
     def test_fwhm_value(self):
         # 2 * TAU / 3 = 40/3 ≈ 13.333 ms

--- a/tests/test_analysis/test_nm_stat_utilities.py
+++ b/tests/test_analysis/test_nm_stat_utilities.py
@@ -234,18 +234,19 @@ class TestStat(unittest.TestCase):
             nsmm.stat(self.data, {"name": "unknownfunc"})
 
     def test_i0_out_of_bounds(self):
-        r = nsmm.stat(self.datanan, {"name": "max"}, x0=-100, xclip=False)
+        r = nsmm.stat(self.datanan, {"name": "max"}, x0=-100)
         self.assertIsNone(r["i0"])
         self.assertIn("error", r)
 
     def test_i1_out_of_bounds(self):
-        r = nsmm.stat(self.datanan, {"name": "max"}, x1=200, xclip=False)
+        r = nsmm.stat(self.datanan, {"name": "max"}, x1=200)
         self.assertIsNone(r["i1"])
         self.assertIn("error", r)
 
-    def test_max_xclip_result_keys(self):
+    def test_full_range_via_inf(self):
+        # -inf/+inf snap to data boundaries without requiring xclip
         r = nsmm.stat(self.datanan, {"name": "max"},
-                      x0=-100, x1=200, xclip=True)
+                      x0=-math.inf, x1=math.inf)
         keys = ["data", "i0", "i1", "n", "nans", "infs",
                 "s", "sunits", "i", "x", "xunits"]
         self.assertEqual(list(r.keys()), keys)

--- a/tests/test_analysis/test_nm_stat_win.py
+++ b/tests/test_analysis/test_nm_stat_win.py
@@ -50,7 +50,7 @@ class TestNMStatWin(unittest.TestCase):
             "on": True,
             "func": {"name": "mean"},
             "x0": 0,
-            "x1": n + 10,
+            "x1": math.inf,
             "transform": None,
             "bsln_on": True,
             "bsln_func": {"name": "mean"},
@@ -61,7 +61,7 @@ class TestNMStatWin(unittest.TestCase):
             "on": True,
             "func": {"name": "max"},
             "x0": 0,
-            "x1": n + 10,
+            "x1": math.inf,
             "transform": None,
             "bsln_on": True,
             "bsln_func": {"name": "mean"},
@@ -320,7 +320,7 @@ class TestNMStatWin(unittest.TestCase):
                 self.w0.compute(b)
 
     def test_compute_max_result_keys(self):
-        r = self.w1.compute(self.datanan, xclip=True, ignore_nans=True)
+        r = self.w1.compute(self.datanan, ignore_nans=True)
         self.assertEqual(len(r), 2)
         self.assertEqual(r[0]["id"], "bsln")
         self.assertEqual(r[1]["id"], "main")
@@ -333,41 +333,43 @@ class TestNMStatWin(unittest.TestCase):
             self.assertIn(k, r[1])
 
     def test_compute_delta_s(self):
-        r = self.w1.compute(self.datanan, xclip=True, ignore_nans=True)
+        r = self.w1.compute(self.datanan, ignore_nans=True)
         if r[1]["Δs"]:
             self.assertAlmostEqual(r[1]["Δs"], r[1]["s"] - r[0]["s"])
 
     def test_compute_x1_out_of_bounds(self):
-        r = self.w1.compute(self.datanan, xclip=False, ignore_nans=True)
+        # finite x1 beyond data range → i1=None, error result (no clip)
+        self.w1.x1 = 200
+        r = self.w1.compute(self.datanan, ignore_nans=True)
         self.assertIsNone(r[1]["i1"])
         self.assertIn("error", r[1])
 
     def test_compute_nans_not_ignored(self):
-        r = self.w1.compute(self.datanan, xclip=True, ignore_nans=False)
+        r = self.w1.compute(self.datanan, ignore_nans=False)
         self.assertTrue(np.isnan(r[0]["s"]))
         self.assertTrue(np.isnan(r[1]["s"]))
         self.assertTrue(np.isnan(r[1]["Δs"]))
 
     def test_compute_mean_at_max_warning(self):
         self.w1.func = {"name": "mean@max", "n_mean": 0}
-        r = self.w1.compute(self.datanan, xclip=True, ignore_nans=True)
+        r = self.w1.compute(self.datanan, ignore_nans=True)
         self.assertIn("warning", r[1]["func"])
 
     def test_compute_mean_at_max_with_n_mean(self):
         self.w1.func = {"name": "mean@max", "n_mean": 5}
-        r = self.w1.compute(self.datanan, xclip=True, ignore_nans=True)
+        r = self.w1.compute(self.datanan, ignore_nans=True)
         self.assertEqual(r[1]["func"]["name"], "mean@max")
         self.assertEqual(r[1]["func"]["n_mean"], 5)
 
     def test_compute_mean_at_min(self):
         self.w1.func = {"name": "mean@min", "n_mean": 5}
-        r = self.w1.compute(self.datanan, xclip=True, ignore_nans=True)
+        r = self.w1.compute(self.datanan, ignore_nans=True)
         self.assertEqual(r[1]["func"]["name"], "mean@min")
 
     def test_compute_level_ylevel(self):
         ylevel = 10
         self.w1.func = {"name": "level+", "ylevel": ylevel}
-        r = self.w1.compute(self.data, xclip=True, ignore_nans=True)
+        r = self.w1.compute(self.data, ignore_nans=True)
         self.assertEqual(len(r), 2)
         self.assertIn("ylevel", r[1]["func"])
         self.assertEqual(r[1]["func"]["ylevel"], ylevel)
@@ -377,14 +379,14 @@ class TestNMStatWin(unittest.TestCase):
         self.w1.bsln_on = True
         with self.assertRaises(RuntimeError):
             self.w1.bsln_func = "mean"  # need mean+std
-            self.w1.compute(self.data, xclip=True, ignore_nans=True)
+            self.w1.compute(self.data, ignore_nans=True)
 
     def test_compute_level_nstd(self):
         n_std = 2
         self.w1.func = {"name": "level+", "n_std": n_std}
         self.w1.bsln_on = True
         self.w1.bsln_func = "mean+std"
-        r = self.w1.compute(self.data, xclip=True, ignore_nans=True)
+        r = self.w1.compute(self.data, ignore_nans=True)
         self.assertIn("ylevel", r[1]["func"])
         self.assertAlmostEqual(
             round(r[1]["Δs"] * 1000),
@@ -394,7 +396,7 @@ class TestNMStatWin(unittest.TestCase):
         n_std = -2
         self.w1.func = {"name": "level-", "n_std": n_std}
         self.w1.bsln_func = "mean+std"
-        r = self.w1.compute(self.data, xclip=True, ignore_nans=True)
+        r = self.w1.compute(self.data, ignore_nans=True)
         self.assertAlmostEqual(
             round(r[1]["Δs"] * 1000),
             round(n_std * r[0]["std"] * 1000))
@@ -405,7 +407,7 @@ class TestNMStatWin(unittest.TestCase):
         self.w1.x0 = -math.inf
         self.w1.x1 = math.inf
         self.w1.func = {"name": "decaytime+", "p0": 36}
-        r = self.w1.compute(self.data, xclip=True, ignore_nans=True)
+        r = self.w1.compute(self.data, ignore_nans=True)
         self.assertEqual(r[0]["id"], "bsln")
         self.assertEqual(r[1]["id"], "decaytime+")
         self.assertIn("Δs", r[1])
@@ -431,17 +433,17 @@ class TestNMStatWin(unittest.TestCase):
 
             with self.assertRaises(RuntimeError):
                 self.w1.bsln_on = False
-                self.w1.compute(self.data, xclip=True)
+                self.w1.compute(self.data)
 
             self.w1.bsln_on = True
-            r = self.w1.compute(self.datanan, xclip=True, ignore_nans=False)
+            r = self.w1.compute(self.datanan, ignore_nans=False)
             self.assertEqual(len(r), 2)
             self.assertTrue(math.isnan(r[1]["Δs"]))
             self.assertEqual(r[0]["id"], "bsln")
             peak = "max" if "+" in f else "min"
             self.assertEqual(r[1]["func"]["name"], peak)
 
-            r = self.w1.compute(self.data, xclip=True, ignore_nans=True)
+            r = self.w1.compute(self.data, ignore_nans=True)
             if math.isnan(r[1]["Δs"]):
                 continue
             self.assertAlmostEqual(r[1]["Δs"], r[1]["s"] - r[0]["s"])

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -939,9 +939,6 @@ class TestNMToolStatsConfig(unittest.TestCase):
     def test_ignore_nans_default(self):
         self.assertTrue(self.cfg.ignore_nans)
 
-    def test_xclip_default(self):
-        self.assertTrue(self.cfg.xclip)
-
     def test_results_to_history_default(self):
         self.assertFalse(self.cfg.results_to_history)
 
@@ -983,7 +980,6 @@ class TestNMToolStatsConfig(unittest.TestCase):
     def test_stats_tool_config_defaults(self):
         t = nms.NMToolStats()
         self.assertTrue(t.config.ignore_nans)
-        self.assertTrue(t.config.xclip)
 
     def test_overwrite_default(self):
         self.assertFalse(self.cfg.overwrite)
@@ -998,9 +994,12 @@ class TestNMToolStatsConfig(unittest.TestCase):
 
     def test_to_dict_contains_all_keys(self):
         d = self.cfg.to_dict()
-        for key in ("ignore_nans", "xclip", "overwrite",
+        for key in ("ignore_nans", "overwrite",
                     "results_to_history", "results_to_cache", "results_to_numpy"):
             self.assertIn(key, d)
+
+    def test_to_dict_does_not_contain_xclip(self):
+        self.assertNotIn("xclip", self.cfg.to_dict())
 
 
 class TestNMToolStatsOverwrite(unittest.TestCase):
@@ -1353,13 +1352,6 @@ class TestNMToolStatsCommandHistory(unittest.TestCase):
 
     # ------------------------------------------------------------------
     # NMToolStats tool-level flag setters
-
-    def test_xclip_setter_logs(self):
-        self._ch.clear()
-        self.tool.xclip = True
-        cmd = self._ch.buffer[0]['command']
-        self.assertIn("stats.xclip", cmd)
-        self.assertIn("True", cmd)
 
     def test_ignore_nans_setter_logs(self):
         self._ch.clear()


### PR DESCRIPTION
## Summary

Closes #286.

`xclip=True` was the only meaningful behaviour: `±inf` already snaps to
data boundaries in `get_xindex()` without any clipping flag, and a finite
out-of-bounds value should return `None` (error result) rather than silently
clipping to the data edge. The parameter added configuration complexity
without benefit.

### Removed from
- `NMToolStatsConfig._schema` and `NMToolStats` (property, setter,
  `_xclip_set()`, `__init__` attribute)
- `NMStatWin.compute()` and `_run_stat()`
- All `NMStatFunc` subclass `compute()` signatures (`nm_stat_func.py`)
- `nm_stat_utilities.stat()`

### Convention going forward
| x0 / x1 value | Behaviour |
|---|---|
| `-inf` / `+inf` | Snaps to first / last sample (via `get_xindex`) |
| Finite, in-range | Resolved to nearest sample index |
| Finite, out-of-range | Returns `None` → error result |

### Tests
- `test_nm_tool_stats.py` — removed `xclip` default and setter tests; added
  `test_to_dict_does_not_contain_xclip`
- `test_nm_stat_win.py` — window setUp changed from `x1=n+10` to
  `x1=math.inf`; `test_compute_x1_out_of_bounds` sets a finite OOB `x1`
  explicitly
- `test_nm_stat_utilities.py` — `test_max_xclip_result_keys` replaced by
  `test_full_range_via_inf`
- `test_nm_stat_igor.py` and `test_nm_stat_func.py` — `xclip` args dropped

## Test plan
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_stats.py -q`
- [ ] `python3 -m pytest tests/test_analysis/test_nm_stat_win.py -q`
- [ ] `python3 -m pytest tests/test_analysis/test_nm_stat_utilities.py -q`
- [ ] `python3 -m pytest tests/test_analysis/test_nm_stat_igor.py -q`
- [ ] `python3 -m pytest -q`

