### PR TITLE
test(analysis): move shared output flag tests to NMTool base test file

### DIFF
--- a/pyneuromatic/analysis/nm_tool.py
+++ b/pyneuromatic/analysis/nm_tool.py
@@ -22,6 +22,10 @@ from __future__ import annotations
 
 import datetime
 
+import pyneuromatic.core.nm_history as nmh
+import pyneuromatic.core.nm_command_history as nmch
+import pyneuromatic.core.nm_configurations as nmc
+import pyneuromatic.core.nm_utilities as nmu
 from pyneuromatic.core.nm_object import NMObject
 from pyneuromatic.core.nm_folder import NMFolder
 from pyneuromatic.core.nm_data import NMData
@@ -60,6 +64,13 @@ class NMTool:
         self._run_meta: dict = {}
         self._config: NMToolConfig | None = None
 
+        # Output flags — conservative defaults; subclasses init from config.
+        self._ignore_nans: bool = True
+        self._overwrite: bool = False
+        self._results_to_history: bool = False
+        self._results_to_cache: bool = True
+        self._results_to_numpy: bool = False
+
     @property
     def name(self) -> str:
         """Tool name used in command history (e.g. ``'stats'``, ``'tool_main'``)."""
@@ -69,6 +80,92 @@ class NMTool:
     def config(self) -> NMToolConfig | None:
         """Tool configuration object, or None if the tool has no config."""
         return self._config
+
+    @property
+    def ignore_nans(self) -> bool:
+        """If True, use NaN-ignoring numpy functions (e.g. ``np.nanmean``)."""
+        return self._ignore_nans
+
+    @ignore_nans.setter
+    def ignore_nans(self, value: bool) -> None:
+        self._ignore_nans_set(value)
+
+    def _ignore_nans_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
+        self._ignore_nans = value
+        nmh.history("set ignore_nans=%s" % value, quiet=quiet)
+        nmch.add_nm_command("%s.ignore_nans = %r" % (self._name, self._ignore_nans))
+
+    @property
+    def overwrite(self) -> bool:
+        """If True, reuse the existing toolfolder (clearing it); otherwise create a new one."""
+        return self._overwrite
+
+    @overwrite.setter
+    def overwrite(self, value: bool) -> None:
+        self._overwrite_set(value)
+
+    def _overwrite_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "overwrite", "boolean"))
+        self._overwrite = value
+        nmh.history("set overwrite=%s" % value, quiet=quiet)
+        nmch.add_nm_command("%s.overwrite = %r" % (self._name, self._overwrite))
+
+    @property
+    def results_to_history(self) -> bool:
+        """If True, print results to the history log after run."""
+        return self._results_to_history
+
+    @results_to_history.setter
+    def results_to_history(self, value: bool) -> None:
+        self._results_to_history_set(value)
+
+    def _results_to_history_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "results_to_history", "boolean"))
+        self._results_to_history = value
+        nmh.history("set results_to_history=%s" % value, quiet=quiet)
+        nmch.add_nm_command(
+            "%s.results_to_history = %r" % (self._name, self._results_to_history)
+        )
+
+    @property
+    def results_to_cache(self) -> bool:
+        """If True, save results to the NMFolder tool-results cache after run."""
+        return self._results_to_cache
+
+    @results_to_cache.setter
+    def results_to_cache(self, value: bool) -> None:
+        self._results_to_cache_set(value)
+
+    def _results_to_cache_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "results_to_cache", "boolean"))
+        self._results_to_cache = value
+        nmh.history("set results_to_cache=%s" % value, quiet=quiet)
+        nmch.add_nm_command(
+            "%s.results_to_cache = %r" % (self._name, self._results_to_cache)
+        )
+
+    @property
+    def results_to_numpy(self) -> bool:
+        """If True, write results as NMData arrays in a toolfolder after run."""
+        return self._results_to_numpy
+
+    @results_to_numpy.setter
+    def results_to_numpy(self, value: bool) -> None:
+        self._results_to_numpy_set(value)
+
+    def _results_to_numpy_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "results_to_numpy", "boolean"))
+        self._results_to_numpy = value
+        nmh.history("set results_to_numpy=%s" % value, quiet=quiet)
+        nmch.add_nm_command(
+            "%s.results_to_numpy = %r" % (self._name, self._results_to_numpy)
+        )
 
     # Read-only convenience properties for accessing selection
     @property

--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -106,16 +106,17 @@ class NMToolSpike(NMTool):
         super().__init__(name="spike")
         self._config = NMToolSpikeConfig()
 
+        # Initialize output flags from config defaults
+        self._ignore_nans = self._config.ignore_nans
+        self._overwrite = self._config.overwrite
+        self._results_to_history = self._config.results_to_history
+        self._results_to_cache = self._config.results_to_cache
+        self._results_to_numpy = self._config.results_to_numpy
+
         self.__ylevel: float = 0.0
         self.__func_name: str = "level+"
         self.__x0: float = -math.inf
         self.__x1: float = math.inf
-        self.__ignore_nans: bool = True
-        self.__overwrite: bool = True
-
-        self.__results_to_history: bool = False
-        self.__results_to_cache: bool = True
-        self.__results_to_numpy: bool = True
 
         # Internal run state — reset by run_init()
         self._spike_times: list[np.ndarray] = []
@@ -211,108 +212,6 @@ class NMToolSpike(NMTool):
         nmh.history("set x1=%g" % self.__x1, quiet=quiet)
         nmch.add_nm_command("%s.x1 = %r" % (self._name, self.__x1))
 
-    @property
-    def ignore_nans(self) -> bool:
-        """If True (default), detect crossings across NaN gaps."""
-        return self.__ignore_nans
-
-    @ignore_nans.setter
-    def ignore_nans(self, value: bool) -> None:
-        self._ignore_nans_set(value)
-
-    def _ignore_nans_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "ignore_nans", "boolean"))
-        self.__ignore_nans = value
-        nmh.history("set ignore_nans=%s" % value, quiet=quiet)
-        nmch.add_nm_command("%s.ignore_nans = %r" % (self._name, self.__ignore_nans))
-
-    @property
-    def overwrite(self) -> bool:
-        """If True, reuse ``{base}_0`` subfolder (clearing old arrays) on each run.
-
-        If False, each run creates a new numbered subfolder
-        (``{base}_0``, ``{base}_1``, …) preserving previous results.
-        """
-        return self.__overwrite
-
-    @overwrite.setter
-    def overwrite(self, value: bool) -> None:
-        self._overwrite_set(value)
-
-    def _overwrite_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "overwrite", "boolean"))
-        self.__overwrite = value
-        nmh.history("set overwrite=%s" % value, quiet=quiet)
-        nmch.add_nm_command("%s.overwrite = %r" % (self._name, self.__overwrite))
-
-    @property
-    def results_to_history(self) -> bool:
-        """If True, print spike counts to the history log after each run."""
-        return self.__results_to_history
-
-    @results_to_history.setter
-    def results_to_history(self, value: bool) -> None:
-        self._results_to_history_set(value)
-
-    def _results_to_history_set(
-        self, value: bool, quiet: bool = nmc.QUIET
-    ) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(
-                nmu.type_error_str(value, "results_to_history", "boolean")
-            )
-        self.__results_to_history = value
-        nmh.history("set results_to_history=%s" % value, quiet=quiet)
-        nmch.add_nm_command(
-            "%s.results_to_history = %r" % (self._name, self.__results_to_history)
-        )
-
-    @property
-    def results_to_cache(self) -> bool:
-        """If True, save spike times dict to folder.toolresults after each run."""
-        return self.__results_to_cache
-
-    @results_to_cache.setter
-    def results_to_cache(self, value: bool) -> None:
-        self._results_to_cache_set(value)
-
-    def _results_to_cache_set(
-        self, value: bool, quiet: bool = nmc.QUIET
-    ) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(
-                nmu.type_error_str(value, "results_to_cache", "boolean")
-            )
-        self.__results_to_cache = value
-        nmh.history("set results_to_cache=%s" % value, quiet=quiet)
-        nmch.add_nm_command(
-            "%s.results_to_cache = %r" % (self._name, self.__results_to_cache)
-        )
-
-    @property
-    def results_to_numpy(self) -> bool:
-        """If True, write SP_ NMData arrays to a Spike subfolder after each run."""
-        return self.__results_to_numpy
-
-    @results_to_numpy.setter
-    def results_to_numpy(self, value: bool) -> None:
-        self._results_to_numpy_set(value)
-
-    def _results_to_numpy_set(
-        self, value: bool, quiet: bool = nmc.QUIET
-    ) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(
-                nmu.type_error_str(value, "results_to_numpy", "boolean")
-            )
-        self.__results_to_numpy = value
-        nmh.history("set results_to_numpy=%s" % value, quiet=quiet)
-        nmch.add_nm_command(
-            "%s.results_to_numpy = %r" % (self._name, self.__results_to_numpy)
-        )
-
     # ------------------------------------------------------------------
     # Lifecycle
 
@@ -347,7 +246,7 @@ class NMToolSpike(NMTool):
             func_name=self.__func_name,
             x0=self.__x0,
             x1=self.__x1,
-            ignore_nans=self.__ignore_nans,
+            ignore_nans=self._ignore_nans,
         )
         self._spike_times.append(x_times)
         self._epoch_names.append(data.name)
@@ -365,12 +264,12 @@ class NMToolSpike(NMTool):
         """
         if not self._epoch_names:
             return True
-        if self.__results_to_history:
-            self._results_to_history()
-        if self.__results_to_cache:
-            self._results_to_cache()
-        if self.__results_to_numpy:
-            self._results_to_numpy()
+        if self._results_to_history:
+            self._write_results_to_history()
+        if self._results_to_cache:
+            self._write_results_to_cache()
+        if self._results_to_numpy:
+            self._write_results_to_numpy()
         return True
 
     # ------------------------------------------------------------------
@@ -382,7 +281,7 @@ class NMToolSpike(NMTool):
         if notes is not None:
             notes.add(text)
 
-    def _results_to_numpy(self) -> NMToolFolder | None:
+    def _write_results_to_numpy(self) -> NMToolFolder | None:
         """Write SP_ NMData arrays to a new Spike subfolder.
 
         Creates a subfolder named ``spike_{dataseries}_{channel}_N``
@@ -397,7 +296,7 @@ class NMToolSpike(NMTool):
         """
         if not isinstance(self.folder, NMFolder):
             return None
-        self._toolfolder = self._make_toolfolder("Spike", overwrite=self.__overwrite)
+        self._toolfolder = self._make_toolfolder("Spike", overwrite=self._overwrite)
         f = self._toolfolder
         for name, times in zip(self._epoch_names, self._spike_times):
             d = f.data.new(
@@ -425,7 +324,7 @@ class NMToolSpike(NMTool):
         )
         return f
 
-    def _results_to_cache(self) -> None:
+    def _write_results_to_cache(self) -> None:
         """Save spike times dict to folder.toolresults."""
         if not isinstance(self.folder, NMFolder):
             return
@@ -435,7 +334,7 @@ class NMToolSpike(NMTool):
         }
         self.folder.toolresults_save("spike", results)
 
-    def _results_to_history(self) -> None:
+    def _write_results_to_history(self) -> None:
         """Print spike counts to the history log."""
         for name, times in zip(self._epoch_names, self._spike_times):
             nmh.history("spike: %s: %d spike(s)" % (name, len(times)))
@@ -870,7 +769,7 @@ class NMToolSpike(NMTool):
                     "units": source.yscale.units,
                 }
                 if out_folder is None:
-                    out_folder = self._make_toolfolder("Spike", overwrite=self.__overwrite)
+                    out_folder = self._make_toolfolder("Spike", overwrite=self._overwrite)
                 array_name = "SPK_%s%d" % (ch_char, spike_counter)
                 d = out_folder.data.new(
                     array_name,
@@ -975,7 +874,7 @@ class NMToolSpike(NMTool):
             spike_times = self._spike_times
             detected_xunits = self._detected_xunits
             if self._toolfolder is None:
-                self._toolfolder = self._make_toolfolder("Spike", overwrite=self.__overwrite)
+                self._toolfolder = self._make_toolfolder("Spike", overwrite=self._overwrite)
             out_folder = self._toolfolder
         all_times = np.concatenate(spike_times)
         if len(all_times) == 0:
@@ -1100,7 +999,7 @@ class NMToolSpike(NMTool):
         else:
             detected_xunits = self._detected_xunits
             if self._toolfolder is None:
-                self._toolfolder = self._make_toolfolder("Spike", overwrite=self.__overwrite)
+                self._toolfolder = self._make_toolfolder("Spike", overwrite=self._overwrite)
             out_folder = self._toolfolder
         lo_isi = float(min_isi) if min_isi is not None else None
         hi_isi = float(max_isi) if max_isi is not None else None

--- a/pyneuromatic/analysis/nm_tool_stats.py
+++ b/pyneuromatic/analysis/nm_tool_stats.py
@@ -86,168 +86,22 @@ class NMToolStats(NMTool):
         super().__init__(name="stats")
         self._config = NMToolStatsConfig()
 
+        # Initialize output flags from config defaults
+        self._ignore_nans = self._config.ignore_nans
+        self._overwrite = self._config.overwrite
+        self._results_to_history = self._config.results_to_history
+        self._results_to_cache = self._config.results_to_cache
+        self._results_to_numpy = self._config.results_to_numpy
+
         self.__win_container = NMStatWinContainer(nm_path="%s.windows" % self._name)
         self.__win_container.new()
 
-        self.__ignore_nans = True
-        # NumPy array analysis
-        # for example: if ignore_nans,
-        # then np.nanmean(array) else np.mean(array)
-
         self.__results: dict[str, list[Any]] = {}
-        # {"w0": [ [{}, {}], [{}, {}]... ],  stat win0
-        #  "w1": [ [{}, {}], [{}, {}]... ],  stat win1
-        #  ...}
-        # for each stat window (e.g. "w0") there is a list
-        # containing results [{}, {}] for each data array.
-        # for each data array there is a list [{}, {}] containing
-        # results for each measure {} made for the stat window
-        # e.g. baseline, main, p0, p1, slope, etc.
-
-        self.__overwrite = False
-
-        self.__results_to_history = False
-        self.__results_to_cache = True
-        self.__results_to_numpy = False
 
     @property
     def windows(self) -> NMStatWinContainer:
         """Return the container of NMStatWin objects for this tool."""
         return self.__win_container
-
-    @property
-    def ignore_nans(self) -> bool:
-        """Return True if NaN values are excluded from calculations."""
-        return self.__ignore_nans
-
-    @ignore_nans.setter
-    def ignore_nans(self, ignore_nans: bool) -> None:
-        return self._ignore_nans_set(ignore_nans)
-
-    def _ignore_nans_set(
-        self,
-        ignore_nans: bool,
-        quiet: bool = nmc.QUIET
-    ) -> None:
-        """Set ignore_nans flag.
-
-        Args:
-            ignore_nans: If True, use NaN-ignoring numpy functions such as
-                ``np.nanmean`` instead of ``np.mean``.
-            quiet: If True, suppress history log output.
-        """
-        if isinstance(ignore_nans, bool):
-            self.__ignore_nans = ignore_nans
-        else:
-            e = nmu.type_error_str(ignore_nans, "ignore_nans", "boolean")
-            raise TypeError(e)
-        nmh.history("set ignore_nans=%s" % ignore_nans, quiet=quiet)
-        nmch.add_nm_command("%s.ignore_nans = %r" % (self._name, self.__ignore_nans))
-
-    @property
-    def results_to_history(self) -> bool:
-        """Return True if results are printed to the history log after run."""
-        return self.__results_to_history
-
-    @results_to_history.setter
-    def results_to_history(self, value: bool) -> None:
-        self._results_to_history_set(value)
-
-    def _results_to_history_set(
-        self,
-        value: bool,
-        quiet: bool = nmc.QUIET,
-    ) -> None:
-        """Set results_to_history flag.
-
-        Args:
-            value: If True, print results to history log in run_finish().
-            quiet: If True, suppress history log output.
-        """
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "results_to_history", "boolean"))
-        self.__results_to_history = value
-        nmh.history("set results_to_history=%s" % value, quiet=quiet)
-        nmch.add_nm_command("%s.results_to_history = %r" % (self._name, self.__results_to_history))
-
-    @property
-    def results_to_cache(self) -> bool:
-        """Return True if results are saved to the NMFolder tool-results cache after run."""
-        return self.__results_to_cache
-
-    @results_to_cache.setter
-    def results_to_cache(self, value: bool) -> None:
-        self._results_to_cache_set(value)
-
-    def _results_to_cache_set(
-        self,
-        value: bool,
-        quiet: bool = nmc.QUIET,
-    ) -> None:
-        """Set results_to_cache flag.
-
-        Args:
-            value: If True, save results to NMFolder tool-results cache in
-                run_finish().
-            quiet: If True, suppress history log output.
-        """
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "results_to_cache", "boolean"))
-        self.__results_to_cache = value
-        nmh.history("set results_to_cache=%s" % value, quiet=quiet)
-        nmch.add_nm_command("%s.results_to_cache = %r" % (self._name, self.__results_to_cache))
-
-    @property
-    def results_to_numpy(self) -> bool:
-        """Return True if results are written as ST_ NMData arrays after run."""
-        return self.__results_to_numpy
-
-    @results_to_numpy.setter
-    def results_to_numpy(self, value: bool) -> None:
-        self._results_to_numpy_set(value)
-
-    def _results_to_numpy_set(
-        self,
-        value: bool,
-        quiet: bool = nmc.QUIET,
-    ) -> None:
-        """Set results_to_numpy flag.
-
-        Args:
-            value: If True, write results as ST_ NMData arrays in
-                run_finish().
-            quiet: If True, suppress history log output.
-        """
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "results_to_numpy", "boolean"))
-        self.__results_to_numpy = value
-        nmh.history("set results_to_numpy=%s" % value, quiet=quiet)
-        nmch.add_nm_command("%s.results_to_numpy = %r" % (self._name, self.__results_to_numpy))
-
-    @property
-    def overwrite(self) -> bool:
-        """If True, reuse ``{base}_0`` subfolder (clearing old arrays) on each run.
-
-        If False, each run creates a new numbered subfolder
-        (``{base}_0``, ``{base}_1``, …) preserving previous results.
-        Default False.
-        """
-        return self.__overwrite
-
-    @overwrite.setter
-    def overwrite(self, value: bool) -> None:
-        self._overwrite_set(value)
-
-    def _overwrite_set(
-        self,
-        value: bool,
-        quiet: bool = nmc.QUIET,
-    ) -> None:
-        if not isinstance(value, bool):
-            raise TypeError(nmu.type_error_str(value, "overwrite", "boolean"))
-        self.__overwrite = value
-        nmh.history("set overwrite=%s" % value, quiet=quiet)
-        nmch.add_nm_command("%s.overwrite = %r" % (self._name, self.__overwrite))
 
     def _add_note(self, data: NMData, text: str) -> None:
         """Append a note to *data*.notes if available."""
@@ -283,7 +137,7 @@ class NMToolStats(NMTool):
             self.windows.selected_name = w.name
             if not w.on:
                 continue
-            w.compute(self.data, ignore_nans=self.__ignore_nans)
+            w.compute(self.data, ignore_nans=self._ignore_nans)
             # results saved to w.results
             if not w.results:
                 continue
@@ -303,15 +157,15 @@ class NMToolStats(NMTool):
         Returns:
             True on success.
         """
-        if self.__results_to_history:
-            self._results_to_history()
-        if self.__results_to_cache:
-            self._results_to_cache()
-        if self.__results_to_numpy:
-            self._results_to_numpy()
+        if self._results_to_history:
+            self._write_results_to_history()
+        if self._results_to_cache:
+            self._write_results_to_cache()
+        if self._results_to_numpy:
+            self._write_results_to_numpy()
         return True  # ok
 
-    def _results_to_history(self, quiet: bool = False) -> None:
+    def _write_results_to_history(self, quiet: bool = False) -> None:
         """Print all results to the history log.
 
         Args:
@@ -333,7 +187,7 @@ class NMToolStats(NMTool):
                     nmh.history(str(rdict), quiet=quiet)
         return None
 
-    def _results_to_cache(self) -> int | None:
+    def _write_results_to_cache(self) -> int | None:
         """Save results to the NMFolder tool-results cache.
 
         Returns:
@@ -459,7 +313,7 @@ class NMToolStats(NMTool):
         )
         return "ST_%s_%s_%s" % (wname, safe, suffix)
 
-    def _results_to_numpy(self) -> NMToolFolder | None:
+    def _write_results_to_numpy(self) -> NMToolFolder | None:
         """Write results as ST_ NMData arrays in a new NMToolFolder.
 
         Creates a subfolder named ``Stats_{dataseries}_{channel}_{epoch_set}_N``
@@ -490,7 +344,7 @@ class NMToolStats(NMTool):
         if not self.__results:
             raise RuntimeError("there are no results to save")
 
-        f = self._make_toolfolder("Stats", overwrite=self.__overwrite)
+        f = self._make_toolfolder("Stats", overwrite=self._overwrite)
 
         for wname, vlist in self.__results.items():
             # vlist: list of lists, one inner list per data array
@@ -569,7 +423,7 @@ class NMToolStats(NMTool):
 class NMToolStats2:
     """Compute summary statistics and histograms of Stats results (ST_ arrays).
 
-    Operates on a NMToolFolder produced by NMToolStats._results_to_numpy().
+    Operates on a NMToolFolder produced by NMToolStats._write_results_to_numpy().
     All options are passed as method parameters rather than stored as instance
     state.
 

--- a/tests/test_analysis/test_nm_tool.py
+++ b/tests/test_analysis/test_nm_tool.py
@@ -873,6 +873,113 @@ class TestNMToolMakeToolfolder(unittest.TestCase):
         self.assertEqual(tf_spike.name, "Spike_0")
 
 
+class TestNMToolOutputFlags(unittest.TestCase):
+    """Tests for the 5 shared output flags on NMTool base class."""
+
+    def setUp(self):
+        self.tool = NMTool()
+
+    # --- defaults ---
+
+    def test_ignore_nans_default(self):
+        self.assertTrue(self.tool.ignore_nans)
+
+    def test_overwrite_default(self):
+        self.assertFalse(self.tool.overwrite)
+
+    def test_results_to_history_default(self):
+        self.assertFalse(self.tool.results_to_history)
+
+    def test_results_to_cache_default(self):
+        self.assertTrue(self.tool.results_to_cache)
+
+    def test_results_to_numpy_default(self):
+        self.assertFalse(self.tool.results_to_numpy)
+
+    # --- ignore_nans ---
+
+    def test_ignore_nans_set_false(self):
+        self.tool.ignore_nans = False
+        self.assertFalse(self.tool.ignore_nans)
+
+    def test_ignore_nans_set_true(self):
+        self.tool.ignore_nans = False
+        self.tool.ignore_nans = True
+        self.assertTrue(self.tool.ignore_nans)
+
+    def test_ignore_nans_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.ignore_nans = 1
+
+    def test_ignore_nans_rejects_none(self):
+        with self.assertRaises(TypeError):
+            self.tool.ignore_nans = None
+
+    # --- overwrite ---
+
+    def test_overwrite_set_true(self):
+        self.tool.overwrite = True
+        self.assertTrue(self.tool.overwrite)
+
+    def test_overwrite_set_false(self):
+        self.tool.overwrite = True
+        self.tool.overwrite = False
+        self.assertFalse(self.tool.overwrite)
+
+    def test_overwrite_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.overwrite = 1
+
+    # --- results_to_history ---
+
+    def test_results_to_history_set_true(self):
+        self.tool.results_to_history = True
+        self.assertTrue(self.tool.results_to_history)
+
+    def test_results_to_history_set_false(self):
+        self.tool.results_to_history = True
+        self.tool.results_to_history = False
+        self.assertFalse(self.tool.results_to_history)
+
+    def test_results_to_history_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.results_to_history = 1
+
+    def test_results_to_history_rejects_none(self):
+        with self.assertRaises(TypeError):
+            self.tool.results_to_history = None
+
+    # --- results_to_cache ---
+
+    def test_results_to_cache_set_false(self):
+        self.tool.results_to_cache = False
+        self.assertFalse(self.tool.results_to_cache)
+
+    def test_results_to_cache_set_true(self):
+        self.tool.results_to_cache = False
+        self.tool.results_to_cache = True
+        self.assertTrue(self.tool.results_to_cache)
+
+    def test_results_to_cache_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.results_to_cache = "yes"
+
+    # --- results_to_numpy ---
+
+    def test_results_to_numpy_set_true(self):
+        self.tool.results_to_numpy = True
+        self.assertTrue(self.tool.results_to_numpy)
+
+    def test_results_to_numpy_set_false(self):
+        self.tool.results_to_numpy = True
+        self.tool.results_to_numpy = False
+        self.assertFalse(self.tool.results_to_numpy)
+
+    def test_results_to_numpy_rejects_non_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.results_to_numpy = 0
+
+
 class TestNMToolConfigProperty(unittest.TestCase):
     """NMTool.config property returns None for base class."""
 

--- a/tests/test_analysis/test_nm_tool_spike.py
+++ b/tests/test_analysis/test_nm_tool_spike.py
@@ -176,39 +176,6 @@ class TestNMToolSpikeProperties(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.tool.x1 = False
 
-    # ignore_nans
-    def test_ignore_nans_set_false(self):
-        self.tool.ignore_nans = False
-        self.assertFalse(self.tool.ignore_nans)
-
-    def test_ignore_nans_rejects_non_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.ignore_nans = 1
-
-    # results_to_* flags
-    def test_results_to_history_set(self):
-        self.tool.results_to_history = True
-        self.assertTrue(self.tool.results_to_history)
-
-    def test_results_to_history_rejects_non_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.results_to_history = 1
-
-    def test_results_to_cache_set(self):
-        self.tool.results_to_cache = False
-        self.assertFalse(self.tool.results_to_cache)
-
-    def test_results_to_cache_rejects_non_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.results_to_cache = "yes"
-
-    def test_results_to_numpy_set(self):
-        self.tool.results_to_numpy = False
-        self.assertFalse(self.tool.results_to_numpy)
-
-    def test_results_to_numpy_rejects_non_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.results_to_numpy = None
 
 
 class TestNMToolSpikeDetection(unittest.TestCase):

--- a/tests/test_analysis/test_nm_tool_stats.py
+++ b/tests/test_analysis/test_nm_tool_stats.py
@@ -37,7 +37,7 @@ def _make_data(n=100, name="recordA0", with_nans=False, units=True):
 
 
 class TestNMToolStats(unittest.TestCase):
-    """Tests for NMToolStats results_to_* flags and _results_to_history()."""
+    """Tests for NMToolStats results_to_* flags and _write_results_to_history()."""
 
     def setUp(self):
         self.tool = nms.NMToolStats()
@@ -53,60 +53,11 @@ class TestNMToolStats(unittest.TestCase):
     def test_results_to_numpy_default(self):
         self.assertFalse(self.tool.results_to_numpy)
 
-    # --- results_to_history ---
-
-    def test_results_to_history_set_true(self):
-        self.tool.results_to_history = True
-        self.assertTrue(self.tool.results_to_history)
-
-    def test_results_to_history_set_false(self):
-        self.tool.results_to_history = True
-        self.tool.results_to_history = False
-        self.assertFalse(self.tool.results_to_history)
-
-    def test_results_to_history_rejects_non_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.results_to_history = 1
-
-    def test_results_to_history_rejects_none(self):
-        with self.assertRaises(TypeError):
-            self.tool.results_to_history = None
-
-    # --- results_to_cache ---
-
-    def test_results_to_cache_set_false(self):
-        self.tool.results_to_cache = False
-        self.assertFalse(self.tool.results_to_cache)
-
-    def test_results_to_cache_set_true(self):
-        self.tool.results_to_cache = False
-        self.tool.results_to_cache = True
-        self.assertTrue(self.tool.results_to_cache)
-
-    def test_results_to_cache_rejects_non_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.results_to_cache = "yes"
-
-    # --- results_to_numpy ---
-
-    def test_results_to_numpy_set_true(self):
-        self.tool.results_to_numpy = True
-        self.assertTrue(self.tool.results_to_numpy)
-
-    def test_results_to_numpy_set_false(self):
-        self.tool.results_to_numpy = True
-        self.tool.results_to_numpy = False
-        self.assertFalse(self.tool.results_to_numpy)
-
-    def test_results_to_numpy_rejects_non_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.results_to_numpy = 0
-
-    # --- _results_to_history ---
+    # --- _write_results_to_history ---
 
     def test_results_to_history_empty_results(self):
         # Should not raise with no results
-        self.tool._results_to_history(quiet=True)
+        self.tool._write_results_to_history(quiet=True)
 
     def test_results_to_history_with_results(self):
         # Populate results via compute then call print
@@ -114,9 +65,9 @@ class TestNMToolStats(unittest.TestCase):
         w = list(self.tool.windows)[0]
         w.func = "mean"
         w.compute(data)
-        self.tool._results_to_history(quiet=True)
+        self.tool._write_results_to_history(quiet=True)
 
-    # --- _results_to_numpy ---
+    # --- _write_results_to_numpy ---
 
     def _setup_folder(self):
         """Create a real NMFolder and wire it into the tool's selection."""
@@ -161,24 +112,24 @@ class TestNMToolStats(unittest.TestCase):
         from pyneuromatic.analysis.nm_tool_folder import NMToolFolder
         self._setup_folder()
         self._run_compute()
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertIsInstance(f, NMToolFolder)
 
     def test_results_to_numpy_folder_named_stats_0_no_dataseries(self):
         # No dataseries selected → fallback name "Stats_0"
         self._setup_folder()
         self._run_compute()
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertEqual(f.name, "Stats_0")
 
     def test_results_to_numpy_second_run_named_stats_1_no_dataseries(self):
         # Second run with no dataseries → "Stats_1"
         self._setup_folder()
         self._run_compute()
-        self.tool._results_to_numpy()
+        self.tool._write_results_to_numpy()
         self.tool._NMToolStats__results.clear()
         self._run_compute()
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertEqual(f.name, "Stats_1")
 
     def test_results_to_numpy_folder_named_with_dataseries(self):
@@ -188,7 +139,7 @@ class TestNMToolStats(unittest.TestCase):
         ds = NMDataSeries(name="Record")
         self.tool._select["dataseries"] = ds
         self._run_compute()
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertEqual(f.name, "Stats_Record_0")
 
     def test_results_to_numpy_folder_named_with_dataseries_and_channel(self):
@@ -199,7 +150,7 @@ class TestNMToolStats(unittest.TestCase):
         self.tool._select["dataseries"] = NMDataSeries(name="Record")
         self.tool._select["channel"] = NMChannel(name="A")
         self._run_compute()
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertEqual(f.name, "Stats_Record_A_0")
 
     def test_results_to_numpy_folder_named_channel_only(self):
@@ -208,32 +159,32 @@ class TestNMToolStats(unittest.TestCase):
         self._setup_folder()
         self.tool._select["channel"] = NMChannel(name="B")
         self._run_compute()
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertEqual(f.name, "Stats_B_0")
 
     def test_results_to_numpy_creates_data_array(self):
         self._setup_folder()
         self._run_compute(n_arrays=3)
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertIn("ST_w0_data", f.data)
 
     def test_results_to_numpy_data_array_length(self):
         self._setup_folder()
         self._run_compute(n_arrays=3)
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         d = f.data.get("ST_w0_data")
         self.assertEqual(len(d.nparray), 3)
 
     def test_results_to_numpy_creates_mean_y_array(self):
         self._setup_folder()
         self._run_compute(func="mean", n_arrays=3)
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertIn("ST_w0_mean_y", f.data)
 
     def test_results_to_numpy_mean_y_array_length(self):
         self._setup_folder()
         self._run_compute(func="mean", n_arrays=3)
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         d = f.data.get("ST_w0_mean_y")
         self.assertEqual(len(d.nparray), 3)
 
@@ -241,7 +192,7 @@ class TestNMToolStats(unittest.TestCase):
         # mean+std → ST_w0_mean_y AND ST_w0_std_y
         self._setup_folder()
         self._run_compute(func="mean+std", n_arrays=3)
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertIn("ST_w0_mean_y", f.data)
         self.assertIn("ST_w0_std_y", f.data)
         self.assertNotIn("ST_w0_mean_std_y", f.data)
@@ -250,7 +201,7 @@ class TestNMToolStats(unittest.TestCase):
         # baseline result → ST_w0_bsln_y
         self._setup_folder()
         self._run_compute_with_bsln()
-        f = self.tool._results_to_numpy()
+        f = self.tool._write_results_to_numpy()
         self.assertIn("ST_w0_bsln_y", f.data)
 
     # --- _sanitize_func_name / _st_array_name ---
@@ -302,13 +253,13 @@ class TestNMToolStats(unittest.TestCase):
         from pyneuromatic.analysis.nm_tool import HIERARCHY_SELECT_KEYS
         self.tool._select = {tier: None for tier in HIERARCHY_SELECT_KEYS}
         # folder is None — should return None
-        result = self.tool._results_to_numpy()
+        result = self.tool._write_results_to_numpy()
         self.assertIsNone(result)
 
     def test_results_to_numpy_no_results_raises(self):
         self._setup_folder()
         with self.assertRaises(RuntimeError):
-            self.tool._results_to_numpy()
+            self.tool._write_results_to_numpy()
 
 
 class TestNMToolStats2(unittest.TestCase):
@@ -1038,43 +989,43 @@ class TestNMToolStatsOverwrite(unittest.TestCase):
     def test_overwrite_false_creates_stats_0(self):
         tool, folder = self._setup(overwrite=False)
         self._fill_results(tool)
-        tool._results_to_numpy()
+        tool._write_results_to_numpy()
         self.assertIn("stats_0", folder.toolfolders)
 
     def test_overwrite_false_creates_stats_1_on_second_run(self):
         tool, folder = self._setup(overwrite=False)
         self._fill_results(tool)
-        tool._results_to_numpy()
+        tool._write_results_to_numpy()
         tool._NMToolStats__results.clear()
         self._fill_results(tool)
-        tool._results_to_numpy()
+        tool._write_results_to_numpy()
         self.assertIn("stats_0", folder.toolfolders)
         self.assertIn("stats_1", folder.toolfolders)
 
     def test_overwrite_true_creates_stats_0(self):
         tool, folder = self._setup(overwrite=True)
         self._fill_results(tool)
-        tool._results_to_numpy()
+        tool._write_results_to_numpy()
         self.assertIn("stats_0", folder.toolfolders)
 
     def test_overwrite_true_reuses_stats_0_on_second_run(self):
         tool, folder = self._setup(overwrite=True)
         self._fill_results(tool)
-        tool._results_to_numpy()
+        tool._write_results_to_numpy()
         tool._NMToolStats__results.clear()
         self._fill_results(tool)
-        tool._results_to_numpy()
+        tool._write_results_to_numpy()
         self.assertIn("stats_0", folder.toolfolders)
         self.assertNotIn("stats_1", folder.toolfolders)
 
     def test_overwrite_true_replaces_st_arrays(self):
         tool, folder = self._setup(overwrite=True)
         self._fill_results(tool, n=3)
-        f = tool._results_to_numpy()
+        f = tool._write_results_to_numpy()
         arr_first = f.data.get("ST_w0_mean_y").nparray.copy()
         tool._NMToolStats__results.clear()
         self._fill_results(tool, n=5)
-        f2 = tool._results_to_numpy()
+        f2 = tool._write_results_to_numpy()
         self.assertIs(f, f2)
         arr_second = f2.data.get("ST_w0_mean_y").nparray
         self.assertEqual(len(arr_second), 5)
@@ -1082,7 +1033,7 @@ class TestNMToolStatsOverwrite(unittest.TestCase):
 
 
 class TestNMToolStatsNotes(unittest.TestCase):
-    """Notes are attached to numeric ST_ arrays in _results_to_numpy()."""
+    """Notes are attached to numeric ST_ arrays in _write_results_to_numpy()."""
 
     def setUp(self):
         from pyneuromatic.core.nm_folder import NMFolder
@@ -1105,7 +1056,7 @@ class TestNMToolStatsNotes(unittest.TestCase):
                 self.tool._NMToolStats__results[wname].append(results)
             else:
                 self.tool._NMToolStats__results[wname] = [results]
-        self.f = self.tool._results_to_numpy()
+        self.f = self.tool._write_results_to_numpy()
         self.st_array = self.f.data.get("ST_w0_mean_y")
 
     def _note_text(self):
@@ -1171,7 +1122,7 @@ class TestNMToolStatsNotes(unittest.TestCase):
                 tool._NMToolStats__results[wname].append(results)
             else:
                 tool._NMToolStats__results[wname] = [results]
-        f = tool._results_to_numpy()
+        f = tool._write_results_to_numpy()
         bsln_arr = f.data.get("ST_w0_bsln_y")
         self.assertIsNotNone(bsln_arr)
         notes = getattr(bsln_arr, "notes", None)


### PR DESCRIPTION
## Summary

- Adds TestNMToolOutputFlags to test_nm_tool.py — tests all 5 shared flags (ignore_nans, overwrite, results_to_history, results_to_cache, results_to_numpy) on a plain NMTool() instance, covering base-class defaults, set true/false, and type rejection
- Removes the duplicate setter/rejection tests from TestNMToolStats (test_nm_tool_stats.py) and TestNMToolSpikeProperties (test_nm_tool_spike.py)
- Tool-specific defaults (e.g. results_to_numpy=True for Spike) and action-method tests (_write_results_to_history, _write_results_to_numpy) remain in their respective tool test files

## Motivation

The 5 flags were moved to NMTool base class in the previous commit. The tests follow: generic property behaviour belongs in the base-class test file, not duplicated across every tool test file.

## Test plan

-  python3 -m pytest tests/test_analysis/test_nm_tool.py -q — new TestNMToolOutputFlags passes
-  python3 -m pytest tests/test_analysis/test_nm_tool_stats.py tests/test_analysis/test_nm_tool_spike.py -q — no regressions
-  python3 -m pytest -q — full suite green