### PR TITLE
feat(analysis): template baseline window for NMToolEvent template matching

### DIFF
--- a/pyneuromatic/analysis/nm_tool_event.py
+++ b/pyneuromatic/analysis/nm_tool_event.py
@@ -58,6 +58,9 @@ class NMToolEventConfig(NMToolConfig):
         baseline_dt: Detection window after t0 (x-units, threshold/nstdv).
             Default 2.0.
         criterion_threshold: Criterion threshold for template matching. Default 4.0.
+        template_baseline: Baseline window (x-units) prepended to the template as
+            zeros before matching. Detected times are shifted forward by this
+            amount to recover the true event onset. Default 0.0.
         onset_search: If True, search backward for event onset. Default True.
         onset_avg: Onset window size (x-units). Default 1.0.
         onset_nstdv: Onset N×stdv. Default 1.0.
@@ -88,7 +91,8 @@ class NMToolEventConfig(NMToolConfig):
         "nstdv":              {"type": float, "default": 4.0,   "min": 0.0},
         "baseline_avg":       {"type": float, "default": 4.0,   "min": 0.0},
         "baseline_dt":        {"type": float, "default": 2.0,   "min": 0.0},
-        "criterion_threshold":     {"type": float, "default": 4.0,   "min": 0.0},
+        "criterion_threshold": {"type": float, "default": 4.0,   "min": 0.0},
+        "template_baseline":  {"type": float, "default": 0.0,   "min": 0.0},
         "onset_search":       {"type": bool,  "default": True},
         "onset_avg":          {"type": float, "default": 1.0,   "min": 0.0},
         "onset_nstdv":        {"type": float, "default": 1.0,   "min": 0.0},
@@ -131,8 +135,13 @@ class NMToolEvent(NMTool):
         baseline_avg: Baseline window size (x-units). Default 4.0.
         baseline_dt: Detection window after t0 (x-units). Default 2.0.
         template: User-supplied 1-D numpy template (algorithm="template").
-            Not TOML-serializable; set directly on the instance.
+            Should contain only the event shape — the baseline is prepended
+            automatically via *template_baseline*. Not TOML-serializable;
+            set directly on the instance.
         criterion_threshold: Criterion threshold for template matching. Default 4.0.
+        template_baseline: Baseline window (x-units) prepended to the template as
+            zeros before matching. Detected times are shifted forward by this
+            amount to recover the true event onset. Default 0.0.
         onset_search: Enable onset refinement. Default True.
         onset_avg: Onset window (x-units). Default 1.0.
         onset_nstdv: Onset N×stdv. Default 1.0.
@@ -163,8 +172,9 @@ class NMToolEvent(NMTool):
         self.__nstdv:         float = 4.0
         self.__baseline_avg:  float = 4.0
         self.__baseline_dt:   float = 2.0
-        self.__template:      np.ndarray | None = None
+        self.__template:          np.ndarray | None = None
         self.__criterion_threshold: float = 4.0
+        self.__template_baseline:   float = 0.0
         self.__onset_search:  bool  = True
         self.__onset_avg:     float = 1.0
         self.__onset_nstdv:   float = 1.0
@@ -359,6 +369,32 @@ class NMToolEvent(NMTool):
         nmh.history("set criterion_threshold=%g" % self.__criterion_threshold, quiet=quiet)
         nmch.add_nm_command(
             "%s.criterion_threshold = %r" % (self._name, self.__criterion_threshold)
+        )
+
+    @property
+    def template_baseline(self) -> float:
+        """Baseline window (x-units) prepended to template as zeros before matching.
+
+        The criterion crossing occurs at the start of this baseline window, so
+        detected times are shifted forward by *template_baseline* to recover the
+        true event onset. Default 0.0 (no baseline prepended).
+        """
+        return self.__template_baseline
+
+    @template_baseline.setter
+    def template_baseline(self, value: float) -> None:
+        self._template_baseline_set(value)
+
+    def _template_baseline_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "template_baseline", "float"))
+        value = float(value)
+        if value < 0:
+            raise ValueError("template_baseline must be >= 0, got %g" % value)
+        self.__template_baseline = value
+        nmh.history("set template_baseline=%g" % self.__template_baseline, quiet=quiet)
+        nmch.add_nm_command(
+            "%s.template_baseline = %r" % (self._name, self.__template_baseline)
         )
 
     @property
@@ -610,14 +646,18 @@ class NMToolEvent(NMTool):
         arr = data.nparray
         if arr is None:
             return None
-        arr_id = id(arr)
-        if arr_id != self._match_criterion_cache_id:
+        cache_key = (id(arr), self.__template_baseline)
+        if cache_key != self._match_criterion_cache_id:
             tpl = self.__template.astype(float, copy=True)
             tpl_min, tpl_max = tpl.min(), tpl.max()
             if tpl_max != tpl_min:
                 tpl = (tpl - tpl_min) / (tpl_max - tpl_min)
+            if self.__template_baseline > 0:
+                xdelta = data.xscale.delta if data.xscale.delta else 1.0
+                n_base = max(1, round(self.__template_baseline / xdelta))
+                tpl = np.concatenate([np.zeros(n_base), tpl])
             self._match_criterion_cache    = nm_math.match_template(arr, tpl)
-            self._match_criterion_cache_id = arr_id
+            self._match_criterion_cache_id = cache_key
         return self._match_criterion_cache
 
     def _detection_value(self) -> float:
@@ -638,7 +678,9 @@ class NMToolEvent(NMTool):
                 self.__nstdv, self.__baseline_avg, self.__baseline_dt,
             )
         else:
-            params = "criterion_threshold=%g" % self.__criterion_threshold
+            params = "criterion_threshold=%g, template_baseline=%g" % (
+                self.__criterion_threshold, self.__template_baseline,
+            )
         return (
             "NMEvent(source=%s, algorithm=%r, polarity=%r, %s, "
             "onset_search=%r, peak_search=%r, refractory=%g, "
@@ -700,6 +742,7 @@ class NMToolEvent(NMTool):
             baseline_dt=self.__baseline_dt,
             template=self.__template,
             criterion_threshold=self.__criterion_threshold,
+            template_baseline=self.__template_baseline,
             refractory=self.__refractory,
             x0=self.__x0,
             x1=self.__x1,
@@ -750,7 +793,7 @@ class NMToolEvent(NMTool):
         f = self._toolfolder
         xunits = self._detected_xunits or ""
 
-        # Store template in toolfolder (normalized to [0, 1]) for reference
+        # Store event-shape template (normalized to [0, 1], baseline not included)
         if self.__algorithm == "template" and self.__template is not None:
             tpl = self.__template.astype(float, copy=True)
             tmin, tmax = tpl.min(), tpl.max()
@@ -900,6 +943,7 @@ class NMToolEvent(NMTool):
             baseline_dt=self.__baseline_dt,
             template=self.__template,
             criterion_threshold=self.__criterion_threshold,
+            template_baseline=self.__template_baseline,
             refractory=self.__refractory,
             x0=start_x,
             x1=self.__x1,

--- a/pyneuromatic/analysis/nm_tool_utilities.py
+++ b/pyneuromatic/analysis/nm_tool_utilities.py
@@ -204,6 +204,7 @@ def find_events_nmdata(
     baseline_dt: float = 2.0,
     template: np.ndarray | None = None,
     criterion_threshold: float = 4.0,
+    template_baseline: float = 0.0,
     refractory: float = 0.0,
     x0: float = -math.inf,
     x1: float = math.inf,
@@ -235,8 +236,18 @@ def find_events_nmdata(
         baseline_avg: Baseline averaging window (x-units, threshold/nstdv).
         baseline_dt: Detection window after t0 (x-units, threshold/nstdv).
         template: 1-D numpy array (template algorithm only). Normalized to
-            [0, 1] internally before calling match_template.
+            [0, 1] internally before calling match_template. If a baseline
+            window is desired, it must already be included in this array
+            (e.g. leading zeros prepended by the caller). Used only when
+            *match_criterion* is ``None``.
         criterion_threshold: Criterion threshold for template matching (default 4).
+        template_baseline: Offset (x-units) applied to shift detected times
+            forward after criterion level-crossing detection. Use this to
+            correct for a baseline window included at the start of the
+            template: a baseline of length *B* causes the criterion crossing
+            to occur *B* before the true event onset, and this shift recovers
+            that offset. Default 0.0 (no shift). Note: the baseline prepending
+            itself is the caller's responsibility (see above).
         refractory: Minimum inter-event interval (x-units, all algorithms).
         x0: Search start (x-units). Default ``-inf``.
         x1: Search end (x-units). Default ``+inf``.
@@ -305,6 +316,9 @@ def find_events_nmdata(
             x1=x1,
         )
         candidate_times = list(candidate_times)
+        # Shift times to recover true event onset (baseline offset correction)
+        if template_baseline > 0:
+            candidate_times = [t + template_baseline for t in candidate_times]
         # Apply refractory filter
         if refractory > 0 and len(candidate_times) > 1:
             filtered = [candidate_times[0]]

--- a/tests/test_analysis/test_nm_tool_event.py
+++ b/tests/test_analysis/test_nm_tool_event.py
@@ -159,6 +159,9 @@ class TestNMToolEventDefaults(unittest.TestCase):
     def test_max_events_default(self):
         self.assertEqual(self.tool.max_events, 0)
 
+    def test_template_baseline_default(self):
+        self.assertEqual(self.tool.template_baseline, 0.0)
+
     def test_results_to_history_default(self):
         self.assertFalse(self.tool.results_to_history)
 
@@ -334,6 +337,23 @@ class TestNMToolEventProperties(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.tool.x1 = True
 
+    # template_baseline
+    def test_template_baseline_accepts_zero(self):
+        self.tool.template_baseline = 0.0
+        self.assertEqual(self.tool.template_baseline, 0.0)
+
+    def test_template_baseline_accepts_positive(self):
+        self.tool.template_baseline = 5e-3
+        self.assertAlmostEqual(self.tool.template_baseline, 5e-3)
+
+    def test_template_baseline_rejects_negative(self):
+        with self.assertRaises(ValueError):
+            self.tool.template_baseline = -1e-3
+
+    def test_template_baseline_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.template_baseline = True
+
 # ---------------------------------------------------------------------------
 # Detection: threshold algorithm
 # ---------------------------------------------------------------------------
@@ -506,6 +526,49 @@ class TestNMToolEventDetectionTemplate(unittest.TestCase):
         tf = list(folder.toolfolders.values())[0]
         ev = tf.data.get("EV_recordA0")
         self.assertEqual(len(ev.nparray), 2)
+
+    def test_template_baseline_shifts_detected_times(self):
+        # Event at 50 ms. With template_baseline=10 ms, the criterion crossing
+        # occurs ~10 ms early; the shift should recover the true event onset.
+        # Without the shift, detected time ≈ 40 ms; with shift ≈ 50 ms.
+        # Refractory prevents re-detections on the decaying tail.
+        event_ms = 50.0
+        baseline_ms = 10.0
+        self.tool.template_baseline = baseline_ms * _MS
+        self.tool.refractory = 20e-3
+        data = _make_epsc_data(
+            event_times_ms=[event_ms],
+            amplitude=-500.0,
+            decay_ms=5.0,
+            noise_std=5.0,
+        )
+        folder = _run(self.tool, [data])
+        tf = list(folder.toolfolders.values())[0]
+        ev = tf.data.get("EV_recordA0")
+        self.assertEqual(len(ev.nparray), 1)
+        # Detected time should be within 2 ms of the true event onset
+        detected_ms = ev.nparray[0] * 1000.0
+        self.assertAlmostEqual(detected_ms, event_ms, delta=2.0)
+
+    def test_template_baseline_zero_no_shift(self):
+        # With template_baseline=0, detected time is also near the event onset
+        # (criterion peaks at event start when no baseline is prepended).
+        # Refractory prevents re-detections on the decaying tail.
+        event_ms = 50.0
+        self.tool.template_baseline = 0.0
+        self.tool.refractory = 20e-3
+        data = _make_epsc_data(
+            event_times_ms=[event_ms],
+            amplitude=-500.0,
+            decay_ms=5.0,
+            noise_std=5.0,
+        )
+        folder = _run(self.tool, [data])
+        tf = list(folder.toolfolders.values())[0]
+        ev = tf.data.get("EV_recordA0")
+        self.assertEqual(len(ev.nparray), 1)
+        detected_ms = ev.nparray[0] * 1000.0
+        self.assertAlmostEqual(detected_ms, event_ms, delta=2.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `template_baseline` parameter (x-units, default 0.0) to
  `NMToolEvent` and `find_events_nmdata()`
- When a template includes a leading baseline window, the criterion
  crossing occurs at the start of that window rather than the event
  onset; `template_baseline` shifts detected times forward to recover
  the true onset
- Baseline prepending (zeros) is handled by
  `NMToolEvent._get_match_criterion()` before `match_template()` is
  called; `find_events_nmdata()` applies only the time shift
- Cache key updated from `id(array)` to `(id(array), template_baseline)`
  so the criterion array is recomputed when the parameter changes
- 6 new tests covering default, property validation, shift correctness,
  and zero-shift behaviour

## Motivation

Previously users had to manually prepend a baseline to their template
and accept that detected times would be offset by the baseline length.
With `template_baseline`, `NMToolEvent` prepends the zeros internally
and corrects the detected times automatically, making it straightforward
to test different baseline lengths without modifying the template array.

## References

- Closes #294
- Clements JD, Bekkers JM (1997) Detection of spontaneous synaptic
  events with an optimally scaled template. *Biophys J* 73:220–229.
