### PR TITLE
fix(analysis): NMToolEvent criterion cache type and xdelta guard

### DIFF
--- a/pyneuromatic/analysis/nm_tool_event.py
+++ b/pyneuromatic/analysis/nm_tool_event.py
@@ -188,8 +188,8 @@ class NMToolEvent(NMTool):
         self.__x1:            float = math.inf
         self.__max_events:    int   = 0
 
-        # Match criterion cache — keyed by id(data.nparray), survives run_init()
-        self._match_criterion_cache_id: int | None        = None
+        # Match criterion cache — keyed by (id(data.nparray), template_baseline)
+        self._match_criterion_cache_id: tuple | None      = None
         self._match_criterion_cache:    np.ndarray | None = None
 
         # Internal run state — reset by run_init()
@@ -653,7 +653,11 @@ class NMToolEvent(NMTool):
             if tpl_max != tpl_min:
                 tpl = (tpl - tpl_min) / (tpl_max - tpl_min)
             if self.__template_baseline > 0:
-                xdelta = data.xscale.delta if data.xscale.delta else 1.0
+                xdelta = data.xscale.delta
+                if not xdelta:
+                    raise ValueError(
+                        "cannot prepend template baseline: xscale.delta is zero or unset"
+                    )
                 n_base = max(1, round(self.__template_baseline / xdelta))
                 tpl = np.concatenate([np.zeros(n_base), tpl])
             self._match_criterion_cache    = nm_math.match_template(arr, tpl)


### PR DESCRIPTION
Fix stale type annotation on _match_criterion_cache_id (int | None → tuple | None) after the cache key was changed to (id(array), template_baseline) in the template_baseline PR.

Replace silent xdelta fallback (default 1.0) in _get_match_criterion() with a ValueError when xscale.delta is unset and template_baseline > 0. The fallback silently computed the wrong number of baseline samples (e.g. 1 instead of 100 at 10 kHz for a 10 ms baseline).