### PR TITLE
refactor(analysis): rename NMMainOpNormalize parameters to prefix-first style

### DIFF
--- a/pyneuromatic/analysis/nm_main_op.py
+++ b/pyneuromatic/analysis/nm_main_op.py
@@ -2015,10 +2015,10 @@ class NMMainOpNormalize(NMMainOp):
 
     Two independent xscale windows are used:
 
-    - Window 1 (``xbgn_min``/``xend_min``) computes the "low" reference via
-      ``fxn1`` (``"mean"``, ``"min"``, or ``"mean@min"``).
-    - Window 2 (``xbgn_max``/``xend_max``) computes the "high" reference via
-      ``fxn2`` (``"mean"``, ``"max"``, or ``"mean@max"``).
+    - Window 1 (``min_xbgn``/``min_xend``) computes the "low" reference via
+      ``min_fxn`` (``"mean"``, ``"min"``, or ``"mean@min"``).
+    - Window 2 (``max_xbgn``/``max_xend``) computes the "high" reference via
+      ``max_fxn`` (``"mean"``, ``"max"``, or ``"mean@max"``).
 
     Two modes (matching NMMainOpBaseline):
 
@@ -2027,16 +2027,16 @@ class NMMainOpNormalize(NMMainOp):
       then applied to every array in that channel.
 
     Parameters:
-        xbgn_min: Window 1 start in xscale units (default 0.0).
-        xend_min: Window 1 end in xscale units (default 0.0).
-        fxn1: Function for the low reference: ``"mean"``, ``"min"``, or
+        min_xbgn: Window 1 start in xscale units (default 0.0).
+        min_xend: Window 1 end in xscale units (default 0.0).
+        min_fxn: Function for the low reference: ``"mean"``, ``"min"``, or
             ``"mean@min"`` (default ``"mean"``).
-        n_mean1: Points around min for ``mean@min`` (default 1).
-        xbgn_max: Window 2 start in xscale units (default 0.0).
-        xend_max: Window 2 end in xscale units (default 0.0).
-        fxn2: Function for the high reference: ``"mean"``, ``"max"``, or
+        min_mean_n: Points around min for ``mean@min`` (default 1).
+        max_xbgn: Window 2 start in xscale units (default 0.0).
+        max_xend: Window 2 end in xscale units (default 0.0).
+        max_fxn: Function for the high reference: ``"mean"``, ``"max"``, or
             ``"mean@max"`` (default ``"mean"``).
-        n_mean2: Points around max for ``mean@max`` (default 1).
+        max_mean_n: Points around max for ``mean@max`` (default 1).
         norm_min: Target normalized minimum (default 0.0).
         norm_max: Target normalized maximum (default 1.0).
         mode: ``"per_array"`` (default) or ``"average"``.
@@ -2050,26 +2050,26 @@ class NMMainOpNormalize(NMMainOp):
 
     def __init__(
         self,
-        xbgn_min: float = 0.0,
-        xend_min: float = 0.0,
-        fxn1: str = "mean",
-        n_mean1: int = 1,
-        xbgn_max: float = 0.0,
-        xend_max: float = 0.0,
-        fxn2: str = "mean",
-        n_mean2: int = 1,
+        min_xbgn: float = 0.0,
+        min_xend: float = 0.0,
+        min_fxn: str = "mean",
+        min_mean_n: int = 1,
+        max_xbgn: float = 0.0,
+        max_xend: float = 0.0,
+        max_fxn: str = "mean",
+        max_mean_n: int = 1,
         norm_min: float = 0.0,
         norm_max: float = 1.0,
         mode: str = "per_array",
     ) -> None:
-        self.xbgn_min = xbgn_min
-        self.xend_min = xend_min
-        self.fxn1 = fxn1
-        self.n_mean1 = n_mean1
-        self.xbgn_max = xbgn_max
-        self.xend_max = xend_max
-        self.fxn2 = fxn2
-        self.n_mean2 = n_mean2
+        self.min_xbgn = min_xbgn
+        self.min_xend = min_xend
+        self.min_fxn = min_fxn
+        self.min_mean_n = min_mean_n
+        self.max_xbgn = max_xbgn
+        self.max_xend = max_xend
+        self.max_fxn = max_fxn
+        self.max_mean_n = max_mean_n
         self.norm_min = norm_min
         self.norm_max = norm_max
         self.mode = mode
@@ -2078,112 +2078,112 @@ class NMMainOpNormalize(NMMainOp):
     # Properties
 
     @property
-    def xbgn_min(self) -> float:
+    def min_xbgn(self) -> float:
         """Window 1 start (xscale units)."""
-        return self._xbgn_min
+        return self._min_xbgn
 
-    @xbgn_min.setter
-    def xbgn_min(self, value: float) -> None:
+    @min_xbgn.setter
+    def min_xbgn(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xbgn_min", "float"))
+            raise TypeError(nmu.type_error_str(value, "min_xbgn", "float"))
         if math.isnan(float(value)):
-            raise ValueError("xbgn_min must not be NaN")
-        self._xbgn_min = float(value)
+            raise ValueError("min_xbgn must not be NaN")
+        self._min_xbgn = float(value)
 
     @property
-    def xend_min(self) -> float:
+    def min_xend(self) -> float:
         """Window 1 end (xscale units)."""
-        return self._xend_min
+        return self._min_xend
 
-    @xend_min.setter
-    def xend_min(self, value: float) -> None:
+    @min_xend.setter
+    def min_xend(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xend_min", "float"))
+            raise TypeError(nmu.type_error_str(value, "min_xend", "float"))
         if math.isnan(float(value)):
-            raise ValueError("xend_min must not be NaN")
-        self._xend_min = float(value)
+            raise ValueError("min_xend must not be NaN")
+        self._min_xend = float(value)
 
     @property
-    def fxn1(self) -> str:
+    def min_fxn(self) -> str:
         """Low-reference function: ``'mean'``, ``'min'``, or ``'mean@min'``."""
-        return self._fxn1
+        return self._min_fxn
 
-    @fxn1.setter
-    def fxn1(self, value: str) -> None:
+    @min_fxn.setter
+    def min_fxn(self, value: str) -> None:
         if not isinstance(value, str):
-            raise TypeError(nmu.type_error_str(value, "fxn1", "string"))
+            raise TypeError(nmu.type_error_str(value, "min_fxn", "string"))
         if value not in self._VALID_FXN1:
             raise ValueError(
-                "fxn1 must be one of %s, got %r" % (sorted(self._VALID_FXN1), value)
+                "min_fxn must be one of %s, got %r" % (sorted(self._VALID_FXN1), value)
             )
-        self._fxn1 = value
+        self._min_fxn = value
 
     @property
-    def n_mean1(self) -> int:
+    def min_mean_n(self) -> int:
         """Points around min for ``mean@min`` (default 1)."""
-        return self._n_mean1
+        return self._min_mean_n
 
-    @n_mean1.setter
-    def n_mean1(self, value: int) -> None:
+    @min_mean_n.setter
+    def min_mean_n(self, value: int) -> None:
         if isinstance(value, bool) or not isinstance(value, int):
-            raise TypeError(nmu.type_error_str(value, "n_mean1", "int"))
+            raise TypeError(nmu.type_error_str(value, "min_mean_n", "int"))
         if value < 1:
-            raise ValueError("n_mean1 must be >= 1, got %d" % value)
-        self._n_mean1 = value
+            raise ValueError("min_mean_n must be >= 1, got %d" % value)
+        self._min_mean_n = value
 
     @property
-    def xbgn_max(self) -> float:
+    def max_xbgn(self) -> float:
         """Window 2 start (xscale units)."""
-        return self._xbgn_max
+        return self._max_xbgn
 
-    @xbgn_max.setter
-    def xbgn_max(self, value: float) -> None:
+    @max_xbgn.setter
+    def max_xbgn(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xbgn_max", "float"))
+            raise TypeError(nmu.type_error_str(value, "max_xbgn", "float"))
         if math.isnan(float(value)):
-            raise ValueError("xbgn_max must not be NaN")
-        self._xbgn_max = float(value)
+            raise ValueError("max_xbgn must not be NaN")
+        self._max_xbgn = float(value)
 
     @property
-    def xend_max(self) -> float:
+    def max_xend(self) -> float:
         """Window 2 end (xscale units)."""
-        return self._xend_max
+        return self._max_xend
 
-    @xend_max.setter
-    def xend_max(self, value: float) -> None:
+    @max_xend.setter
+    def max_xend(self, value: float) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xend_max", "float"))
+            raise TypeError(nmu.type_error_str(value, "max_xend", "float"))
         if math.isnan(float(value)):
-            raise ValueError("xend_max must not be NaN")
-        self._xend_max = float(value)
+            raise ValueError("max_xend must not be NaN")
+        self._max_xend = float(value)
 
     @property
-    def fxn2(self) -> str:
+    def max_fxn(self) -> str:
         """High-reference function: ``'mean'``, ``'max'``, or ``'mean@max'``."""
-        return self._fxn2
+        return self._max_fxn
 
-    @fxn2.setter
-    def fxn2(self, value: str) -> None:
+    @max_fxn.setter
+    def max_fxn(self, value: str) -> None:
         if not isinstance(value, str):
-            raise TypeError(nmu.type_error_str(value, "fxn2", "string"))
+            raise TypeError(nmu.type_error_str(value, "max_fxn", "string"))
         if value not in self._VALID_FXN2:
             raise ValueError(
-                "fxn2 must be one of %s, got %r" % (sorted(self._VALID_FXN2), value)
+                "max_fxn must be one of %s, got %r" % (sorted(self._VALID_FXN2), value)
             )
-        self._fxn2 = value
+        self._max_fxn = value
 
     @property
-    def n_mean2(self) -> int:
+    def max_mean_n(self) -> int:
         """Points around max for ``mean@max`` (default 1)."""
-        return self._n_mean2
+        return self._max_mean_n
 
-    @n_mean2.setter
-    def n_mean2(self, value: int) -> None:
+    @max_mean_n.setter
+    def max_mean_n(self, value: int) -> None:
         if isinstance(value, bool) or not isinstance(value, int):
-            raise TypeError(nmu.type_error_str(value, "n_mean2", "int"))
+            raise TypeError(nmu.type_error_str(value, "max_mean_n", "int"))
         if value < 1:
-            raise ValueError("n_mean2 must be >= 1, got %d" % value)
-        self._n_mean2 = value
+            raise ValueError("max_mean_n must be >= 1, got %d" % value)
+        self._max_mean_n = value
 
     @property
     def norm_min(self) -> float:
@@ -2226,13 +2226,13 @@ class NMMainOpNormalize(NMMainOp):
     # Validation helper
 
     def _validate_windows(self) -> None:
-        if self._xend_min < self._xbgn_min:
+        if self._min_xend < self._min_xbgn:
             raise ValueError(
-                "xend_min (%g) must be >= xbgn_min (%g)" % (self._xend_min, self._xbgn_min)
+                "min_xend (%g) must be >= min_xbgn (%g)" % (self._min_xend, self._min_xbgn)
             )
-        if self._xend_max < self._xbgn_max:
+        if self._max_xend < self._max_xbgn:
             raise ValueError(
-                "xend_max (%g) must be >= xbgn_max (%g)" % (self._xend_max, self._xbgn_max)
+                "max_xend (%g) must be >= max_xbgn (%g)" % (self._max_xend, self._max_xbgn)
             )
 
     # ------------------------------------------------------------------
@@ -2283,10 +2283,10 @@ class NMMainOpNormalize(NMMainOp):
 
         arr = data.nparray.astype(float)
         xd = data.xscale.to_dict()
-        sl1 = nm_math.xscale_window_to_slice(arr, xd, self._xbgn_min, self._xend_min)
-        sl2 = nm_math.xscale_window_to_slice(arr, xd, self._xbgn_max, self._xend_max)
-        ref_min = nm_math.compute_ref_value(arr[sl1], self._fxn1, self._n_mean1)
-        ref_max = nm_math.compute_ref_value(arr[sl2], self._fxn2, self._n_mean2)
+        sl1 = nm_math.xscale_window_to_slice(arr, xd, self._min_xbgn, self._min_xend)
+        sl2 = nm_math.xscale_window_to_slice(arr, xd, self._max_xbgn, self._max_xend)
+        ref_min = nm_math.compute_ref_value(arr[sl1], self._min_fxn, self._min_mean_n)
+        ref_max = nm_math.compute_ref_value(arr[sl2], self._max_fxn, self._max_mean_n)
 
         if self._mode == "per_array":
             data.nparray = self._apply(arr, ref_min, ref_max)
@@ -2319,12 +2319,12 @@ class NMMainOpNormalize(NMMainOp):
 
     def _op_params_str(self) -> str:
         return (
-            "xbgn_min=%r, xend_min=%r, fxn1=%r, n_mean1=%d, "
-            "xbgn_max=%r, xend_max=%r, fxn2=%r, n_mean2=%d, "
+            "min_xbgn=%r, min_xend=%r, min_fxn=%r, min_mean_n=%d, "
+            "max_xbgn=%r, max_xend=%r, max_fxn=%r, max_mean_n=%d, "
             "norm_min=%r, norm_max=%r, mode=%r"
         ) % (
-            self._xbgn_min, self._xend_min, self._fxn1, self._n_mean1,
-            self._xbgn_max, self._xend_max, self._fxn2, self._n_mean2,
+            self._min_xbgn, self._min_xend, self._min_fxn, self._min_mean_n,
+            self._max_xbgn, self._max_xend, self._max_fxn, self._max_mean_n,
             self._norm_min, self._norm_max, self._mode,
         )
 

--- a/tests/test_analysis/test_nm_tool_main.py
+++ b/tests/test_analysis/test_nm_tool_main.py
@@ -679,7 +679,7 @@ class TestNMMainOpInsertPoints(unittest.TestCase):
         self._run()
         np.testing.assert_array_equal(self.data.nparray, [0.0, 1.0, 2.0, 3.0])
 
-    def test_insert_ax1(self):
+    def test_insert_at_end(self):
         self.op.index = 3
         self._run()
         np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 0.0])
@@ -758,7 +758,7 @@ class TestNMMainOpDeletePoints(unittest.TestCase):
         self._run()
         np.testing.assert_array_equal(self.data.nparray, [2.0, 3.0, 4.0, 5.0])
 
-    def test_delete_ax1(self):
+    def test_delete_at_end(self):
         self.op.index = 4
         self._run()
         np.testing.assert_array_equal(self.data.nparray, [1.0, 2.0, 3.0, 4.0])
@@ -1498,10 +1498,10 @@ class TestNMMainOpNormalize(unittest.TestCase):
     # per_array mode — correct values
 
     def test_per_array_min_max(self):
-        # [0,5,10], fxn1=min→0, fxn2=max→10, range=10 → [0.0, 0.5, 1.0]
+        # [0,5,10], min_fxn=min→0, max_fxn=max→10, range=10 → [0.0, 0.5, 1.0]
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=2.0, fxn1="min",
-            xbgn_max=0.0, xend_max=2.0, fxn2="max",
+            min_xbgn=0.0, min_xend=2.0, min_fxn="min",
+            max_xbgn=0.0, max_xend=2.0, max_fxn="max",
         )
         data = _make_data("RecordA0", [0.0, 5.0, 10.0])
         op.run_init()
@@ -1509,10 +1509,10 @@ class TestNMMainOpNormalize(unittest.TestCase):
         np.testing.assert_array_almost_equal(data.nparray, [0.0, 0.5, 1.0])
 
     def test_per_array_mean_zero_range(self):
-        # fxn1=mean and fxn2=mean over same window → ref_min==ref_max → norm_min everywhere
+        # min_fxn=mean and max_fxn=mean over same window → ref_min==ref_max → norm_min everywhere
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=4.0, fxn1="mean",
-            xbgn_max=0.0, xend_max=4.0, fxn2="mean",
+            min_xbgn=0.0, min_xend=4.0, min_fxn="mean",
+            max_xbgn=0.0, max_xend=4.0, max_fxn="mean",
             norm_min=-99.0,
         )
         data = _make_data("RecordA0", [0.0, 2.0, 4.0, 6.0, 8.0])
@@ -1523,8 +1523,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_per_array_uses_windows(self):
         # [0,1,2,3,4] xdelta=1; window1=[0,0]→first point(0), window2=[4,4]→last point(4)
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=0.0, fxn1="mean",
-            xbgn_max=4.0, xend_max=4.0, fxn2="mean",
+            min_xbgn=0.0, min_xend=0.0, min_fxn="mean",
+            max_xbgn=4.0, max_xend=4.0, max_fxn="mean",
         )
         data = _make_data("RecordA0", [0.0, 1.0, 2.0, 3.0, 4.0])
         op.run_init()
@@ -1534,8 +1534,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_per_array_custom_norm_range(self):
         # norm_min=-1, norm_max=1; [0,5,10]→ref_min=0,ref_max=10 → [-1,0,1]
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=2.0, fxn1="min",
-            xbgn_max=0.0, xend_max=2.0, fxn2="max",
+            min_xbgn=0.0, min_xend=2.0, min_fxn="min",
+            max_xbgn=0.0, max_xend=2.0, max_fxn="max",
             norm_min=-1.0, norm_max=1.0,
         )
         data = _make_data("RecordA0", [0.0, 5.0, 10.0])
@@ -1544,11 +1544,11 @@ class TestNMMainOpNormalize(unittest.TestCase):
         np.testing.assert_array_almost_equal(data.nparray, [-1.0, 0.0, 1.0])
 
     def test_per_array_mean_at_min(self):
-        # [3,1,2], fxn1=mean@min, n_mean1=3; min at i=1, mean of [3,1,2]=2.0 → ref_min=2.0
-        # fxn2=max → ref_max=3.0; range=1; normalized: arr-2.0 → [1,-1,0]
+        # [3,1,2], min_fxn=mean@min, min_mean_n=3; min at i=1, mean of [3,1,2]=2.0 → ref_min=2.0
+        # max_fxn=max → ref_max=3.0; range=1; normalized: arr-2.0 → [1,-1,0]
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=2.0, fxn1="mean@min", n_mean1=3,
-            xbgn_max=0.0, xend_max=2.0, fxn2="max",
+            min_xbgn=0.0, min_xend=2.0, min_fxn="mean@min", min_mean_n=3,
+            max_xbgn=0.0, max_xend=2.0, max_fxn="max",
         )
         data = _make_data("RecordA0", [3.0, 1.0, 2.0])
         op.run_init()
@@ -1556,11 +1556,11 @@ class TestNMMainOpNormalize(unittest.TestCase):
         np.testing.assert_array_almost_equal(data.nparray, [1.0, -1.0, 0.0])
 
     def test_per_array_mean_at_max(self):
-        # [1,5,3], fxn2=mean@max, n_mean2=3; max at i=1, mean of [1,5,3]=3.0 → ref_max=3.0
-        # fxn1=min → ref_min=1.0; range=2; normalized: (arr-1)/2 → [0,2,1]
+        # [1,5,3], max_fxn=mean@max, max_mean_n=3; max at i=1, mean of [1,5,3]=3.0 → ref_max=3.0
+        # min_fxn=min → ref_min=1.0; range=2; normalized: (arr-1)/2 → [0,2,1]
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=2.0, fxn1="min",
-            xbgn_max=0.0, xend_max=2.0, fxn2="mean@max", n_mean2=3,
+            min_xbgn=0.0, min_xend=2.0, min_fxn="min",
+            max_xbgn=0.0, max_xend=2.0, max_fxn="mean@max", max_mean_n=3,
         )
         data = _make_data("RecordA0", [1.0, 5.0, 3.0])
         op.run_init()
@@ -1569,8 +1569,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
 
     def test_per_array_preserves_length(self):
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=99.0, fxn1="min",
-            xbgn_max=0.0, xend_max=99.0, fxn2="max",
+            min_xbgn=0.0, min_xend=99.0, min_fxn="min",
+            max_xbgn=0.0, max_xend=99.0, max_fxn="max",
         )
         data = _make_data("RecordA0", list(range(100)))
         op.run_init()
@@ -1583,8 +1583,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_average_mode_shared_refs(self):
         # 2 arrays same channel; ref_mins=[0,2]→avg=1, ref_maxes=[4,6]→avg=5, range=4
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=1.0, fxn1="min",
-            xbgn_max=0.0, xend_max=1.0, fxn2="max",
+            min_xbgn=0.0, min_xend=1.0, min_fxn="min",
+            max_xbgn=0.0, max_xend=1.0, max_fxn="max",
             mode="average",
         )
         d0 = _make_data("RecordA0", [0.0, 4.0])
@@ -1596,8 +1596,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
     def test_average_mode_per_channel(self):
         # Channel A ref_max=10, channel B ref_max=5 — independent
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=1.0, fxn1="min",
-            xbgn_max=0.0, xend_max=1.0, fxn2="max",
+            min_xbgn=0.0, min_xend=1.0, min_fxn="min",
+            max_xbgn=0.0, max_xend=1.0, max_fxn="max",
             mode="average",
         )
         dA = _make_data("RecordA0", [0.0, 10.0])
@@ -1614,25 +1614,25 @@ class TestNMMainOpNormalize(unittest.TestCase):
     # ------------------------------------------------------------------
     # validation
 
-    def test_fxn1_rejects_unknown(self):
+    def test_min_fxn_rejects_unknown(self):
         with self.assertRaises(ValueError):
-            NMMainOpNormalize(fxn1="bad")
+            NMMainOpNormalize(min_fxn="bad")
 
-    def test_fxn1_rejects_non_string(self):
+    def test_min_fxn_rejects_non_string(self):
         with self.assertRaises(TypeError):
-            NMMainOpNormalize(fxn1=42)
+            NMMainOpNormalize(min_fxn=42)
 
-    def test_fxn2_rejects_unknown(self):
+    def test_max_fxn_rejects_unknown(self):
         with self.assertRaises(ValueError):
-            NMMainOpNormalize(fxn2="bad")
+            NMMainOpNormalize(max_fxn="bad")
 
-    def test_n_mean1_rejects_bool(self):
+    def test_min_mean_n_rejects_bool(self):
         with self.assertRaises(TypeError):
-            NMMainOpNormalize(n_mean1=True)
+            NMMainOpNormalize(min_mean_n=True)
 
-    def test_n_mean1_rejects_zero(self):
+    def test_min_mean_n_rejects_zero(self):
         with self.assertRaises(ValueError):
-            NMMainOpNormalize(n_mean1=0)
+            NMMainOpNormalize(min_mean_n=0)
 
     def test_norm_min_rejects_bool(self):
         with self.assertRaises(TypeError):
@@ -1646,26 +1646,26 @@ class TestNMMainOpNormalize(unittest.TestCase):
         with self.assertRaises(ValueError):
             NMMainOpNormalize(mode="bad")
 
-    def test_x1_min_before_x0_min_raises(self):
-        op = NMMainOpNormalize(xbgn_min=5.0, xend_min=0.0)
+    def test_min_xend_before_min_xbgn_raises(self):
+        op = NMMainOpNormalize(min_xbgn=5.0, min_xend=0.0)
         with self.assertRaises(ValueError):
             op.run_init()
 
-    def test_x0_min_rejects_nan(self):
+    def test_min_xbgn_rejects_nan(self):
         with self.assertRaises(ValueError):
-            NMMainOpNormalize(xbgn_min=float("nan"))
+            NMMainOpNormalize(min_xbgn=float("nan"))
 
-    def test_x1_min_rejects_nan(self):
+    def test_min_xend_rejects_nan(self):
         with self.assertRaises(ValueError):
-            NMMainOpNormalize(xend_min=float("nan"))
+            NMMainOpNormalize(min_xend=float("nan"))
 
-    def test_x0_max_rejects_nan(self):
+    def test_max_xbgn_rejects_nan(self):
         with self.assertRaises(ValueError):
-            NMMainOpNormalize(xbgn_max=float("nan"))
+            NMMainOpNormalize(max_xbgn=float("nan"))
 
-    def test_x1_max_rejects_nan(self):
+    def test_max_xend_rejects_nan(self):
         with self.assertRaises(ValueError):
-            NMMainOpNormalize(xend_max=float("nan"))
+            NMMainOpNormalize(max_xend=float("nan"))
 
     # ------------------------------------------------------------------
     # edge cases / notes
@@ -1679,8 +1679,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
 
     def test_note_per_array(self):
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=2.0, fxn1="min",
-            xbgn_max=0.0, xend_max=2.0, fxn2="max",
+            min_xbgn=0.0, min_xend=2.0, min_fxn="min",
+            max_xbgn=0.0, max_xend=2.0, max_fxn="max",
             mode="per_array",
         )
         data = _make_data("RecordA0", [0.0, 5.0, 10.0])
@@ -1695,8 +1695,8 @@ class TestNMMainOpNormalize(unittest.TestCase):
 
     def test_note_average(self):
         op = NMMainOpNormalize(
-            xbgn_min=0.0, xend_min=1.0, fxn1="min",
-            xbgn_max=0.0, xend_max=1.0, fxn2="max",
+            min_xbgn=0.0, min_xend=1.0, min_fxn="min",
+            max_xbgn=0.0, max_xend=1.0, max_fxn="max",
             mode="average",
         )
         data = _make_data("RecordA0", [0.0, 10.0])


### PR DESCRIPTION
## Summary

- Renames `NMMainOpNormalize` parameters to prefix-first grouping for
  consistency with Igor NeuroMatic naming convention
- All Window 1 parameters now start with `min_`, all Window 2 with `max_`

| Old | New |
|-----|-----|
| `xbgn_min` | `min_xbgn` |
| `xend_min` | `min_xend` |
| `fxn1` | `min_fxn` |
| `n_mean1` | `min_mean_n` |
| `xbgn_max` | `max_xbgn` |
| `xend_max` | `max_xend` |
| `fxn2` | `max_fxn` |
| `n_mean2` | `max_mean_n` |

## Test plan

- [x] `NMMainOpNormalize` smoke test passes with new parameter names
- [x] 733 tests passing across nm_math, nm_tool_fit, nm_tool_spike, nm_tool_event — no regressions
- [x] Closes #299
