### PR TITLE
refactor(analysis): promote xbgn/xend to NMTool base class

### DIFF
--- a/pyneuromatic/analysis/nm_tool.py
+++ b/pyneuromatic/analysis/nm_tool.py
@@ -21,6 +21,7 @@ Paper: https://doi.org/10.3389/fninf.2018.00014
 from __future__ import annotations
 
 import datetime
+import math
 
 import pyneuromatic.core.nm_history as nmh
 import pyneuromatic.core.nm_command_history as nmch
@@ -70,6 +71,10 @@ class NMTool:
         self._results_to_history: bool = False
         self._results_to_cache: bool = True
         self._results_to_numpy: bool = False
+
+        # X-axis window — subclasses init from config.
+        self._xbgn: float = -math.inf
+        self._xend: float = math.inf
 
     @property
     def name(self) -> str:
@@ -166,6 +171,42 @@ class NMTool:
         nmch.add_nm_command(
             "%s.results_to_numpy = %r" % (self._name, self._results_to_numpy)
         )
+
+    @property
+    def xbgn(self) -> float:
+        """X-axis window start. Default ``-inf`` (no lower bound)."""
+        return self._xbgn
+
+    @xbgn.setter
+    def xbgn(self, value: float) -> None:
+        self._xbgn_set(value)
+
+    def _xbgn_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "xbgn", "float"))
+        if math.isnan(value):
+            raise ValueError("xbgn cannot be NaN")
+        self._xbgn = float(value)
+        nmh.history("set xbgn=%g" % self._xbgn, quiet=quiet)
+        nmch.add_nm_command("%s.xbgn = %r" % (self._name, self._xbgn))
+
+    @property
+    def xend(self) -> float:
+        """X-axis window end. Default ``+inf`` (no upper bound)."""
+        return self._xend
+
+    @xend.setter
+    def xend(self, value: float) -> None:
+        self._xend_set(value)
+
+    def _xend_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "xend", "float"))
+        if math.isnan(value):
+            raise ValueError("xend cannot be NaN")
+        self._xend = float(value)
+        nmh.history("set xend=%g" % self._xend, quiet=quiet)
+        nmch.add_nm_command("%s.xend = %r" % (self._name, self._xend))
 
     # Read-only convenience properties for accessing selection
     @property

--- a/pyneuromatic/analysis/nm_tool_event.py
+++ b/pyneuromatic/analysis/nm_tool_event.py
@@ -184,9 +184,10 @@ class NMToolEvent(NMTool):
         self.__peak_nstdv:    float = 1.0
         self.__peak_limit:    float = 4.0
         self.__refractory:    float = 0.0
-        self.__xbgn:          float = -math.inf
-        self.__xend:          float = math.inf
         self.__max_events:    int   = 0
+
+        self._xbgn = self._config.xbgn
+        self._xend = self._config.xend
 
         # Match criterion cache — keyed by (id(data.nparray), template_baseline)
         self._match_criterion_cache_id: tuple | None      = None
@@ -577,42 +578,6 @@ class NMToolEvent(NMTool):
         )
 
     @property
-    def xbgn(self) -> float:
-        """X-axis search start. Default ``-inf``."""
-        return self.__xbgn
-
-    @xbgn.setter
-    def xbgn(self, value: float) -> None:
-        self._xbgn_set(value)
-
-    def _xbgn_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xbgn", "float"))
-        if math.isnan(value):
-            raise ValueError("xbgn cannot be NaN")
-        self.__xbgn = float(value)
-        nmh.history("set xbgn=%g" % self.__xbgn, quiet=quiet)
-        nmch.add_nm_command("%s.xbgn = %r" % (self._name, self.__xbgn))
-
-    @property
-    def xend(self) -> float:
-        """X-axis search end. Default ``+inf``."""
-        return self.__xend
-
-    @xend.setter
-    def xend(self, value: float) -> None:
-        self._xend_set(value)
-
-    def _xend_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xend", "float"))
-        if math.isnan(value):
-            raise ValueError("xend cannot be NaN")
-        self.__xend = float(value)
-        nmh.history("set xend=%g" % self.__xend, quiet=quiet)
-        nmch.add_nm_command("%s.xend = %r" % (self._name, self.__xend))
-
-    @property
     def max_events(self) -> int:
         """Max accepted events per epoch (0 = no limit)."""
         return self.__max_events
@@ -692,7 +657,7 @@ class NMToolEvent(NMTool):
             % (
                 epoch_name, alg, pol, params,
                 self.__onset_search, self.__peak_search, self.__refractory,
-                self.__xbgn, self.__xend, n_accept, n_reject,
+                self._xbgn, self._xend, n_accept, n_reject,
             )
         )
 
@@ -748,8 +713,8 @@ class NMToolEvent(NMTool):
             criterion_threshold=self.__criterion_threshold,
             template_baseline=self.__template_baseline,
             refractory=self.__refractory,
-            xbgn=self.__xbgn,
-            xend=self.__xend,
+            xbgn=self._xbgn,
+            xend=self._xend,
             onset_search=self.__onset_search,
             onset_avg=self.__onset_avg,
             onset_nstdv=self.__onset_nstdv,
@@ -950,7 +915,7 @@ class NMToolEvent(NMTool):
             template_baseline=self.__template_baseline,
             refractory=self.__refractory,
             xbgn=start_x,
-            xend=self.__xend,
+            xend=self._xend,
             onset_search=self.__onset_search,
             onset_avg=self.__onset_avg,
             onset_nstdv=self.__onset_nstdv,

--- a/pyneuromatic/analysis/nm_tool_fit.py
+++ b/pyneuromatic/analysis/nm_tool_fit.py
@@ -167,9 +167,10 @@ class NMToolFit(NMTool):
         self._results_to_cache = self._config.results_to_cache
         self._results_to_numpy = self._config.results_to_numpy
 
+        self._xbgn = self._config.xbgn
+        self._xend = self._config.xend
+
         self.__func_name: str = "line"
-        self.__xbgn: float = -math.inf
-        self.__xend: float = math.inf
         self.__maxfev: int = self._config.maxfev
         self.__x_origin: float = self._config.x_origin
 
@@ -211,42 +212,6 @@ class NMToolFit(NMTool):
         self.__func_name = value
         nmh.history("set func_name=%r" % self.__func_name, quiet=quiet)
         nmch.add_nm_command("%s.func_name = %r" % (self._name, self.__func_name))
-
-    @property
-    def xbgn(self) -> float:
-        """Fit window start (x-units). Default ``-inf``."""
-        return self.__xbgn
-
-    @xbgn.setter
-    def xbgn(self, value: float) -> None:
-        self._xbgn_set(value)
-
-    def _xbgn_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xbgn", "float"))
-        if math.isnan(value):
-            raise ValueError("xbgn cannot be NaN")
-        self.__xbgn = float(value)
-        nmh.history("set xbgn=%g" % self.__xbgn, quiet=quiet)
-        nmch.add_nm_command("%s.xbgn = %r" % (self._name, self.__xbgn))
-
-    @property
-    def xend(self) -> float:
-        """Fit window end (x-units). Default ``+inf``."""
-        return self.__xend
-
-    @xend.setter
-    def xend(self, value: float) -> None:
-        self._xend_set(value)
-
-    def _xend_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xend", "float"))
-        if math.isnan(value):
-            raise ValueError("xend cannot be NaN")
-        self.__xend = float(value)
-        nmh.history("set xend=%g" % self.__xend, quiet=quiet)
-        nmch.add_nm_command("%s.xend = %r" % (self._name, self.__xend))
 
     @property
     def maxfev(self) -> int:
@@ -416,8 +381,8 @@ class NMToolFit(NMTool):
         result = fit_nmdata(
             data,
             func_name=self.__func_name,
-            xbgn=self.__xbgn,
-            xend=self.__xend,
+            xbgn=self._xbgn,
+            xend=self._xend,
             degree=degree,
             x_origin=self.__x_origin,
             p0=self.__p0,
@@ -452,8 +417,8 @@ class NMToolFit(NMTool):
         """Build the notes annotation string for output arrays."""
         parts = [
             "NMFit(func_name=%r" % self.__func_name,
-            "xbgn=%s" % self.__xbgn,
-            "xend=%s" % self.__xend,
+            "xbgn=%s" % self._xbgn,
+            "xend=%s" % self._xend,
             "n_epochs=%d" % len(self._epoch_names),
         ]
         if self.__func_name == "exp" and self.__x_origin != 0.0:

--- a/pyneuromatic/analysis/nm_tool_spike.py
+++ b/pyneuromatic/analysis/nm_tool_spike.py
@@ -113,10 +113,11 @@ class NMToolSpike(NMTool):
         self._results_to_cache = self._config.results_to_cache
         self._results_to_numpy = self._config.results_to_numpy
 
+        self._xbgn = self._config.xbgn
+        self._xend = self._config.xend
+
         self.__ylevel: float = 0.0
         self.__func_name: str = "level+"
-        self.__xbgn: float = -math.inf
-        self.__xend: float = math.inf
 
         # Internal run state — reset by run_init()
         self._spike_times: list[np.ndarray] = []
@@ -176,42 +177,6 @@ class NMToolSpike(NMTool):
         nmh.history("set func_name=%r" % self.__func_name, quiet=quiet)
         nmch.add_nm_command("%s.func_name = %r" % (self._name, self.__func_name))
 
-    @property
-    def xbgn(self) -> float:
-        """X-axis window start for detection. Default ``-inf`` (no lower bound)."""
-        return self.__xbgn
-
-    @xbgn.setter
-    def xbgn(self, value: float) -> None:
-        self._xbgn_set(value)
-
-    def _xbgn_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xbgn", "float"))
-        if math.isnan(value):
-            raise ValueError("xbgn cannot be NaN")
-        self.__xbgn = float(value)
-        nmh.history("set xbgn=%g" % self.__xbgn, quiet=quiet)
-        nmch.add_nm_command("%s.xbgn = %r" % (self._name, self.__xbgn))
-
-    @property
-    def xend(self) -> float:
-        """X-axis window end for detection. Default ``+inf`` (no upper bound)."""
-        return self.__xend
-
-    @xend.setter
-    def xend(self, value: float) -> None:
-        self._xend_set(value)
-
-    def _xend_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError(nmu.type_error_str(value, "xend", "float"))
-        if math.isnan(value):
-            raise ValueError("xend cannot be NaN")
-        self.__xend = float(value)
-        nmh.history("set xend=%g" % self.__xend, quiet=quiet)
-        nmch.add_nm_command("%s.xend = %r" % (self._name, self.__xend))
-
     # ------------------------------------------------------------------
     # Lifecycle
 
@@ -244,8 +209,8 @@ class NMToolSpike(NMTool):
         _indexes, x_times = find_level_crossings_nmdata(
             data, self.__ylevel,
             func_name=self.__func_name,
-            xbgn=self.__xbgn,
-            xend=self.__xend,
+            xbgn=self._xbgn,
+            xend=self._xend,
             ignore_nans=self._ignore_nans,
         )
         self._spike_times.append(x_times)
@@ -308,7 +273,7 @@ class NMToolSpike(NMTool):
                 d,
                 "NMSpike(source=%s, ylevel=%g, func_name=%r, xbgn=%s, xend=%s, n=%d)"
                 % (name, self.__ylevel, self.__func_name,
-                   self.__xbgn, self.__xend, len(times)),
+                   self._xbgn, self._xend, len(times)),
             )
         counts = np.array([len(t) for t in self._spike_times], dtype=float)
         d_count = f.data.new("SP_count", nparray=counts)
@@ -316,7 +281,7 @@ class NMToolSpike(NMTool):
             d_count,
             "NMSpike(ylevel=%g, func_name=%r, xbgn=%s, xend=%s, n_epochs=%d)"
             % (self.__ylevel, self.__func_name,
-               self.__xbgn, self.__xend, len(self._epoch_names)),
+               self._xbgn, self._xend, len(self._epoch_names)),
         )
         f.data.new(
             "SP_epoch_names",

--- a/tests/test_analysis/test_nm_tool.py
+++ b/tests/test_analysis/test_nm_tool.py
@@ -5,6 +5,7 @@ Tests for NMTool base class.
 Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
 acquiring and simulating electrophysiology data.
 """
+import math
 import unittest
 
 from pyneuromatic.core.nm_manager import NMManager, HIERARCHY_SELECT_KEYS
@@ -978,6 +979,73 @@ class TestNMToolOutputFlags(unittest.TestCase):
     def test_results_to_numpy_rejects_non_bool(self):
         with self.assertRaises(TypeError):
             self.tool.results_to_numpy = 0
+
+
+class TestNMToolXWindow(unittest.TestCase):
+    """Tests for xbgn/xend x-axis window properties on NMTool base class."""
+
+    def setUp(self):
+        self.tool = NMTool()
+
+    # --- defaults ---
+
+    def test_xbgn_default(self):
+        self.assertEqual(self.tool.xbgn, -math.inf)
+
+    def test_xend_default(self):
+        self.assertEqual(self.tool.xend, math.inf)
+
+    # --- xbgn ---
+
+    def test_xbgn_accepts_float(self):
+        self.tool.xbgn = 0.01
+        self.assertAlmostEqual(self.tool.xbgn, 0.01)
+
+    def test_xbgn_accepts_int(self):
+        self.tool.xbgn = 5
+        self.assertEqual(self.tool.xbgn, 5.0)
+
+    def test_xbgn_accepts_neg_inf(self):
+        self.tool.xbgn = -math.inf
+        self.assertEqual(self.tool.xbgn, -math.inf)
+
+    def test_xbgn_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            self.tool.xbgn = math.nan
+
+    def test_xbgn_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.xbgn = True
+
+    def test_xbgn_rejects_string(self):
+        with self.assertRaises(TypeError):
+            self.tool.xbgn = "start"
+
+    # --- xend ---
+
+    def test_xend_accepts_float(self):
+        self.tool.xend = 0.05
+        self.assertAlmostEqual(self.tool.xend, 0.05)
+
+    def test_xend_accepts_int(self):
+        self.tool.xend = 100
+        self.assertEqual(self.tool.xend, 100.0)
+
+    def test_xend_accepts_pos_inf(self):
+        self.tool.xend = math.inf
+        self.assertEqual(self.tool.xend, math.inf)
+
+    def test_xend_rejects_nan(self):
+        with self.assertRaises(ValueError):
+            self.tool.xend = math.nan
+
+    def test_xend_rejects_bool(self):
+        with self.assertRaises(TypeError):
+            self.tool.xend = False
+
+    def test_xend_rejects_string(self):
+        with self.assertRaises(TypeError):
+            self.tool.xend = "end"
 
 
 class TestNMToolConfigProperty(unittest.TestCase):

--- a/tests/test_analysis/test_nm_tool_event.py
+++ b/tests/test_analysis/test_nm_tool_event.py
@@ -150,12 +150,6 @@ class TestNMToolEventDefaults(unittest.TestCase):
     def test_refractory_default(self):
         self.assertEqual(self.tool.refractory, 0.0)
 
-    def test_xbgn_default(self):
-        self.assertEqual(self.tool.xbgn, -math.inf)
-
-    def test_xend_default(self):
-        self.assertEqual(self.tool.xend, math.inf)
-
     def test_max_events_default(self):
         self.assertEqual(self.tool.max_events, 0)
 
@@ -311,31 +305,6 @@ class TestNMToolEventProperties(unittest.TestCase):
     def test_refractory_rejects_negative(self):
         with self.assertRaises(ValueError):
             self.tool.refractory = -1.0
-
-    # xbgn / xend
-    def test_xbgn_accepts_float(self):
-        self.tool.xbgn = 0.01
-        self.assertAlmostEqual(self.tool.xbgn, 0.01)
-
-    def test_xend_accepts_float(self):
-        self.tool.xend = 0.01
-        self.assertAlmostEqual(self.tool.xend, 0.01)
-
-    def test_xbgn_rejects_nan(self):
-        with self.assertRaises(ValueError):
-            self.tool.xbgn = math.nan
-
-    def test_xend_rejects_nan(self):
-        with self.assertRaises(ValueError):
-            self.tool.xend = math.nan
-
-    def test_xbgn_rejects_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.xbgn = True
-
-    def test_xend_rejects_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.xend = True
 
     # template_baseline
     def test_template_baseline_accepts_zero(self):

--- a/tests/test_analysis/test_nm_tool_fit.py
+++ b/tests/test_analysis/test_nm_tool_fit.py
@@ -86,12 +86,6 @@ class TestNMToolFitDefaults(unittest.TestCase):
     def test_no_degree_property(self):
         self.assertFalse(hasattr(self.tool, "degree"))
 
-    def test_xbgn_default(self):
-        self.assertEqual(self.tool.xbgn, -math.inf)
-
-    def test_xend_default(self):
-        self.assertEqual(self.tool.xend, math.inf)
-
     def test_p0_default(self):
         self.assertIsNone(self.tool.p0)
 
@@ -160,26 +154,6 @@ class TestNMToolFitProperties(unittest.TestCase):
     def test_func_name_type_error(self):
         with self.assertRaises(TypeError):
             self.tool.func_name = 3
-
-    def test_xbgn_valid(self):
-        self.tool.xbgn = 5.0
-        self.assertEqual(self.tool.xbgn, 5.0)
-
-    def test_xbgn_nan_raises(self):
-        with self.assertRaises(ValueError):
-            self.tool.xbgn = float("nan")
-
-    def test_xbgn_type_error(self):
-        with self.assertRaises(TypeError):
-            self.tool.xbgn = "start"
-
-    def test_xend_valid(self):
-        self.tool.xend = 100.0
-        self.assertEqual(self.tool.xend, 100.0)
-
-    def test_xend_nan_raises(self):
-        with self.assertRaises(ValueError):
-            self.tool.xend = float("nan")
 
     def test_p0_dict_accepted(self):
         self.tool.p0 = {"A": 1.0, "Tau": 5.0}

--- a/tests/test_analysis/test_nm_tool_spike.py
+++ b/tests/test_analysis/test_nm_tool_spike.py
@@ -83,14 +83,6 @@ class TestNMToolSpikeDefaults(unittest.TestCase):
     def test_func_name_default(self):
         self.assertEqual(self.tool.func_name, "level+")
 
-    def test_xbgn_default(self):
-        import math
-        self.assertEqual(self.tool.xbgn, -math.inf)
-
-    def test_xend_default(self):
-        import math
-        self.assertEqual(self.tool.xend, math.inf)
-
     def test_ignore_nans_default(self):
         self.assertTrue(self.tool.ignore_nans)
 
@@ -143,40 +135,6 @@ class TestNMToolSpikeProperties(unittest.TestCase):
     def test_func_name_rejects_non_string(self):
         with self.assertRaises(TypeError):
             self.tool.func_name = 1
-
-    # xbgn / xend
-    def test_xbgn_accepts_float(self):
-        self.tool.xbgn = 0.01
-        self.assertAlmostEqual(self.tool.xbgn, 0.01)
-
-    def test_xbgn_accepts_inf(self):
-        import math
-        self.tool.xbgn = -math.inf
-        self.assertEqual(self.tool.xbgn, -math.inf)
-
-    def test_xbgn_rejects_nan(self):
-        import math
-        with self.assertRaises(ValueError):
-            self.tool.xbgn = math.nan
-
-    def test_xbgn_rejects_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.xbgn = True
-
-    def test_xend_accepts_float(self):
-        self.tool.xend = 0.05
-        self.assertAlmostEqual(self.tool.xend, 0.05)
-
-    def test_xend_rejects_nan(self):
-        import math
-        with self.assertRaises(ValueError):
-            self.tool.xend = math.nan
-
-    def test_xend_rejects_bool(self):
-        with self.assertRaises(TypeError):
-            self.tool.xend = False
-
-
 
 class TestNMToolSpikeDetection(unittest.TestCase):
     """run_all detection behaviour."""


### PR DESCRIPTION
## Summary

- Move `xbgn`/`xend` x-axis window properties from `NMToolSpike`,
  `NMToolEvent`, and `NMToolFit` into `NMTool`, eliminating ~100 lines
  of duplicated property/setter code across the three subclasses
- Each subclass `__init__` now syncs `_xbgn`/`_xend` from its config;
  all internal references updated from name-mangled `__xbgn`/`__xend`
  to the inherited protected attrs
- Consolidate generic default and validation tests into a new
  `TestNMToolXWindow` class in `test_nm_tool.py`; behaviour tests
  (detection/fit window restriction) remain in the subclass files

Closes #301 

## Test plan

- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool.py` — new `TestNMToolXWindow` (14 tests)
- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_spike.py tests/test_analysis/test_nm_tool_event.py tests/test_analysis/test_nm_tool_fit.py` — regression check on all subclass tests
