### PR TITLE
feat(analysis): add double-exponential and Boltzmann fits to NMToolFit

### DIFF
--- a/pyneuromatic/analysis/nm_tool_fit.py
+++ b/pyneuromatic/analysis/nm_tool_fit.py
@@ -37,7 +37,7 @@ from pyneuromatic.analysis.nm_tool_utilities import fit_nmdata
 
 _POLY_FUNC_NAMES: list[str] = ["poly%d" % d for d in range(2, 10)]
 _VALID_FUNC_NAMES: frozenset[str] = frozenset(
-    {"line", "exp", "gauss"} | set(_POLY_FUNC_NAMES)
+    {"line", "exp", "exp2", "gauss", "boltzmann"} | set(_POLY_FUNC_NAMES)
 )
 
 
@@ -62,9 +62,16 @@ def _eval_model(func_name: str, result: dict, x: np.ndarray) -> np.ndarray:
     if fn == "exp":
         A, B, X0, Y0 = result["A"], result["Tau"], result["X0"], result["Y0"]
         return A * np.exp(-(x - X0) / B) + Y0
+    if fn == "exp2":
+        A1, B1, A2, B2 = result["A1"], result["Tau1"], result["A2"], result["Tau2"]
+        X0, Y0 = result["X0"], result["Y0"]
+        return A1 * np.exp(-(x - X0) / B1) + A2 * np.exp(-(x - X0) / B2) + Y0
     if fn == "gauss":
         A, mu, sg, Y0 = result["A"], result["Mu"], result["Sigma"], result["Y0"]
         return A * np.exp(-0.5 * ((x - mu) / sg) ** 2) + Y0
+    if fn == "boltzmann":
+        A, V50, K, Y0 = result["A"], result["V50"], result["K"], result["Y0"]
+        return A / (1.0 + np.exp(-(x - V50) / K)) + Y0
     return np.full_like(x, float("nan"), dtype=float)
 
 
@@ -89,7 +96,7 @@ class NMToolFitConfig(NMToolConfig):
     _TOML_TYPE = "fit_config"
     _schema = {
         "func_name":          {"type": str,   "default": "line",
-                               "choices": ["line"] + _POLY_FUNC_NAMES + ["exp", "gauss"]},
+                               "choices": ["line"] + _POLY_FUNC_NAMES + ["exp", "exp2", "gauss", "boltzmann"]},
         "xbgn":                 {"type": float, "default": -math.inf},
         "xend":                 {"type": float, "default":  math.inf},
         "maxfev":             {"type": int,   "default": 10000, "min": 1},
@@ -121,8 +128,12 @@ class NMToolFit(NMTool):
       (Ck = coefficient of x^k)
     * ``"exp"``               — ``y = A * exp(-(x - X0) / Tau) + Y0``
       (A = amplitude, Tau = decay time constant, X0 = fixed x-origin, Y0 = y-offset)
+    * ``"exp2"``              — ``y = A1 * exp(-(x - X0) / Tau1) + A2 * exp(-(x - X0) / Tau2) + Y0``
+      (Tau1 ≤ Tau2 after fitting; X0 = fixed x-origin)
     * ``"gauss"``             — ``y = A * exp(-0.5 * ((x - mu) / sigma)^2) + Y0``
       (A = amplitude, mu = mean, sigma = std dev, Y0 = y-offset)
+    * ``"boltzmann"``         — ``y = A / (1 + exp(-(x - V50) / K)) + Y0``
+      (A = amplitude, V50 = midpoint, K = slope factor, Y0 = y-offset)
 
     Initial parameters for nonlinear fits (``exp``, ``gauss``) are
     auto-estimated from the data; supply *p0* to override.  ``X0`` in the
@@ -421,7 +432,7 @@ class NMToolFit(NMTool):
             "xend=%s" % self._xend,
             "n_epochs=%d" % len(self._epoch_names),
         ]
-        if self.__func_name == "exp" and self.__x_origin != 0.0:
+        if self.__func_name in ("exp", "exp2") and self.__x_origin != 0.0:
             parts.append("x_origin=%s" % self.__x_origin)
         if not self._ignore_nans:
             parts.append("ignore_nans=False")
@@ -519,6 +530,23 @@ class NMToolFit(NMTool):
                 _write("err_" + p("Tau"), [r["Tau_err"] for r in self._fit_results])
                 _write("err_" + p("Y0"),  [r["Y0_err"]  for r in self._fit_results])
 
+        elif self.__func_name == "exp2":
+            _write(p("A1"),     [r["A1"]   for r in self._fit_results])
+            _write(p("Tau1"),   [r["Tau1"] for r in self._fit_results])
+            _write(p("A2"),     [r["A2"]   for r in self._fit_results])
+            _write(p("Tau2"),   [r["Tau2"] for r in self._fit_results])
+            _write(p("X0"),     [r["X0"]   for r in self._fit_results])
+            _write(p("Y0"),     [r["Y0"]   for r in self._fit_results])
+            _write("R2",        [r["r2"]        for r in self._fit_results])
+            _write("ChiSqr",    [r["chi_sqr"]   for r in self._fit_results])
+            _write("Converged", [float(r["converged"]) for r in self._fit_results])
+            if self.__results_errors:
+                _write("err_" + p("A1"),   [r["A1_err"]   for r in self._fit_results])
+                _write("err_" + p("Tau1"), [r["Tau1_err"] for r in self._fit_results])
+                _write("err_" + p("A2"),   [r["A2_err"]   for r in self._fit_results])
+                _write("err_" + p("Tau2"), [r["Tau2_err"] for r in self._fit_results])
+                _write("err_" + p("Y0"),   [r["Y0_err"]   for r in self._fit_results])
+
         elif self.__func_name == "gauss":
             _write(p("A"),      [r["A"]     for r in self._fit_results])
             _write(p("Mu"),     [r["Mu"]    for r in self._fit_results])
@@ -532,6 +560,20 @@ class NMToolFit(NMTool):
                 _write("err_" + p("Mu"),    [r["Mu_err"]    for r in self._fit_results])
                 _write("err_" + p("Sigma"), [r["Sigma_err"] for r in self._fit_results])
                 _write("err_" + p("Y0"),    [r["Y0_err"]    for r in self._fit_results])
+
+        elif self.__func_name == "boltzmann":
+            _write(p("A"),   [r["A"]   for r in self._fit_results])
+            _write(p("V50"), [r["V50"] for r in self._fit_results])
+            _write(p("K"),   [r["K"]   for r in self._fit_results])
+            _write(p("Y0"),  [r["Y0"]  for r in self._fit_results])
+            _write("R2",        [r["r2"]        for r in self._fit_results])
+            _write("ChiSqr",    [r["chi_sqr"]   for r in self._fit_results])
+            _write("Converged", [float(r["converged"]) for r in self._fit_results])
+            if self.__results_errors:
+                _write("err_" + p("A"),   [r["A_err"]   for r in self._fit_results])
+                _write("err_" + p("V50"), [r["V50_err"] for r in self._fit_results])
+                _write("err_" + p("K"),   [r["K_err"]   for r in self._fit_results])
+                _write("err_" + p("Y0"),  [r["Y0_err"]  for r in self._fit_results])
 
         if self.__results_residuals:
             for name, result in zip(self._epoch_names, self._fit_results):

--- a/pyneuromatic/analysis/nm_tool_fit.py
+++ b/pyneuromatic/analysis/nm_tool_fit.py
@@ -70,8 +70,8 @@ def _eval_model(func_name: str, result: dict, x: np.ndarray) -> np.ndarray:
         A, mu, sg, Y0 = result["A"], result["Mu"], result["Sigma"], result["Y0"]
         return A * np.exp(-0.5 * ((x - mu) / sg) ** 2) + Y0
     if fn == "boltzmann":
-        A, V50, K, Y0 = result["A"], result["V50"], result["K"], result["Y0"]
-        return A / (1.0 + np.exp(-(x - V50) / K)) + Y0
+        A, X50, K, Y0 = result["A"], result["X50"], result["K"], result["Y0"]
+        return A / (1.0 + np.exp(-(x - X50) / K)) + Y0
     return np.full_like(x, float("nan"), dtype=float)
 
 
@@ -132,8 +132,8 @@ class NMToolFit(NMTool):
       (Tau1 ≤ Tau2 after fitting; X0 = fixed x-origin)
     * ``"gauss"``             — ``y = A * exp(-0.5 * ((x - mu) / sigma)^2) + Y0``
       (A = amplitude, mu = mean, sigma = std dev, Y0 = y-offset)
-    * ``"boltzmann"``         — ``y = A / (1 + exp(-(x - V50) / K)) + Y0``
-      (A = amplitude, V50 = midpoint, K = slope factor, Y0 = y-offset)
+    * ``"boltzmann"``         — ``y = A / (1 + exp(-(x - X50) / K)) + Y0``
+      (A = amplitude, X50 = midpoint, K = slope factor, Y0 = y-offset)
 
     Initial parameters for nonlinear fits (``exp``, ``gauss``) are
     auto-estimated from the data; supply *p0* to override.  ``X0`` in the
@@ -563,7 +563,7 @@ class NMToolFit(NMTool):
 
         elif self.__func_name == "boltzmann":
             _write(p("A"),   [r["A"]   for r in self._fit_results])
-            _write(p("V50"), [r["V50"] for r in self._fit_results])
+            _write(p("X50"), [r["X50"] for r in self._fit_results])
             _write(p("K"),   [r["K"]   for r in self._fit_results])
             _write(p("Y0"),  [r["Y0"]  for r in self._fit_results])
             _write("R2",        [r["r2"]        for r in self._fit_results])
@@ -571,7 +571,7 @@ class NMToolFit(NMTool):
             _write("Converged", [float(r["converged"]) for r in self._fit_results])
             if self.__results_errors:
                 _write("err_" + p("A"),   [r["A_err"]   for r in self._fit_results])
-                _write("err_" + p("V50"), [r["V50_err"] for r in self._fit_results])
+                _write("err_" + p("X50"), [r["X50_err"] for r in self._fit_results])
                 _write("err_" + p("K"),   [r["K_err"]   for r in self._fit_results])
                 _write("err_" + p("Y0"),  [r["Y0_err"]  for r in self._fit_results])
 

--- a/pyneuromatic/analysis/nm_tool_utilities.py
+++ b/pyneuromatic/analysis/nm_tool_utilities.py
@@ -438,11 +438,15 @@ def fit_nmdata(
         return nm_math.fit_poly(data.nparray, degree=degree, sigma=sigma, **common)
     if func_name == "exp":
         return nm_math.fit_exp(data.nparray, x_origin=x_origin, p0=p0, sigma=sigma, maxfev=maxfev, **common)
+    if func_name == "exp2":
+        return nm_math.fit_exp2(data.nparray, x_origin=x_origin, p0=p0, sigma=sigma, maxfev=maxfev, **common)
     if func_name == "gauss":
         return nm_math.fit_gauss(data.nparray, p0=p0, sigma=sigma, maxfev=maxfev, **common)
+    if func_name == "boltzmann":
+        return nm_math.fit_boltzmann(data.nparray, p0=p0, sigma=sigma, maxfev=maxfev, **common)
     raise ValueError(
-        "fit_nmdata: func_name must be 'line', 'poly2'–'poly9', 'exp', or 'gauss', got %r"
-        % func_name
+        "fit_nmdata: func_name must be 'line', 'poly2'–'poly9', 'exp', 'exp2', "
+        "'gauss', or 'boltzmann', got %r" % func_name
     )
 
 

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -2294,3 +2294,265 @@ def fit_gauss(
         "n":         n,
         "converged": converged,
     }
+
+
+def fit_exp2(
+    yarray: np.ndarray,
+    xstart: float = 0.0,
+    xdelta: float = 1.0,
+    xarray: np.ndarray | None = None,
+    xbgn: float = -math.inf,
+    xend: float = math.inf,
+    x_origin: float = 0.0,
+    p0: dict | None = None,
+    sigma: np.ndarray | None = None,
+    maxfev: int = 10000,
+    ignore_nans: bool = True,
+) -> dict:
+    """Fit a double exponential to *yarray*.
+
+    Model: ``f(x) = A1 * exp(-(x - X0) / Tau1) + A2 * exp(-(x - X0) / Tau2) + Y0``
+
+    where:
+
+    * **A1**, **A2** — amplitudes
+    * **Tau1**, **Tau2** — time constants (sorted so Tau1 ≤ Tau2 after fitting)
+    * **X0** — fixed x-origin (``x_origin``); not fitted
+    * **Y0** — y-offset
+
+    Missing initial-parameter keys in *p0* are auto-estimated:
+    ``A1 = A2 = (y[0] - y[-1]) / 2``, ``Tau1 = range/5``,
+    ``Tau2 = range/2``, ``Y0 = y[-1]``.
+
+    Args:
+        yarray:    1-D numpy array of y-values.
+        xstart:    X-axis start value (uniform spacing).
+        xdelta:    X-axis sample interval (uniform spacing).
+        xarray:    Non-uniform x-values array; overrides *xstart*/*xdelta*.
+        xbgn:      Fit window start (x-units). Default ``-inf``.
+        xend:      Fit window end (x-units). Default ``+inf``.
+        x_origin:  Fixed x-offset (X0) in the model. Default 0.0.
+        p0:        Initial parameter estimates as a dict with optional keys
+                   ``"A1"``, ``"Tau1"``, ``"A2"``, ``"Tau2"``, ``"Y0"``.
+                   Missing keys are auto-estimated.
+        sigma:     Per-point standard deviations for weighted fitting.
+        maxfev:    Maximum function evaluations for the optimizer. Default 10000.
+        ignore_nans: If True (default), exclude NaN values before fitting.
+
+    Returns:
+        Dict with keys:
+
+        * ``"A1"``, ``"Tau1"``, ``"A2"``, ``"Tau2"``, ``"X0"``, ``"Y0"``
+          — fitted parameters (Tau1 ≤ Tau2; ``"X0"`` echoes ``x_origin``)
+        * ``"A1_err"``, ``"Tau1_err"``, ``"A2_err"``, ``"Tau2_err"``,
+          ``"Y0_err"`` — one-standard-deviation parameter uncertainties
+        * ``"r2"``, ``"chi_sqr"``, ``"yfit"``, ``"residuals"``, ``"x"``,
+          ``"n"``, ``"converged"``
+
+    Raises:
+        ValueError: Fewer than 5 data points, or *sigma* length mismatch.
+    """
+    from scipy.optimize import curve_fit  # noqa: PLC0415
+
+    x, y = _extract_xy_window(yarray, xstart, xdelta, xarray, xbgn, xend, ignore_nans)
+    n = len(x)
+    if n < 5:
+        raise ValueError("fit_exp2: need at least 5 data points, got %d" % n)
+
+    if sigma is not None and len(sigma) != n:
+        raise ValueError(
+            "fit_exp2: sigma length (%d) != windowed data length (%d)" % (len(sigma), n)
+        )
+
+    p0_dict = p0 or {}
+    _win = max(1, n // 10)
+    _y_start = float(np.nanmedian(y[:_win]))
+    _y_end   = float(np.nanmedian(y[-_win:]))
+    _half_amp = (_y_start - _y_end) / 2.0
+    x_span = float(x[-1] - x[0])
+    A1_0   = p0_dict.get("A1",   _half_amp)
+    Tau1_0 = p0_dict.get("Tau1", x_span / 5.0 if x_span > 0 else 1.0)
+    A2_0   = p0_dict.get("A2",   _half_amp)
+    Tau2_0 = p0_dict.get("Tau2", x_span / 2.0 if x_span > 0 else 2.0)
+    Y0_0   = p0_dict.get("Y0",   _y_end)
+
+    def _model(xv, A1, B1, A2, B2, Y0):
+        return A1 * np.exp(-(xv - x_origin) / B1) + A2 * np.exp(-(xv - x_origin) / B2) + Y0
+
+    converged = True
+    try:
+        popt, pcov = curve_fit(
+            _model, x, y,
+            p0=[A1_0, Tau1_0, A2_0, Tau2_0, Y0_0],
+            sigma=sigma,
+            absolute_sigma=(sigma is not None),
+            maxfev=maxfev,
+        )
+        A1_f, B1_f, A2_f, B2_f, Y0_f = [float(v) for v in popt]
+        perr = np.sqrt(np.maximum(0.0, np.diag(pcov)))
+        A1_e, B1_e, A2_e, B2_e, Y0_e = [float(v) for v in perr]
+        # Sort so Tau1 <= Tau2
+        if B1_f > B2_f:
+            A1_f, B1_f, A1_e, B1_e, A2_f, B2_f, A2_e, B2_e = (
+                A2_f, B2_f, A2_e, B2_e, A1_f, B1_f, A1_e, B1_e
+            )
+    except RuntimeError:
+        A1_f, B1_f, A2_f, B2_f, Y0_f = A1_0, Tau1_0, A2_0, Tau2_0, Y0_0
+        A1_e = B1_e = A2_e = B2_e = Y0_e = float("nan")
+        converged = False
+
+    y_fit = _model(x, A1_f, B1_f, A2_f, B2_f, Y0_f)
+    r2 = _r2(y, y_fit)
+    residuals = y - y_fit
+    if sigma is not None:
+        chi_sqr = float(np.sum((residuals / np.asarray(sigma, dtype=float)) ** 2))
+    else:
+        chi_sqr = float(np.sum(residuals ** 2)) / n
+
+    return {
+        "A1":      A1_f,
+        "Tau1":    B1_f,
+        "A2":      A2_f,
+        "Tau2":    B2_f,
+        "X0":      float(x_origin),
+        "Y0":      Y0_f,
+        "A1_err":  A1_e,
+        "Tau1_err": B1_e,
+        "A2_err":  A2_e,
+        "Tau2_err": B2_e,
+        "Y0_err":  Y0_e,
+        "r2":        r2,
+        "chi_sqr":   chi_sqr,
+        "yfit":      y_fit,
+        "residuals": residuals,
+        "x":         x,
+        "n":         n,
+        "converged": converged,
+    }
+
+
+def fit_boltzmann(
+    yarray: np.ndarray,
+    xstart: float = 0.0,
+    xdelta: float = 1.0,
+    xarray: np.ndarray | None = None,
+    xbgn: float = -math.inf,
+    xend: float = math.inf,
+    p0: dict | None = None,
+    sigma: np.ndarray | None = None,
+    maxfev: int = 10000,
+    ignore_nans: bool = True,
+) -> dict:
+    """Fit a Boltzmann sigmoid to *yarray*.
+
+    Model: ``f(x) = A / (1 + exp(-(x - V50) / K)) + Y0``
+
+    where:
+
+    * **A** — amplitude (range of the sigmoid)
+    * **V50** — midpoint (x at half-maximum)
+    * **K** — slope factor (positive = rising, negative = falling)
+    * **Y0** — y-offset (baseline)
+
+    Missing initial-parameter keys in *p0* are auto-estimated:
+    ``Y0 = min(y)``, ``A = max(y) - min(y)``,
+    ``V50 = x at y closest to Y0 + A/2``, ``K = (x[-1] - x[0]) / 10``.
+
+    Args:
+        yarray:    1-D numpy array of y-values.
+        xstart:    X-axis start value (uniform spacing).
+        xdelta:    X-axis sample interval (uniform spacing).
+        xarray:    Non-uniform x-values array; overrides *xstart*/*xdelta*.
+        xbgn:      Fit window start (x-units). Default ``-inf``.
+        xend:      Fit window end (x-units). Default ``+inf``.
+        p0:        Initial parameter estimates as a dict with optional keys
+                   ``"A"``, ``"V50"``, ``"K"``, ``"Y0"``.
+                   Missing keys are auto-estimated.
+        sigma:     Per-point standard deviations for weighted fitting.
+        maxfev:    Maximum function evaluations for the optimizer. Default 10000.
+        ignore_nans: If True (default), exclude NaN values before fitting.
+
+    Returns:
+        Dict with keys:
+
+        * ``"A"``, ``"V50"``, ``"K"``, ``"Y0"`` — fitted parameters
+        * ``"A_err"``, ``"V50_err"``, ``"K_err"``, ``"Y0_err"``
+          — one-standard-deviation parameter uncertainties
+        * ``"r2"``, ``"chi_sqr"``, ``"yfit"``, ``"residuals"``, ``"x"``,
+          ``"n"``, ``"converged"``
+
+    Raises:
+        ValueError: Fewer than 4 data points, or *sigma* length mismatch.
+    """
+    from scipy.optimize import curve_fit  # noqa: PLC0415
+
+    x, y = _extract_xy_window(yarray, xstart, xdelta, xarray, xbgn, xend, ignore_nans)
+    n = len(x)
+    if n < 4:
+        raise ValueError("fit_boltzmann: need at least 4 data points, got %d" % n)
+
+    if sigma is not None and len(sigma) != n:
+        raise ValueError(
+            "fit_boltzmann: sigma length (%d) != windowed data length (%d)"
+            % (len(sigma), n)
+        )
+
+    p0_dict = p0 or {}
+    y_min = float(np.nanmin(y))
+    y_max = float(np.nanmax(y))
+    x_span = float(x[-1] - x[0])
+    Y0_0  = p0_dict.get("Y0",  y_min)
+    A0    = p0_dict.get("A",   y_max - y_min)
+    # x closest to half-maximum
+    half  = Y0_0 + A0 / 2.0
+    V50_0 = p0_dict.get("V50", float(x[int(np.argmin(np.abs(y - half)))]))
+    # Sign of K: positive for rising, negative for falling sigmoid
+    _K_mag = x_span / 10.0 if x_span > 0 else 1.0
+    _rising = float(np.nanmean(y[n // 2:])) >= float(np.nanmean(y[:n // 2]))
+    K0    = p0_dict.get("K",   _K_mag if _rising else -_K_mag)
+
+    def _model(xv, A, V50, K, Y0):
+        return A / (1.0 + np.exp(-(xv - V50) / K)) + Y0
+
+    converged = True
+    try:
+        popt, pcov = curve_fit(
+            _model, x, y,
+            p0=[A0, V50_0, K0, Y0_0],
+            sigma=sigma,
+            absolute_sigma=(sigma is not None),
+            maxfev=maxfev,
+        )
+        A_f, V50_f, K_f, Y0_f = [float(v) for v in popt]
+        perr = np.sqrt(np.maximum(0.0, np.diag(pcov)))
+        A_e, V50_e, K_e, Y0_e = [float(v) for v in perr]
+    except RuntimeError:
+        A_f, V50_f, K_f, Y0_f = A0, V50_0, K0, Y0_0
+        A_e = V50_e = K_e = Y0_e = float("nan")
+        converged = False
+
+    y_fit = _model(x, A_f, V50_f, K_f, Y0_f)
+    r2 = _r2(y, y_fit)
+    residuals = y - y_fit
+    if sigma is not None:
+        chi_sqr = float(np.sum((residuals / np.asarray(sigma, dtype=float)) ** 2))
+    else:
+        chi_sqr = float(np.sum(residuals ** 2)) / n
+
+    return {
+        "A":       A_f,
+        "V50":     V50_f,
+        "K":       K_f,
+        "Y0":      Y0_f,
+        "A_err":   A_e,
+        "V50_err": V50_e,
+        "K_err":   K_e,
+        "Y0_err":  Y0_e,
+        "r2":        r2,
+        "chi_sqr":   chi_sqr,
+        "yfit":      y_fit,
+        "residuals": residuals,
+        "x":         x,
+        "n":         n,
+        "converged": converged,
+    }

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -2445,18 +2445,18 @@ def fit_boltzmann(
 ) -> dict:
     """Fit a Boltzmann sigmoid to *yarray*.
 
-    Model: ``f(x) = A / (1 + exp(-(x - V50) / K)) + Y0``
+    Model: ``f(x) = A / (1 + exp(-(x - X50) / K)) + Y0``
 
     where:
 
     * **A** — amplitude (range of the sigmoid)
-    * **V50** — midpoint (x at half-maximum)
+    * **X50** — midpoint (x at half-maximum)
     * **K** — slope factor (positive = rising, negative = falling)
     * **Y0** — y-offset (baseline)
 
     Missing initial-parameter keys in *p0* are auto-estimated:
     ``Y0 = min(y)``, ``A = max(y) - min(y)``,
-    ``V50 = x at y closest to Y0 + A/2``, ``K = (x[-1] - x[0]) / 10``.
+    ``X50 = x at y closest to Y0 + A/2``, ``K = (x[-1] - x[0]) / 10``.
 
     Args:
         yarray:    1-D numpy array of y-values.
@@ -2466,7 +2466,7 @@ def fit_boltzmann(
         xbgn:      Fit window start (x-units). Default ``-inf``.
         xend:      Fit window end (x-units). Default ``+inf``.
         p0:        Initial parameter estimates as a dict with optional keys
-                   ``"A"``, ``"V50"``, ``"K"``, ``"Y0"``.
+                   ``"A"``, ``"X50"``, ``"K"``, ``"Y0"``.
                    Missing keys are auto-estimated.
         sigma:     Per-point standard deviations for weighted fitting.
         maxfev:    Maximum function evaluations for the optimizer. Default 10000.
@@ -2475,8 +2475,8 @@ def fit_boltzmann(
     Returns:
         Dict with keys:
 
-        * ``"A"``, ``"V50"``, ``"K"``, ``"Y0"`` — fitted parameters
-        * ``"A_err"``, ``"V50_err"``, ``"K_err"``, ``"Y0_err"``
+        * ``"A"``, ``"X50"``, ``"K"``, ``"Y0"`` — fitted parameters
+        * ``"A_err"``, ``"X50_err"``, ``"K_err"``, ``"Y0_err"``
           — one-standard-deviation parameter uncertainties
         * ``"r2"``, ``"chi_sqr"``, ``"yfit"``, ``"residuals"``, ``"x"``,
           ``"n"``, ``"converged"``
@@ -2505,33 +2505,33 @@ def fit_boltzmann(
     A0    = p0_dict.get("A",   y_max - y_min)
     # x closest to half-maximum
     half  = Y0_0 + A0 / 2.0
-    V50_0 = p0_dict.get("V50", float(x[int(np.argmin(np.abs(y - half)))]))
+    X50_0 = p0_dict.get("X50", float(x[int(np.argmin(np.abs(y - half)))]))
     # Sign of K: positive for rising, negative for falling sigmoid
     _K_mag = x_span / 10.0 if x_span > 0 else 1.0
     _rising = float(np.nanmean(y[n // 2:])) >= float(np.nanmean(y[:n // 2]))
     K0    = p0_dict.get("K",   _K_mag if _rising else -_K_mag)
 
-    def _model(xv, A, V50, K, Y0):
-        return A / (1.0 + np.exp(-(xv - V50) / K)) + Y0
+    def _model(xv, A, X50, K, Y0):
+        return A / (1.0 + np.exp(-(xv - X50) / K)) + Y0
 
     converged = True
     try:
         popt, pcov = curve_fit(
             _model, x, y,
-            p0=[A0, V50_0, K0, Y0_0],
+            p0=[A0, X50_0, K0, Y0_0],
             sigma=sigma,
             absolute_sigma=(sigma is not None),
             maxfev=maxfev,
         )
-        A_f, V50_f, K_f, Y0_f = [float(v) for v in popt]
+        A_f, X50_f, K_f, Y0_f = [float(v) for v in popt]
         perr = np.sqrt(np.maximum(0.0, np.diag(pcov)))
-        A_e, V50_e, K_e, Y0_e = [float(v) for v in perr]
+        A_e, X50_e, K_e, Y0_e = [float(v) for v in perr]
     except RuntimeError:
-        A_f, V50_f, K_f, Y0_f = A0, V50_0, K0, Y0_0
-        A_e = V50_e = K_e = Y0_e = float("nan")
+        A_f, X50_f, K_f, Y0_f = A0, X50_0, K0, Y0_0
+        A_e = X50_e = K_e = Y0_e = float("nan")
         converged = False
 
-    y_fit = _model(x, A_f, V50_f, K_f, Y0_f)
+    y_fit = _model(x, A_f, X50_f, K_f, Y0_f)
     r2 = _r2(y, y_fit)
     residuals = y - y_fit
     if sigma is not None:
@@ -2541,11 +2541,11 @@ def fit_boltzmann(
 
     return {
         "A":       A_f,
-        "V50":     V50_f,
+        "X50":     X50_f,
         "K":       K_f,
         "Y0":      Y0_f,
         "A_err":   A_e,
-        "V50_err": V50_e,
+        "X50_err": X50_e,
         "K_err":   K_e,
         "Y0_err":  Y0_e,
         "r2":        r2,

--- a/tests/test_analysis/test_nm_tool_fit.py
+++ b/tests/test_analysis/test_nm_tool_fit.py
@@ -63,9 +63,9 @@ def _make_exp2_data(A1, Tau1, A2, Tau2, C, n=_N, xstart=_XSTART, xdelta=_XDELTA,
                   xscale={"start": xstart, "delta": xdelta})
 
 
-def _make_boltzmann_data(A, V50, k, C, n=_N, xstart=_XSTART, xdelta=_XDELTA, name="recordA0"):
+def _make_boltzmann_data(A, X50, k, C, n=_N, xstart=_XSTART, xdelta=_XDELTA, name="recordA0"):
     x = xstart + np.arange(n) * xdelta
-    y = A / (1.0 + np.exp(-(x - V50) / k)) + C
+    y = A / (1.0 + np.exp(-(x - X50) / k)) + C
     return NMData(NM, name=name, nparray=y,
                   xscale={"start": xstart, "delta": xdelta})
 
@@ -1196,18 +1196,18 @@ class TestNMToolFitBoltzmann(unittest.TestCase):
         tool.func_name = "boltzmann"
         folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, 10.0, 0.0)])
         tf = folder.toolfolders.get("Fit_Boltzmann_0")
-        for name in ("FT_A", "FT_V50", "FT_K", "FT_Y0",
+        for name in ("FT_A", "FT_X50", "FT_K", "FT_Y0",
                      "FT_R2", "FT_ChiSqr", "FT_Converged"):
             self.assertIn(name, tf.data, msg="%s missing" % name)
 
     def test_params_match_known_values(self):
-        A, V50, K, C = 1.0, 50.0, 10.0, 0.0
+        A, X50, K, C = 1.0, 50.0, 10.0, 0.0
         tool = NMToolFit()
         tool.func_name = "boltzmann"
-        folder = _run(tool, [_make_boltzmann_data(A, V50, K, C)])
+        folder = _run(tool, [_make_boltzmann_data(A, X50, K, C)])
         tf = folder.toolfolders.get("Fit_Boltzmann_0")
         self.assertAlmostEqual(float(tf.data["FT_A"].nparray[0]),   A,   places=4)
-        self.assertAlmostEqual(float(tf.data["FT_V50"].nparray[0]), V50, places=3)
+        self.assertAlmostEqual(float(tf.data["FT_X50"].nparray[0]), X50, places=3)
         self.assertAlmostEqual(float(tf.data["FT_K"].nparray[0]),   K,   places=3)
         self.assertAlmostEqual(float(tf.data["FT_Y0"].nparray[0]),  C,   places=4)
 
@@ -1234,7 +1234,7 @@ class TestNMToolFitBoltzmann(unittest.TestCase):
         tool.results_errors = True
         folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, 10.0, 0.0)])
         tf = folder.toolfolders.get("Fit_Boltzmann_0")
-        for name in ("FT_err_A", "FT_err_V50", "FT_err_K", "FT_err_Y0"):
+        for name in ("FT_err_A", "FT_err_X50", "FT_err_K", "FT_err_Y0"):
             self.assertIn(name, tf.data, msg="%s missing" % name)
 
     def test_converged_is_one_for_exact_data(self):
@@ -1256,7 +1256,7 @@ class TestNMToolFitBoltzmann(unittest.TestCase):
     def test_p0_override_used(self):
         tool = NMToolFit()
         tool.func_name = "boltzmann"
-        tool.p0 = {"V50": 50.0, "K": 10.0}
+        tool.p0 = {"X50": 50.0, "K": 10.0}
         folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, 10.0, 0.0)])
         tf = folder.toolfolders.get("Fit_Boltzmann_0")
         self.assertGreater(float(tf.data["FT_R2"].nparray[0]), 0.999)

--- a/tests/test_analysis/test_nm_tool_fit.py
+++ b/tests/test_analysis/test_nm_tool_fit.py
@@ -56,6 +56,20 @@ def _make_gauss_data(A, mu, sigma_g, C, n=_N, xstart=_XSTART, xdelta=_XDELTA, na
                   xscale={"start": xstart, "delta": xdelta})
 
 
+def _make_exp2_data(A1, Tau1, A2, Tau2, C, n=_N, xstart=_XSTART, xdelta=_XDELTA, name="recordA0"):
+    x = xstart + np.arange(n) * xdelta
+    y = A1 * np.exp(-x / Tau1) + A2 * np.exp(-x / Tau2) + C
+    return NMData(NM, name=name, nparray=y,
+                  xscale={"start": xstart, "delta": xdelta})
+
+
+def _make_boltzmann_data(A, V50, k, C, n=_N, xstart=_XSTART, xdelta=_XDELTA, name="recordA0"):
+    x = xstart + np.arange(n) * xdelta
+    y = A / (1.0 + np.exp(-(x - V50) / k)) + C
+    return NMData(NM, name=name, nparray=y,
+                  xscale={"start": xstart, "delta": xdelta})
+
+
 def _make_targets(data_list, folder=None):
     if folder is None:
         folder = NMFolder(NM, name="TestFolder")
@@ -1062,6 +1076,195 @@ class TestNMToolFitParamNames(unittest.TestCase):
         tf = folder.toolfolders.get("Fit_Line_0")
         self.assertIn("FT_M", tf.data)
         self.assertIn("FT_B", tf.data)
+
+
+# ---------------------------------------------------------------------------
+# Double exponential
+# ---------------------------------------------------------------------------
+
+class TestNMToolFitExp2(unittest.TestCase):
+
+    def test_func_name_exp2_accepted(self):
+        tool = NMToolFit()
+        tool.func_name = "exp2"
+        self.assertEqual(tool.func_name, "exp2")
+
+    def test_toolfolder_name_exp2(self):
+        tool = NMToolFit()
+        tool.func_name = "exp2"
+        folder = _run(tool, [_make_exp2_data(30.0, 5.0, 20.0, 20.0, 2.0)])
+        self.assertIn("Fit_Exp2_0", folder.toolfolders)
+
+    def test_output_arrays_present(self):
+        tool = NMToolFit()
+        tool.func_name = "exp2"
+        folder = _run(tool, [_make_exp2_data(30.0, 5.0, 20.0, 20.0, 2.0)])
+        tf = folder.toolfolders.get("Fit_Exp2_0")
+        for name in ("FT_A1", "FT_Tau1", "FT_A2", "FT_Tau2", "FT_X0", "FT_Y0",
+                     "FT_R2", "FT_ChiSqr", "FT_Converged"):
+            self.assertIn(name, tf.data, msg="%s missing" % name)
+
+    def test_params_match_known_values(self):
+        A1, Tau1, A2, Tau2, C = 30.0, 5.0, 20.0, 20.0, 2.0
+        tool = NMToolFit()
+        tool.func_name = "exp2"
+        folder = _run(tool, [_make_exp2_data(A1, Tau1, A2, Tau2, C)])
+        tf = folder.toolfolders.get("Fit_Exp2_0")
+        fit_a1   = float(tf.data["FT_A1"].nparray[0])
+        fit_tau1 = float(tf.data["FT_Tau1"].nparray[0])
+        fit_a2   = float(tf.data["FT_A2"].nparray[0])
+        fit_tau2 = float(tf.data["FT_Tau2"].nparray[0])
+        fit_y0   = float(tf.data["FT_Y0"].nparray[0])
+        # Tau1 <= Tau2 after sorting
+        self.assertLessEqual(fit_tau1, fit_tau2)
+        self.assertAlmostEqual(fit_tau1, Tau1, places=3)
+        self.assertAlmostEqual(fit_tau2, Tau2, places=3)
+        self.assertAlmostEqual(fit_y0,   C,    places=3)
+        # A1 corresponds to smaller Tau1, A2 to larger Tau2
+        self.assertAlmostEqual(fit_a1, A1, places=2)
+        self.assertAlmostEqual(fit_a2, A2, places=2)
+
+    def test_r2_near_one_for_exact_data(self):
+        tool = NMToolFit()
+        tool.func_name = "exp2"
+        folder = _run(tool, [_make_exp2_data(30.0, 5.0, 20.0, 20.0, 2.0)])
+        tf = folder.toolfolders.get("Fit_Exp2_0")
+        r2 = float(tf.data["FT_R2"].nparray[0])
+        self.assertGreater(r2, 0.9999)
+
+    def test_tau_sorted_tau1_le_tau2(self):
+        tool = NMToolFit()
+        tool.func_name = "exp2"
+        # Deliberately give larger Tau first in p0 to ensure sort works
+        tool.p0 = {"Tau1": 20.0, "Tau2": 5.0}
+        folder = _run(tool, [_make_exp2_data(30.0, 5.0, 20.0, 20.0, 0.0)])
+        tf = folder.toolfolders.get("Fit_Exp2_0")
+        tau1 = float(tf.data["FT_Tau1"].nparray[0])
+        tau2 = float(tf.data["FT_Tau2"].nparray[0])
+        self.assertLessEqual(tau1, tau2)
+
+    def test_errors_written_when_enabled(self):
+        tool = NMToolFit()
+        tool.func_name = "exp2"
+        tool.results_errors = True
+        folder = _run(tool, [_make_exp2_data(30.0, 5.0, 20.0, 20.0, 2.0)])
+        tf = folder.toolfolders.get("Fit_Exp2_0")
+        for name in ("FT_err_A1", "FT_err_Tau1", "FT_err_A2", "FT_err_Tau2", "FT_err_Y0"):
+            self.assertIn(name, tf.data, msg="%s missing" % name)
+
+    def test_converged_is_one_for_exact_data(self):
+        tool = NMToolFit()
+        tool.func_name = "exp2"
+        folder = _run(tool, [_make_exp2_data(30.0, 5.0, 20.0, 20.0, 2.0)])
+        tf = folder.toolfolders.get("Fit_Exp2_0")
+        self.assertEqual(float(tf.data["FT_Converged"].nparray[0]), 1.0)
+
+    def test_multi_epoch_array_length(self):
+        tool = NMToolFit()
+        tool.func_name = "exp2"
+        d0 = _make_exp2_data(30.0, 5.0, 20.0, 20.0, 2.0, name="recordA0")
+        d1 = _make_exp2_data(15.0, 5.0, 10.0, 20.0, 1.0, name="recordA1")
+        folder = _run(tool, [d0, d1])
+        tf = folder.toolfolders.get("Fit_Exp2_0")
+        self.assertEqual(len(tf.data["FT_A1"].nparray), 2)
+
+    def test_config_accepts_exp2(self):
+        cfg = NMToolFitConfig()
+        cfg.func_name = "exp2"
+        self.assertEqual(cfg.func_name, "exp2")
+
+
+# ---------------------------------------------------------------------------
+# Boltzmann (sigmoid)
+# ---------------------------------------------------------------------------
+
+class TestNMToolFitBoltzmann(unittest.TestCase):
+
+    def test_func_name_boltzmann_accepted(self):
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        self.assertEqual(tool.func_name, "boltzmann")
+
+    def test_toolfolder_name_boltzmann(self):
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, 10.0, 0.0)])
+        self.assertIn("Fit_Boltzmann_0", folder.toolfolders)
+
+    def test_output_arrays_present(self):
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, 10.0, 0.0)])
+        tf = folder.toolfolders.get("Fit_Boltzmann_0")
+        for name in ("FT_A", "FT_V50", "FT_K", "FT_Y0",
+                     "FT_R2", "FT_ChiSqr", "FT_Converged"):
+            self.assertIn(name, tf.data, msg="%s missing" % name)
+
+    def test_params_match_known_values(self):
+        A, V50, K, C = 1.0, 50.0, 10.0, 0.0
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        folder = _run(tool, [_make_boltzmann_data(A, V50, K, C)])
+        tf = folder.toolfolders.get("Fit_Boltzmann_0")
+        self.assertAlmostEqual(float(tf.data["FT_A"].nparray[0]),   A,   places=4)
+        self.assertAlmostEqual(float(tf.data["FT_V50"].nparray[0]), V50, places=3)
+        self.assertAlmostEqual(float(tf.data["FT_K"].nparray[0]),   K,   places=3)
+        self.assertAlmostEqual(float(tf.data["FT_Y0"].nparray[0]),  C,   places=4)
+
+    def test_r2_near_one_for_exact_data(self):
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, 10.0, 0.0)])
+        tf = folder.toolfolders.get("Fit_Boltzmann_0")
+        r2 = float(tf.data["FT_R2"].nparray[0])
+        self.assertGreater(r2, 0.9999)
+
+    def test_falling_sigmoid_negative_k(self):
+        # Negative k → falling sigmoid
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, -10.0, 0.0)])
+        tf = folder.toolfolders.get("Fit_Boltzmann_0")
+        K_fit = float(tf.data["FT_K"].nparray[0])
+        self.assertLess(K_fit, 0.0)
+
+    def test_errors_written_when_enabled(self):
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        tool.results_errors = True
+        folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, 10.0, 0.0)])
+        tf = folder.toolfolders.get("Fit_Boltzmann_0")
+        for name in ("FT_err_A", "FT_err_V50", "FT_err_K", "FT_err_Y0"):
+            self.assertIn(name, tf.data, msg="%s missing" % name)
+
+    def test_converged_is_one_for_exact_data(self):
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, 10.0, 0.0)])
+        tf = folder.toolfolders.get("Fit_Boltzmann_0")
+        self.assertEqual(float(tf.data["FT_Converged"].nparray[0]), 1.0)
+
+    def test_multi_epoch_array_length(self):
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        d0 = _make_boltzmann_data(1.0, 50.0, 10.0, 0.0, name="recordA0")
+        d1 = _make_boltzmann_data(2.0, 40.0,  8.0, 0.5, name="recordA1")
+        folder = _run(tool, [d0, d1])
+        tf = folder.toolfolders.get("Fit_Boltzmann_0")
+        self.assertEqual(len(tf.data["FT_A"].nparray), 2)
+
+    def test_p0_override_used(self):
+        tool = NMToolFit()
+        tool.func_name = "boltzmann"
+        tool.p0 = {"V50": 50.0, "K": 10.0}
+        folder = _run(tool, [_make_boltzmann_data(1.0, 50.0, 10.0, 0.0)])
+        tf = folder.toolfolders.get("Fit_Boltzmann_0")
+        self.assertGreater(float(tf.data["FT_R2"].nparray[0]), 0.999)
+
+    def test_config_accepts_boltzmann(self):
+        cfg = NMToolFitConfig()
+        cfg.func_name = "boltzmann"
+        self.assertEqual(cfg.func_name, "boltzmann")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add `fit_exp2` (double exponential) and `fit_boltzmann` (sigmoid) to
  `nm_math.py`, following the existing `fit_exp`/`fit_gauss` pattern
- Route both through `fit_nmdata()` in `nm_tool_utilities.py`
- Wire up `_VALID_FUNC_NAMES`, config schema, `_eval_model`,
  `_note_str`, and `_write_results_to_numpy` in `NMToolFit`

**Double exponential** (`func_name="exp2"`):
`y = A1·exp(-(x−X0)/Tau1) + A2·exp(-(x−X0)/Tau2) + Y0`
— Tau1 ≤ Tau2 enforced after fitting; shared `x_origin` with `exp`

**Boltzmann sigmoid** (`func_name="boltzmann"`):
`y = A / (1 + exp(-(x−X50)/K)) + Y0`
— Auto-detects rising vs falling from data to initialise sign of K

Both support `sigma` (weighted fitting), `results_errors`,
`results_residuals`, and `results_fit_array`.

Closes #303

## Test plan

- [ ] `python3 -m pytest tests/test_analysis/test_nm_tool_fit.py` — 138 tests including new `TestNMToolFitExp2` (9 tests) and `TestNMToolFitBoltzmann` (9 tests)
- [ ] Verify parameter recovery on synthetic data (R² > 0.9999)
- [ ] Verify Tau1 ≤ Tau2 sorting for double exponential
- [ ] Verify negative K auto-detected for falling sigmoid
