### PR TITLE
feat(analysis): add NMToolPulse synthetic waveform generator

### DIFF
--- a/pyneuromatic/analysis/__init__.py
+++ b/pyneuromatic/analysis/__init__.py
@@ -2,5 +2,7 @@
 from pyneuromatic.analysis.nm_tool_event import NMToolEvent, NMToolEventConfig
 from pyneuromatic.analysis.nm_tool_fit import NMToolFit, NMToolFitConfig
 from pyneuromatic.analysis.nm_tool_main import NMToolMain
+from pyneuromatic.analysis.nm_pulse import NMPulse, NMPulseContainer
+from pyneuromatic.analysis.nm_tool_pulse import NMToolPulse, NMToolPulseConfig
 from pyneuromatic.analysis.nm_tool_spike import NMToolSpike, NMToolSpikeConfig
 from pyneuromatic.analysis.nm_tool_stats import NMToolStats, NMToolStatsConfig

--- a/pyneuromatic/analysis/nm_pulse.py
+++ b/pyneuromatic/analysis/nm_pulse.py
@@ -1,0 +1,494 @@
+# -*- coding: utf-8 -*-
+"""
+NMPulse and NMPulseContainer: single-pulse component and ordered container.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import numpy.random as _rng
+
+import pyneuromatic.core.nm_configurations as nmc
+import pyneuromatic.core.nm_history as nmh
+from pyneuromatic.core.nm_command_history import add_nm_command
+import pyneuromatic.core.nm_utilities as nmu
+from pyneuromatic.analysis.nm_pulse_func import (
+    NMPulseFunc,
+    NMPulseFuncSquare,
+    _VALID_SHAPES,
+    _pulse_func_from_dict,
+)
+
+_FLOAT_ATTRS: tuple[str, ...] = (
+    "amp", "onset", "width",
+    "amp_delta", "onset_delta", "width_delta",
+    "amp_stdv", "onset_stdv", "width_stdv",
+)
+
+# Keys that belong to the NMPulseFunc subclass, not to NMPulse directly.
+_FUNC_ONLY_KEYS: frozenset[str] = frozenset({
+    "tau", "freq", "phase", "f0", "f1", "data", "xdelta_data",
+})
+
+
+class NMPulse:
+    """Single pulse component: shape, parameters, and epoch targeting.
+
+    Lightweight class (does not inherit NMObject) following the NMStatWin
+    pattern. Each NMPulse defines one waveform component that can be added
+    to an output epoch array.
+
+    Epoch targeting:
+        - ``epoch="all"`` (default): fires on every epoch (stride controlled
+          by ``epoch_delta``).
+        - ``epoch=N``: fires starting at epoch N, then every ``epoch_delta``
+          epochs.
+
+    Parameter variation per occurrence (0-based firing count):
+        - ``delta_<param>``: linear shift per occurrence.
+        - ``stdv_<param>``: Gaussian noise σ added each occurrence.
+
+    Args:
+        name: Pulse name (default ``"NMPulse0"``).
+        config: Optional dict of initial parameter values.
+        nm_path: Dot-path used in command history entries.
+    """
+
+    def __init__(
+        self,
+        name: str = "NMPulse0",
+        config: dict | None = None,
+        nm_path: str = "pulse.pulses",
+    ) -> None:
+        if not isinstance(name, str) or not name:
+            raise ValueError("name must be a non-empty string")
+        self._name = name
+        self._nm_path = nm_path
+
+        self._func: NMPulseFunc = NMPulseFuncSquare()
+        self._epoch: int = 0
+        self._epoch_delta: int = 0
+        self._amp: float = 1.0
+        self._onset: float = 10.0
+        self._width: float = math.inf
+        self._amp_delta: float = 0.0
+        self._onset_delta: float = 0.0
+        self._width_delta: float = 0.0
+        self._amp_stdv: float = 0.0
+        self._onset_stdv: float = 0.0
+        self._width_stdv: float = 0.0
+
+        if config is not None:
+            self._config_set(config, quiet=True)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, NMPulse):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+    @property
+    def name(self) -> str:
+        """Pulse name string."""
+        return self._name
+
+    # ------------------------------------------------------------------
+    # pulse shape / func
+
+    @property
+    def func(self) -> NMPulseFunc:
+        """The NMPulseFunc instance holding shape-specific parameters."""
+        return self._func
+
+    @property
+    def pulse(self) -> str:
+        """Pulse shape name (e.g. ``"square"``, ``"sin"``, ``"user"``)."""
+        return self._func.name
+
+    @pulse.setter
+    def pulse(self, value: str) -> None:
+        self._pulse_set(value)
+        add_nm_command("%s[%r].pulse = %r" % (self._nm_path, self._name, value))
+
+    def _pulse_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
+        if not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "pulse", "string"))
+        if value not in _VALID_SHAPES:
+            raise ValueError(
+                "pulse must be one of %s, got %r" % (sorted(_VALID_SHAPES), value)
+            )
+        self._func = _pulse_func_from_dict({"pulse": value})
+        nmh.history("set pulse=%r" % value, path=self._name, quiet=quiet)
+
+    # ------------------------------------------------------------------
+    # epoch targeting
+
+    @property
+    def epoch(self) -> int:
+        """Starting epoch index (0-based). Use ``"all"`` as shorthand for ``epoch=0, epoch_delta=1``."""
+        return self._epoch
+
+    @epoch.setter
+    def epoch(self, value: int | str) -> None:
+        self._epoch_set(value)
+        add_nm_command("%s[%r].epoch = %r" % (self._nm_path, self._name, self._epoch))
+
+    def _epoch_set(self, value: int | str, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "epoch", "int or 'all'"))
+        if isinstance(value, str):
+            if value != "all":
+                raise ValueError("epoch string must be 'all', got %r" % value)
+            self._epoch = 0
+            self._epoch_delta = 1
+            nmh.history("set epoch='all' (epoch=0, epoch_delta=1)", path=self._name, quiet=quiet)
+            return
+        if not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "epoch", "int or 'all'"))
+        if value < 0:
+            raise ValueError("epoch must be >= 0, got %d" % value)
+        self._epoch = value
+        nmh.history("set epoch=%d" % self._epoch, path=self._name, quiet=quiet)
+
+    @property
+    def epoch_delta(self) -> int:
+        """Stride between firings (>= 0). ``0`` fires only once; ``2`` fires every other epoch."""
+        return self._epoch_delta
+
+    @epoch_delta.setter
+    def epoch_delta(self, value: int) -> None:
+        self._epoch_delta_set(value)
+        add_nm_command(
+            "%s[%r].epoch_delta = %r" % (self._nm_path, self._name, self._epoch_delta)
+        )
+
+    def _epoch_delta_set(self, value: int, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "epoch_delta", "int"))
+        if value < 0:
+            raise ValueError("epoch_delta must be >= 0, got %d" % value)
+        self._epoch_delta = value
+        nmh.history("set epoch_delta=%d" % self._epoch_delta, path=self._name, quiet=quiet)
+
+    # ------------------------------------------------------------------
+    # float parameters (amp, onset, width, delta_*, stdv_*)
+
+    def _float_set(self, attr: str, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, attr, "float"))
+        setattr(self, "_" + attr, float(value))
+        nmh.history("set %s=%g" % (attr, float(value)), path=self._name, quiet=quiet)
+
+    @property
+    def amp(self) -> float:
+        return self._amp
+
+    @amp.setter
+    def amp(self, value: float) -> None:
+        self._float_set("amp", value)
+        add_nm_command("%s[%r].amp = %r" % (self._nm_path, self._name, self._amp))
+
+    @property
+    def onset(self) -> float:
+        return self._onset
+
+    @onset.setter
+    def onset(self, value: float) -> None:
+        self._float_set("onset", value)
+        add_nm_command("%s[%r].onset = %r" % (self._nm_path, self._name, self._onset))
+
+    @property
+    def width(self) -> float:
+        return self._width
+
+    @width.setter
+    def width(self, value: float) -> None:
+        self._float_set("width", value)
+        add_nm_command("%s[%r].width = %r" % (self._nm_path, self._name, self._width))
+
+    @property
+    def amp_delta(self) -> float:
+        return self._amp_delta
+
+    @amp_delta.setter
+    def amp_delta(self, value: float) -> None:
+        self._float_set("amp_delta", value)
+        add_nm_command(
+            "%s[%r].amp_delta = %r" % (self._nm_path, self._name, self._amp_delta)
+        )
+
+    @property
+    def onset_delta(self) -> float:
+        return self._onset_delta
+
+    @onset_delta.setter
+    def onset_delta(self, value: float) -> None:
+        self._float_set("onset_delta", value)
+        add_nm_command(
+            "%s[%r].onset_delta = %r" % (self._nm_path, self._name, self._onset_delta)
+        )
+
+    @property
+    def width_delta(self) -> float:
+        return self._width_delta
+
+    @width_delta.setter
+    def width_delta(self, value: float) -> None:
+        self._float_set("width_delta", value)
+        add_nm_command(
+            "%s[%r].width_delta = %r" % (self._nm_path, self._name, self._width_delta)
+        )
+
+    @property
+    def amp_stdv(self) -> float:
+        return self._amp_stdv
+
+    @amp_stdv.setter
+    def amp_stdv(self, value: float) -> None:
+        self._float_set("amp_stdv", value)
+        add_nm_command(
+            "%s[%r].amp_stdv = %r" % (self._nm_path, self._name, self._amp_stdv)
+        )
+
+    @property
+    def onset_stdv(self) -> float:
+        return self._onset_stdv
+
+    @onset_stdv.setter
+    def onset_stdv(self, value: float) -> None:
+        self._float_set("onset_stdv", value)
+        add_nm_command(
+            "%s[%r].onset_stdv = %r" % (self._nm_path, self._name, self._onset_stdv)
+        )
+
+    @property
+    def width_stdv(self) -> float:
+        return self._width_stdv
+
+    @width_stdv.setter
+    def width_stdv(self, value: float) -> None:
+        self._float_set("width_stdv", value)
+        add_nm_command(
+            "%s[%r].width_stdv = %r" % (self._nm_path, self._name, self._width_stdv)
+        )
+
+    # ------------------------------------------------------------------
+    # Epoch targeting
+
+    def targets_epoch(self, epoch_idx: int) -> bool:
+        """Return True if this pulse fires on epoch *epoch_idx*.
+
+        When ``epoch_delta=0``: fires only on ``epoch``.
+        When ``epoch_delta=M``: fires on ``epoch``, ``epoch+M``, ``epoch+2M``, ...
+        """
+        if epoch_idx < self._epoch:
+            return False
+        if self._epoch_delta == 0:
+            return epoch_idx == self._epoch
+        return (epoch_idx - self._epoch) % self._epoch_delta == 0
+
+    def _occurrence_idx(self, epoch_idx: int) -> int:
+        """Return the 0-based firing count for *epoch_idx* (used to scale delta_*)."""
+        if self._epoch_delta == 0:
+            return 0
+        return (epoch_idx - self._epoch) // self._epoch_delta
+
+    # ------------------------------------------------------------------
+    # Waveform generation
+
+    def waveform(
+        self,
+        n_points: int,
+        xstart: float,
+        xdelta: float,
+        epoch_idx: int,
+    ) -> np.ndarray:
+        """Compute this pulse's contribution for *epoch_idx*.
+
+        Scales delta_* by occurrence index and adds stdv noise, then
+        delegates to the appropriate nm_math.pulse_* function.
+
+        Args:
+            n_points: Number of samples.
+            xstart: X-value of the first sample.
+            xdelta: Sample interval.
+            epoch_idx: 0-based epoch counter from NMToolPulse.run().
+
+        Returns:
+            1-D float64 array of length *n_points*.
+        """
+        occ = self._occurrence_idx(epoch_idx)
+        amp   = self._amp   + self._amp_delta   * occ + (
+            _rng.normal(0.0, self._amp_stdv)   if self._amp_stdv   > 0 else 0.0)
+        onset = self._onset + self._onset_delta * occ + (
+            _rng.normal(0.0, self._onset_stdv) if self._onset_stdv > 0 else 0.0)
+        width = self._width + self._width_delta * occ + (
+            _rng.normal(0.0, self._width_stdv) if self._width_stdv > 0 else 0.0)
+
+        return self._func.waveform(n_points, xstart, xdelta, amp, onset, width)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+
+    def _config_set(self, config: dict, quiet: bool = nmc.QUIET) -> None:
+        """Set multiple parameters from a dict. Unknown keys raise KeyError.
+
+        Two-phase: shape name + func-only keys (tau, freq, phase, f0, f1,
+        data, xdelta_data) are used to create/update the NMPulseFunc; all
+        other keys (amp, onset, width, delta_*, stdv_*, epoch, epoch_delta)
+        are applied to NMPulse attrs directly.
+        """
+        if not isinstance(config, dict):
+            raise TypeError(nmu.type_error_str(config, "config", "dict"))
+
+        # Validate all keys up front
+        pulse_name = None
+        func_kwargs: dict = {}
+        nm_attrs: dict = {}
+        for k, v in config.items():
+            if not isinstance(k, str):
+                raise TypeError(nmu.type_error_str(k, "key", "string"))
+            kl = k.lower()
+            if kl == "name":
+                continue
+            elif kl == "pulse":
+                pulse_name = v
+            elif kl in _FUNC_ONLY_KEYS:
+                func_kwargs[kl] = v
+            elif kl in ("epoch", "epoch_delta") or kl in _FLOAT_ATTRS:
+                nm_attrs[kl] = v
+            else:
+                raise KeyError("NMPulse: unknown config key %r" % k)
+
+        # Phase 1: update NMPulseFunc if pulse name or func-only keys changed
+        if pulse_name is not None or func_kwargs:
+            name = pulse_name if pulse_name is not None else self._func.name
+            self._func = _pulse_func_from_dict({"pulse": name, **func_kwargs})
+
+        # Phase 2: apply NMPulse scalar attrs
+        for kl, v in nm_attrs.items():
+            if kl == "epoch":
+                self._epoch_set(v, quiet=True)
+            elif kl == "epoch_delta":
+                self._epoch_delta_set(v, quiet=True)
+            else:
+                self._float_set(kl, v, quiet=True)
+
+        nmh.history("set config=%s" % config, path=self._name, quiet=quiet)
+
+    def to_dict(self) -> dict:
+        """Serialise to a plain dict (JSON/TOML-safe).
+
+        The ``"pulse"`` key and any shape-specific keys (e.g. ``"freq"``,
+        ``"tau"``) come from the embedded :class:`NMPulseFunc`.  Universal
+        parameters (amp, onset, width, tau) and variation parameters are
+        stored directly on NMPulse and take precedence over any overlapping
+        values in the func's dict.
+        """
+        d: dict = {
+            "name":          self._name,
+            "epoch":         self._epoch,
+            "epoch_delta":   self._epoch_delta,
+            "amp":           self._amp,
+            "onset":         self._onset,
+            "width":         self._width,
+            "amp_delta":     self._amp_delta,
+            "onset_delta":   self._onset_delta,
+            "width_delta":   self._width_delta,
+            "amp_stdv":      self._amp_stdv,
+            "onset_stdv":    self._onset_stdv,
+            "width_stdv":    self._width_stdv,
+        }
+        # Merge func-specific entries (pulse name + shape params like tau/freq/phase).
+        d.update(self._func.to_dict())
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict, nm_path: str = "pulse.pulses") -> "NMPulse":
+        """Reconstruct an NMPulse from a dict produced by ``to_dict()``."""
+        name = d.get("name", "NMPulse0")
+        p = cls(name=name, nm_path=nm_path)
+        p._config_set({k: v for k, v in d.items() if k != "name"}, quiet=True)
+        return p
+
+
+class NMPulseContainer:
+    """Ordered container of NMPulse objects with auto-naming.
+
+    Pulses are created via ``new()`` and named ``"p0"``, ``"p1"``, etc.
+
+    Args:
+        nm_path: Dot-path used in command history entries.
+    """
+
+    def __init__(self, nm_path: str = "pulse.pulses") -> None:
+        self._nm_path = nm_path
+        self._pulses: dict[str, NMPulse] = {}
+        self._count: int = 0
+
+    def new(
+        self,
+        config: dict | None = None,
+        quiet: bool = nmc.QUIET,
+    ) -> NMPulse:
+        """Create, register, and return a new NMPulse with an auto-name.
+
+        Args:
+            config: Optional dict of initial parameter values (passed to
+                ``NMPulse._config_set()``).
+
+        Returns:
+            The new NMPulse.
+        """
+        name = "p%d" % self._count
+        self._count += 1
+        p = NMPulse(name=name, config=config, nm_path=self._nm_path)
+        self._pulses[name] = p
+        nmh.history("new NMPulse=%s" % name, quiet=quiet)
+        add_nm_command("%s.new(%r)" % (self._nm_path, name))
+        return p
+
+    def __iter__(self):
+        """Iterate over NMPulse objects in insertion order."""
+        return iter(self._pulses.values())
+
+    def __len__(self) -> int:
+        return len(self._pulses)
+
+    def __getitem__(self, name: str) -> NMPulse:
+        return self._pulses[name]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._pulses
+
+    def to_dict(self) -> dict:
+        """Serialise the container to a plain dict."""
+        return {"pulses": [p.to_dict() for p in self._pulses.values()]}
+
+    @classmethod
+    def from_dict(cls, d: dict, nm_path: str = "pulse.pulses") -> "NMPulseContainer":
+        """Reconstruct a container from a dict produced by ``to_dict()``."""
+        container = cls(nm_path=nm_path)
+        for pd in d.get("pulses", []):
+            name = pd.get("name", "p%d" % container._count)
+            p = NMPulse.from_dict(pd, nm_path=nm_path)
+            p._name = name
+            container._pulses[name] = p
+            container._count += 1
+        return container

--- a/pyneuromatic/analysis/nm_pulse_func.py
+++ b/pyneuromatic/analysis/nm_pulse_func.py
@@ -1,0 +1,550 @@
+# -*- coding: utf-8 -*-
+"""
+NMPulseFunc class hierarchy: pulse shape types with parameters and waveform generation.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+
+import pyneuromatic.core.nm_utilities as nmu
+
+_VALID_SHAPES: frozenset[str] = frozenset({
+    "square", "ramp+", "ramp-", "exp", "alpha",
+    "sin", "sinzap", "user",
+})
+
+
+# =========================================================================
+# NMPulseFunc base class
+# =========================================================================
+
+
+class NMPulseFunc:
+    """Base class for pulse shape types.
+
+    Lightweight class (following NMStatFunc pattern) that represents a pulse
+    shape with its shape-specific parameters.  Universal parameters
+    (``amp``, ``onset``, ``width``) are passed as arguments to
+    :meth:`waveform` by the caller (:class:`~pyneuromatic.analysis.nm_pulse.NMPulse`)
+    so that per-epoch variation (``delta_*``/``stdv_*``) can be applied
+    before dispatch.
+
+    Each subclass stores only its own shape-specific parameters and
+    implements :meth:`waveform`.
+
+    Args:
+        name: Pulse shape name string (e.g. ``"square"``, ``"sin"``).
+    """
+
+    _VALID_KEYS: frozenset[str] = frozenset()
+
+    def __init__(self, name: str) -> None:
+        self._name = name
+
+    def __repr__(self) -> str:
+        d = self.to_dict()
+        params = ", ".join("%s=%r" % (k, v) for k, v in d.items())
+        return "%s(%s)" % (self.__class__.__name__, params)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, NMPulseFunc):
+            return self.to_dict() == other.to_dict()
+        if isinstance(other, dict):
+            return self.to_dict() == other
+        return NotImplemented
+
+    @property
+    def name(self) -> str:
+        """Pulse shape name string."""
+        return self._name
+
+    def to_dict(self) -> dict:
+        """Return shape-specific parameters as a dict with a ``"pulse"`` key."""
+        return {"pulse": self._name}
+
+    def _build_masked_x(
+        self,
+        n_points: int,
+        xstart: float,
+        xdelta: float,
+        onset: float,
+        width: float,
+    ) -> tuple:
+        """Validate args and build the x-axis, zero output array, and window mask.
+
+        Returns:
+            ``(x, y, mask)`` — x-axis array, zero-filled output array, and
+            boolean mask selecting samples in ``[onset, onset + width)``.
+            When ``width`` is ``inf`` the mask selects ``x >= onset``.
+        """
+        if n_points < 1:
+            raise ValueError("n_points must be >= 1, got %d" % n_points)
+        if xdelta <= 0:
+            raise ValueError("xdelta must be > 0, got %s" % xdelta)
+        if width <= 0:
+            raise ValueError("width must be > 0, got %s" % width)
+        x = xstart + np.arange(n_points) * xdelta
+        y = np.zeros(n_points, dtype=float)
+        if math.isinf(width):
+            mask = x >= onset
+        else:
+            mask = (x >= onset) & (x < onset + width)
+        return x, y, mask
+
+    def waveform(
+        self,
+        n_points: int,
+        xstart: float,
+        xdelta: float,
+        amp: float,
+        onset: float,
+        width: float,
+        **kwargs,
+    ) -> np.ndarray:
+        """Generate the waveform for this pulse shape.
+
+        Args:
+            n_points: Number of samples.
+            xstart: X-value of the first sample.
+            xdelta: Sample interval.
+            amp: Pulse amplitude (already varied by caller).
+            onset: Pulse start x-value (already varied by caller).
+            width: Pulse duration (already varied by caller).
+            **kwargs: Shape-specific overrides (e.g. ``tau=`` for exp/alpha).
+
+        Returns:
+            1-D float64 array of length *n_points*.
+        """
+        raise NotImplementedError(
+            "%s.waveform() not implemented" % self.__class__.__name__
+        )
+
+
+# =========================================================================
+# Subclasses
+# =========================================================================
+
+
+class NMPulseFuncSquare(NMPulseFunc):
+    """Square (rectangular) pulse.
+
+    Args:
+        name: Must be ``"square"``.
+    """
+
+    def __init__(self, name: str = "square") -> None:
+        if name != "square":
+            raise ValueError("name must be 'square', got %r" % name)
+        super().__init__(name)
+
+    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+        y[mask] = amp
+        return y
+
+
+class NMPulseFuncRamp(NMPulseFunc):
+    """Linear ramp pulse (rising or falling).
+
+    Args:
+        name: ``"ramp+"`` for a rising ramp or ``"ramp-"`` for a falling ramp.
+    """
+
+    def __init__(self, name: str) -> None:
+        if name not in ("ramp+", "ramp-"):
+            raise ValueError("name must be 'ramp+' or 'ramp-', got %r" % name)
+        super().__init__(name)
+        self._direction: str = name[-1]
+
+    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+        if not np.any(mask):
+            return y
+        if math.isinf(width):
+            ew = xstart + (n_points - 1) * xdelta - onset
+            if ew <= 0:
+                return y
+        else:
+            ew = width
+        t = (x[mask] - onset) / ew
+        y[mask] = amp * t if self._direction == "+" else amp * (1.0 - t)
+        return y
+
+
+class NMPulseFuncExp(NMPulseFunc):
+    """Decaying exponential pulse.
+
+    Args:
+        name: Must be ``"exp"``.
+        tau: Time constant (> 0). Default 10.0.
+    """
+
+    _VALID_KEYS: frozenset[str] = frozenset({"tau"})
+
+    def __init__(self, name: str = "exp", tau: float = 10.0) -> None:
+        if name != "exp":
+            raise ValueError("name must be 'exp', got %r" % name)
+        if isinstance(tau, bool) or not isinstance(tau, (int, float)):
+            raise TypeError(nmu.type_error_str(tau, "tau", "float"))
+        tau = float(tau)
+        if tau <= 0:
+            raise ValueError("tau must be > 0, got %s" % tau)
+        super().__init__(name)
+        self._tau: float = tau
+
+    @property
+    def tau(self) -> float:
+        """Time constant."""
+        return self._tau
+
+    def to_dict(self) -> dict:
+        return {"pulse": self._name, "tau": self._tau}
+
+    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+        y[mask] = amp * np.exp(-(x[mask] - onset) / self._tau)
+        return y
+
+
+class NMPulseFuncAlpha(NMPulseFunc):
+    """Alpha-function pulse (peaks at onset + tau).
+
+    Args:
+        name: Must be ``"alpha"``.
+        tau: Time to peak from onset (> 0). Default 10.0.
+    """
+
+    _VALID_KEYS: frozenset[str] = frozenset({"tau"})
+
+    def __init__(self, name: str = "alpha", tau: float = 10.0) -> None:
+        if name != "alpha":
+            raise ValueError("name must be 'alpha', got %r" % name)
+        if isinstance(tau, bool) or not isinstance(tau, (int, float)):
+            raise TypeError(nmu.type_error_str(tau, "tau", "float"))
+        tau = float(tau)
+        if tau <= 0:
+            raise ValueError("tau must be > 0, got %s" % tau)
+        super().__init__(name)
+        self._tau: float = tau
+
+    @property
+    def tau(self) -> float:
+        """Time to peak."""
+        return self._tau
+
+    def to_dict(self) -> dict:
+        return {"pulse": self._name, "tau": self._tau}
+
+    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+        t = (x[mask] - onset) / self._tau
+        y[mask] = amp * t * np.exp(1.0 - t)
+        return y
+
+
+class NMPulseFuncSin(NMPulseFunc):
+    """Sinusoidal pulse.
+
+    Args:
+        name: Must be ``"sin"``.
+        freq: Frequency in cycles per x-unit (> 0). Default 1.0.
+        phase: Phase offset in radians. Default 0.0.
+    """
+
+    _VALID_KEYS: frozenset[str] = frozenset({"freq", "phase"})
+
+    def __init__(
+        self, name: str = "sin", freq: float = 1.0, phase: float = 0.0
+    ) -> None:
+        if name != "sin":
+            raise ValueError("name must be 'sin', got %r" % name)
+        freq, phase = _validate_freq_phase(freq, phase)
+        super().__init__(name)
+        self._freq: float = freq
+        self._phase: float = phase
+
+    @property
+    def freq(self) -> float:
+        """Frequency in cycles per x-unit."""
+        return self._freq
+
+    @freq.setter
+    def freq(self, value: float) -> None:
+        self._freq, _ = _validate_freq_phase(value, self._phase)
+
+    @property
+    def phase(self) -> float:
+        """Phase offset in radians."""
+        return self._phase
+
+    @phase.setter
+    def phase(self, value: float) -> None:
+        _, self._phase = _validate_freq_phase(self._freq, value)
+
+    def to_dict(self) -> dict:
+        return {"pulse": self._name, "freq": self._freq, "phase": self._phase}
+
+    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+        y[mask] = amp * np.sin(2.0 * math.pi * self._freq * (x[mask] - onset) + self._phase)
+        return y
+
+
+
+class NMPulseFuncSinZap(NMPulseFunc):
+    """Linear-frequency-sweep (chirp) pulse.
+
+    Frequency sweeps linearly from *f0* to *f1* over the pulse duration.
+
+    Args:
+        name: Must be ``"sinzap"``.
+        f0: Starting frequency in cycles per x-unit (> 0). Default 1.0.
+        f1: Ending frequency in cycles per x-unit (> 0). Default 10.0.
+    """
+
+    _VALID_KEYS: frozenset[str] = frozenset({"f0", "f1"})
+
+    def __init__(
+        self, name: str = "sinzap", f0: float = 1.0, f1: float = 10.0
+    ) -> None:
+        if name != "sinzap":
+            raise ValueError("name must be 'sinzap', got %r" % name)
+        f0, f1 = _validate_f0_f1(f0, f1)
+        super().__init__(name)
+        self._f0: float = f0
+        self._f1: float = f1
+
+    @property
+    def f0(self) -> float:
+        """Starting frequency."""
+        return self._f0
+
+    @f0.setter
+    def f0(self, value: float) -> None:
+        self._f0, _ = _validate_f0_f1(value, self._f1)
+
+    @property
+    def f1(self) -> float:
+        """Ending frequency."""
+        return self._f1
+
+    @f1.setter
+    def f1(self, value: float) -> None:
+        _, self._f1 = _validate_f0_f1(self._f0, value)
+
+    def to_dict(self) -> dict:
+        return {"pulse": self._name, "f0": self._f0, "f1": self._f1}
+
+    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+        if not np.any(mask):
+            return y
+        if math.isinf(width):
+            ew = xstart + (n_points - 1) * xdelta - onset
+            if ew <= 0:
+                return y
+        else:
+            ew = width
+        t = x[mask] - onset
+        phi = 2.0 * math.pi * (self._f0 * t + (self._f1 - self._f0) / (2.0 * ew) * t ** 2)
+        y[mask] = amp * np.sin(phi)
+        return y
+
+
+class NMPulseFuncUser(NMPulseFunc):
+    """User-supplied waveform pulse.
+
+    The stored numpy array is treated as a template: at ``waveform()`` time it
+    is normalised so its absolute peak maps to *amp*, shifted to start at
+    *onset*, resampled to the target x-scale via ``np.interp``, and truncated
+    at ``onset + width``.
+
+    .. note::
+        The data array is **not** included in :meth:`to_dict` output (JSON /
+        TOML serialisation limitation).  Save the array separately and
+        re-supply it on load.
+
+    Args:
+        name: Must be ``"user"``.
+        data: 1-D numpy array representing the waveform template (any
+            sampling rate).
+        xdelta_data: Sample interval of *data* in the same x-units as the
+            target waveform. Default 1.0.
+    """
+
+    _VALID_KEYS: frozenset[str] = frozenset({"data", "xdelta_data"})
+
+    def __init__(
+        self,
+        name: str = "user",
+        data: np.ndarray | None = None,
+        xdelta_data: float = 1.0,
+    ) -> None:
+        if name != "user":
+            raise ValueError("name must be 'user', got %r" % name)
+        if data is None:
+            raise KeyError("missing key 'data' for NMPulseFuncUser")
+        data = np.asarray(data, dtype=float)
+        if data.ndim != 1 or len(data) == 0:
+            raise ValueError("data must be a non-empty 1-D array")
+        if isinstance(xdelta_data, bool) or not isinstance(xdelta_data, (int, float)):
+            raise TypeError(nmu.type_error_str(xdelta_data, "xdelta_data", "float"))
+        xdelta_data = float(xdelta_data)
+        if xdelta_data <= 0:
+            raise ValueError("xdelta_data must be > 0, got %s" % xdelta_data)
+        super().__init__(name)
+        self._data: np.ndarray = data
+        self._xdelta_data: float = xdelta_data
+
+    @property
+    def data(self) -> np.ndarray:
+        """The waveform template array."""
+        return self._data
+
+    @property
+    def xdelta_data(self) -> float:
+        """Sample interval of the template array."""
+        return self._xdelta_data
+
+    def to_dict(self) -> dict:
+        return {
+            "pulse": self._name,
+            "xdelta_data": self._xdelta_data,
+            "n_data": len(self._data),
+        }
+
+    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+        if not np.any(mask):
+            return y
+
+        peak = np.max(np.abs(self._data))
+        if peak == 0.0:
+            return y
+        data_norm = self._data / peak
+
+        x_src = np.arange(len(self._data)) * self._xdelta_data
+        x_tgt = x[mask] - onset
+        y_interp = np.interp(x_tgt, x_src, data_norm, left=0.0, right=0.0)
+        y[mask] = amp * y_interp
+        return y
+
+
+# =========================================================================
+# Validation helpers
+# =========================================================================
+
+
+def _validate_freq_phase(freq: float, phase: float) -> tuple[float, float]:
+    if isinstance(freq, bool) or not isinstance(freq, (int, float)):
+        raise TypeError(nmu.type_error_str(freq, "freq", "float"))
+    freq = float(freq)
+    if freq <= 0:
+        raise ValueError("freq must be > 0, got %s" % freq)
+    if isinstance(phase, bool) or not isinstance(phase, (int, float)):
+        raise TypeError(nmu.type_error_str(phase, "phase", "float"))
+    return freq, float(phase)
+
+
+def _validate_f0_f1(f0: float, f1: float) -> tuple[float, float]:
+    if isinstance(f0, bool) or not isinstance(f0, (int, float)):
+        raise TypeError(nmu.type_error_str(f0, "f0", "float"))
+    f0 = float(f0)
+    if f0 <= 0:
+        raise ValueError("f0 must be > 0, got %s" % f0)
+    if isinstance(f1, bool) or not isinstance(f1, (int, float)):
+        raise TypeError(nmu.type_error_str(f1, "f1", "float"))
+    f1 = float(f1)
+    if f1 <= 0:
+        raise ValueError("f1 must be > 0, got %s" % f1)
+    return f0, f1
+
+
+# =========================================================================
+# Registry and factory
+# =========================================================================
+
+_PULSE_FUNC_REGISTRY: dict[str, type[NMPulseFunc]] = {
+    "square": NMPulseFuncSquare,
+    "ramp+":  NMPulseFuncRamp,
+    "ramp-":  NMPulseFuncRamp,
+    "exp":    NMPulseFuncExp,
+    "alpha":  NMPulseFuncAlpha,
+    "sin":    NMPulseFuncSin,
+    "sinzap": NMPulseFuncSinZap,
+    "user":   NMPulseFuncUser,
+}
+
+
+def _pulse_func_from_dict(d: dict | str) -> NMPulseFunc:
+    """Create an :class:`NMPulseFunc` from a dict or bare shape-name string.
+
+    Args:
+        d: Dict with at least a ``"pulse"`` key, or a bare shape-name string.
+            Additional keys are the shape-specific parameters for that
+            subclass (e.g. ``"tau"`` for ``"exp"``, ``"freq"`` for
+            ``"sin"``).  Unknown keys raise :exc:`KeyError`.
+
+    Returns:
+        An :class:`NMPulseFunc` subclass instance.
+
+    Raises:
+        TypeError: If *d* is not a dict or string.
+        KeyError: If ``"pulse"`` key is missing, a required key is absent
+            (e.g. ``"data"`` for ``"user"``), or an unknown key is present.
+        ValueError: If the shape name is not in :data:`_VALID_SHAPES`, or a
+            parameter value is invalid.
+    """
+    if isinstance(d, str):
+        d = {"pulse": d}
+    if not isinstance(d, dict):
+        raise TypeError(nmu.type_error_str(d, "pulse func", "dictionary or string"))
+    if "pulse" not in d:
+        raise KeyError("missing key 'pulse'")
+    name = d["pulse"]
+    if not isinstance(name, str):
+        raise TypeError(nmu.type_error_str(name, "pulse", "string"))
+    name = name.lower()
+    if name not in _PULSE_FUNC_REGISTRY:
+        raise ValueError("unknown pulse shape %r; valid shapes: %s"
+                         % (name, sorted(_VALID_SHAPES)))
+    cls = _PULSE_FUNC_REGISTRY[name]
+
+    # Extract valid keys for this subclass; reject unknown keys
+    kwargs: dict = {}
+    for key, val in d.items():
+        k = key.lower()
+        if k == "pulse":
+            continue
+        if k in cls._VALID_KEYS:
+            kwargs[k] = val
+        else:
+            if cls._VALID_KEYS:
+                raise KeyError(
+                    "unknown key %r for pulse %r (valid: %s)"
+                    % (key, name, sorted(cls._VALID_KEYS))
+                )
+            else:
+                raise KeyError(
+                    "pulse %r takes no extra parameters, got %r" % (name, key)
+                )
+
+    return cls(name=name, **kwargs)

--- a/pyneuromatic/analysis/nm_tool_pulse.py
+++ b/pyneuromatic/analysis/nm_tool_pulse.py
@@ -1,0 +1,317 @@
+# -*- coding: utf-8 -*-
+"""
+NMToolPulse: synthetic waveform generator tool.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import math
+import numpy as np
+
+from pyneuromatic.analysis.nm_tool import NMTool
+from pyneuromatic.analysis.nm_tool_config import NMToolConfig
+from pyneuromatic.analysis.nm_pulse import NMPulse, NMPulseContainer
+from pyneuromatic.core.nm_data import NMData
+from pyneuromatic.core.nm_folder import NMFolder
+import pyneuromatic.core.nm_command_history as nmch
+import pyneuromatic.core.nm_configurations as nmc
+import pyneuromatic.core.nm_history as nmh
+import pyneuromatic.core.nm_utilities as nmu
+
+
+class NMToolPulseConfig(NMToolConfig):
+    """Configuration for NMToolPulse.
+
+    Parameters:
+        n_points: Number of samples in the output waveform. Default 100.
+        xstart: X-value of the first sample. Default 0.0.
+        xdelta: Sample interval (must be > 0). Default 1.0.
+        prefix: Prefix for output array names (non-empty). Default ``"PG_"``.
+        channel: Channel string inserted between prefix and epoch index.
+            Default ``""`` (no channel). Combined with prefix:
+            ``{prefix}{channel}{epoch_idx}``.
+        overwrite: Overwrite existing arrays in NMFolder.data. Default True.
+    """
+
+    _TOML_TYPE = "pulse_config"
+    _schema = {
+        "n_points":  {"type": int,   "default": 100, "min": 1},
+        "xstart":    {"type": float, "default": 0.0},
+        "xdelta":    {"type": float, "default": 1.0, "min": 0},
+        "prefix":    {"type": str,   "default": "PG_"},
+        "chan":       {"type": str,   "default": ""},
+        "overwrite": {"type": bool,  "default": True},
+    }
+
+
+class NMToolPulse(NMTool):
+    """Synthetic waveform generator tool.
+
+    Manages a container of :class:`~pyneuromatic.analysis.nm_pulse.NMPulse`
+    objects. On each ``run()`` call all pulses that target the current epoch
+    are summed to produce a 1-D output array written directly to
+    ``NMFolder.data`` (not a subfolder). The prefix acts as a namespace to
+    avoid collisions with other data in the folder.
+
+    Output array naming: ``{prefix}{channel}{epoch_idx}``
+
+    Examples::
+
+        t = NMToolPulse()
+        t.pulses.new({"pulse": "square", "amp": 1, "onset": 5, "width": 10})
+        t.pulses.new({"pulse": "exp", "amp": 0.5, "onset": 5, "tau": 20})
+        # drive directly (no NMManager)
+        t.run_all([{}])
+        # → NMFolder.data contains PG_0 (sum of both pulses)
+    """
+
+    def __init__(self, name: str = "pulse") -> None:
+        super().__init__(name=name)
+        self._config = NMToolPulseConfig()
+        self.__n_points: int   = self._config.n_points
+        self.__xstart:   float = self._config.xstart
+        self.__xdelta:   float = self._config.xdelta
+        self.__prefix:   str   = self._config.prefix
+        self.__chan:  str   = self._config.chan
+        self._overwrite        = self._config.overwrite
+        self._results_to_numpy = True
+
+        self.__pulses: NMPulseContainer = NMPulseContainer(
+            nm_path=self._name + ".pulses"
+        )
+        self._waveforms:   list[np.ndarray] = []
+        self._epoch_names: list[str]        = []
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def n_points(self) -> int:
+        """Number of samples in each output waveform."""
+        return self.__n_points
+
+    @n_points.setter
+    def n_points(self, value: int) -> None:
+        self._n_points_set(value)
+
+    def _n_points_set(self, value: int, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "n_points", "int"))
+        if value < 1:
+            raise ValueError("n_points must be >= 1, got %d" % value)
+        self.__n_points = value
+        nmh.history("set n_points=%d" % self.__n_points, quiet=quiet)
+        nmch.add_nm_command("%s.n_points = %r" % (self._name, self.__n_points))
+
+    @property
+    def xstart(self) -> float:
+        """X-value of the first sample."""
+        return self.__xstart
+
+    @xstart.setter
+    def xstart(self, value: float) -> None:
+        self._xstart_set(value)
+
+    def _xstart_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "xstart", "float"))
+        self.__xstart = float(value)
+        nmh.history("set xstart=%g" % self.__xstart, quiet=quiet)
+        nmch.add_nm_command("%s.xstart = %r" % (self._name, self.__xstart))
+
+    @property
+    def xdelta(self) -> float:
+        """Sample interval (must be > 0)."""
+        return self.__xdelta
+
+    @xdelta.setter
+    def xdelta(self, value: float) -> None:
+        self._xdelta_set(value)
+
+    def _xdelta_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "xdelta", "float"))
+        if value <= 0:
+            raise ValueError("xdelta must be > 0, got %s" % value)
+        self.__xdelta = float(value)
+        nmh.history("set xdelta=%g" % self.__xdelta, quiet=quiet)
+        nmch.add_nm_command("%s.xdelta = %r" % (self._name, self.__xdelta))
+
+    @property
+    def prefix(self) -> str:
+        """Output array name prefix (e.g. ``"PG_"``, ``"DAC_0_"``, ``"Record"``)."""
+        return self.__prefix
+
+    @prefix.setter
+    def prefix(self, value: str) -> None:
+        self._prefix_set(value)
+
+    def _prefix_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "prefix", "string"))
+        if not value:
+            raise ValueError("prefix must be a non-empty string")
+        self.__prefix = value
+        nmh.history("set prefix=%r" % self.__prefix, quiet=quiet)
+        nmch.add_nm_command("%s.prefix = %r" % (self._name, self.__prefix))
+
+    @property
+    def chan(self) -> str:
+        """Channel string inserted between prefix and epoch index (e.g. ``"A"``)."""
+        return self.__chan
+
+    @chan.setter
+    def chan(self, value: str) -> None:
+        self._chan_set(value)
+
+    def _chan_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "chan", "string"))
+        self.__chan = value
+        nmh.history("set chan=%r" % self.__chan, quiet=quiet)
+        nmch.add_nm_command("%s.chan = %r" % (self._name, self.__chan))
+
+    @property
+    def pulses(self) -> NMPulseContainer:
+        """The container of NMPulse objects."""
+        return self.__pulses
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run_init(self) -> bool:
+        """Validate parameters and reset accumulators."""
+        if self.__n_points < 1:
+            raise ValueError("n_points must be >= 1")
+        if self.__xdelta <= 0:
+            raise ValueError("xdelta must be > 0")
+        if not self.__prefix:
+            raise ValueError("prefix must be non-empty")
+        self._waveforms = []
+        self._epoch_names = []
+        return True
+
+    def run(self) -> bool:
+        """Generate and accumulate the waveform for the current epoch.
+
+        All pulses targeting this epoch index are summed. The result is
+        appended to ``_waveforms``; the epoch name from ``self.data.name``
+        (or a fallback) is appended to ``_epoch_names``.
+
+        Returns:
+            True.
+        """
+        epoch_idx = len(self._epoch_names)
+        epoch_name = self.data.name if self.data else "wave_%d" % epoch_idx
+
+        y = np.zeros(self.__n_points, dtype=float)
+        for p in self.__pulses:
+            if p.targets_epoch(epoch_idx):
+                y += p.waveform(
+                    self.__n_points, self.__xstart, self.__xdelta, epoch_idx
+                )
+
+        self._waveforms.append(y)
+        self._epoch_names.append(epoch_name)
+        return True
+
+    def run_finish(self) -> bool:
+        """Write output arrays to NMFolder.data.
+
+        Returns:
+            True.
+        """
+        if not self._epoch_names:
+            return True
+        if self._results_to_numpy:
+            self._write_results_to_numpy()
+        return True
+
+    # ------------------------------------------------------------------
+    # Output
+
+    def _note_str(self) -> str:
+        pulse_strs = []
+        for p in self.__pulses:
+            d = p.func.to_dict()
+            parts = [d["pulse"]]
+            parts.append("amp=%g" % p.amp)
+            parts.append("onset=%g" % p.onset)
+            if not math.isinf(p.width):
+                parts.append("width=%g" % p.width)
+            for key in ("tau", "freq", "phase", "f0", "f1"):
+                if key in d:
+                    parts.append("%s=%g" % (key, d[key]))
+            if p.epoch != 0 or p.epoch_delta != 0:
+                parts.append("epoch=%d" % p.epoch)
+                parts.append("epoch_delta=%d" % p.epoch_delta)
+            pulse_strs.append("(%s)" % ", ".join(parts))
+        parts = [
+            "NMPulse(n_points=%d" % self.__n_points,
+            "xstart=%g" % self.__xstart,
+            "xdelta=%g" % self.__xdelta,
+        ]
+        if self.__chan:
+            parts.append("chan=%r" % self.__chan)
+        parts.append("pulses=[%s])" % ", ".join(pulse_strs))
+        return ", ".join(parts)
+
+    def _add_note(self, data: NMData, text: str) -> None:
+        notes = getattr(data, "notes", None)
+        if notes is not None:
+            notes.add(text)
+
+    def _write_results_to_numpy(self) -> NMFolder | None:
+        """Write ``{prefix}{channel}{epoch_idx}`` NMData arrays to NMFolder.data.
+
+        Also writes a ``{prefix}{channel}epoch_names`` object array of source
+        epoch name strings.
+
+        Returns:
+            The NMFolder written to, or None if no folder is set.
+        """
+        if not isinstance(self.folder, NMFolder):
+            return None
+
+        f = self.folder
+        note = self._note_str()
+        xscale = {"start": self.__xstart, "delta": self.__xdelta, "units": ""}
+        stem = self.__prefix + self.__chan
+
+        for idx, (epoch_name, waveform) in enumerate(
+            zip(self._epoch_names, self._waveforms)
+        ):
+            name = stem + str(idx)
+            if name in f.data and self._overwrite:
+                del f.data[name]
+            d = f.data.new(
+                name,
+                nparray=waveform,
+                xscale=xscale,
+            )
+            self._add_note(d, note)
+
+        epoch_names_key = stem.rstrip("_") + "_epoch_names"
+        if epoch_names_key in f.data and self._overwrite:
+            del f.data[epoch_names_key]
+        f.data.new(
+            epoch_names_key,
+            nparray=np.array(self._epoch_names, dtype=object),
+        )
+
+        return f

--- a/pyneuromatic/core/nm_math.py
+++ b/pyneuromatic/core/nm_math.py
@@ -2556,3 +2556,4 @@ def fit_boltzmann(
         "n":         n,
         "converged": converged,
     }
+

--- a/tests/test_analysis/test_nm_pulse_func.py
+++ b/tests/test_analysis/test_nm_pulse_func.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for nm_pulse_func: NMPulseFunc hierarchy and _pulse_func_from_dict."""
+import math
+import unittest
+
+import numpy as np
+
+from pyneuromatic.analysis.nm_pulse_func import (
+    NMPulseFunc,
+    NMPulseFuncSquare,
+    NMPulseFuncRamp,
+    NMPulseFuncExp,
+    NMPulseFuncAlpha,
+    NMPulseFuncSin,
+    NMPulseFuncSinZap,
+    NMPulseFuncUser,
+    _pulse_func_from_dict,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _wave(func, n=100, xstart=0.0, xdelta=1.0, amp=1.0, onset=0.0, width=math.inf):
+    return func.waveform(n, xstart, xdelta, amp, onset, width)
+
+
+# ---------------------------------------------------------------------------
+# Square
+# ---------------------------------------------------------------------------
+
+class TestNMPulseFuncSquare(unittest.TestCase):
+
+    def setUp(self):
+        self.f = NMPulseFuncSquare()
+
+    def test_name(self):
+        self.assertEqual(self.f.name, "square")
+
+    def test_to_dict(self):
+        self.assertEqual(self.f.to_dict(), {"pulse": "square"})
+
+    def test_waveform_inside_window(self):
+        y = _wave(self.f, amp=2.0, onset=10.0, width=5.0)
+        self.assertAlmostEqual(y[10], 2.0)
+        self.assertAlmostEqual(y[14], 2.0)
+
+    def test_waveform_outside_window(self):
+        y = _wave(self.f, amp=2.0, onset=10.0, width=5.0)
+        self.assertAlmostEqual(y[9], 0.0)
+        self.assertAlmostEqual(y[15], 0.0)
+
+    def test_inf_width_step(self):
+        y = _wave(self.f, amp=1.0, onset=10.0)
+        self.assertAlmostEqual(y[9], 0.0)
+        self.assertAlmostEqual(y[10], 1.0)
+        self.assertAlmostEqual(y[99], 1.0)
+
+    def test_eq(self):
+        self.assertEqual(self.f, NMPulseFuncSquare())
+
+    def test_bad_name(self):
+        with self.assertRaises(ValueError):
+            NMPulseFuncSquare(name="exp")
+
+    def test_no_extra_keys(self):
+        with self.assertRaises(KeyError):
+            _pulse_func_from_dict({"pulse": "square", "tau": 5.0})
+
+
+# ---------------------------------------------------------------------------
+# Ramp
+# ---------------------------------------------------------------------------
+
+class TestNMPulseFuncRamp(unittest.TestCase):
+
+    def test_ramp_plus_rises(self):
+        f = NMPulseFuncRamp("ramp+")
+        y = _wave(f, n=11, amp=1.0, onset=0.0, width=10.0)
+        self.assertAlmostEqual(y[0], 0.0, places=5)
+        self.assertAlmostEqual(y[9], 0.9, places=5)
+        self.assertAlmostEqual(y[10], 0.0)
+
+    def test_ramp_minus_falls(self):
+        f = NMPulseFuncRamp("ramp-")
+        y = _wave(f, n=11, amp=1.0, onset=0.0, width=10.0)
+        self.assertAlmostEqual(y[0], 1.0, places=5)
+        self.assertAlmostEqual(y[9], 0.1, places=5)
+        self.assertAlmostEqual(y[10], 0.0)
+
+    def test_inf_width_reaches_amp_at_end(self):
+        f = NMPulseFuncRamp("ramp+")
+        y = _wave(f, n=11, xdelta=1.0, amp=1.0, onset=0.0)
+        self.assertAlmostEqual(y[0], 0.0, places=5)
+        self.assertAlmostEqual(y[10], 1.0, places=5)
+
+    def test_to_dict(self):
+        self.assertEqual(NMPulseFuncRamp("ramp+").to_dict(), {"pulse": "ramp+"})
+        self.assertEqual(NMPulseFuncRamp("ramp-").to_dict(), {"pulse": "ramp-"})
+
+    def test_bad_name(self):
+        with self.assertRaises(ValueError):
+            NMPulseFuncRamp("ramp")
+
+
+# ---------------------------------------------------------------------------
+# Exp
+# ---------------------------------------------------------------------------
+
+class TestNMPulseFuncExp(unittest.TestCase):
+
+    def setUp(self):
+        self.f = NMPulseFuncExp(tau=10.0)
+
+    def test_name(self):
+        self.assertEqual(self.f.name, "exp")
+
+    def test_tau_property(self):
+        self.assertAlmostEqual(self.f.tau, 10.0)
+
+    def test_to_dict(self):
+        self.assertEqual(self.f.to_dict(), {"pulse": "exp", "tau": 10.0})
+
+    def test_amp_at_onset(self):
+        y = _wave(self.f, amp=3.0, onset=0.0)
+        self.assertAlmostEqual(y[0], 3.0)
+
+    def test_decays(self):
+        y = _wave(self.f, amp=1.0, onset=0.0)
+        self.assertGreater(y[0], y[10])
+
+    def test_value_at_one_tau(self):
+        # at x = onset + tau, y = amp * exp(-1)
+        y = _wave(self.f, amp=1.0, onset=0.0)
+        self.assertAlmostEqual(y[10], math.exp(-1.0), places=10)
+
+    def test_bad_tau(self):
+        with self.assertRaises(ValueError):
+            NMPulseFuncExp(tau=0.0)
+        with self.assertRaises(ValueError):
+            NMPulseFuncExp(tau=-1.0)
+
+
+# ---------------------------------------------------------------------------
+# Alpha
+# ---------------------------------------------------------------------------
+
+class TestNMPulseFuncAlpha(unittest.TestCase):
+
+    def setUp(self):
+        self.f = NMPulseFuncAlpha(tau=10.0)
+
+    def test_name(self):
+        self.assertEqual(self.f.name, "alpha")
+
+    def test_peak_at_onset_plus_tau(self):
+        y = _wave(self.f, n=100, amp=1.0, onset=0.0)
+        self.assertAlmostEqual(int(np.argmax(y)), 10, delta=1)
+
+    def test_to_dict(self):
+        self.assertEqual(self.f.to_dict(), {"pulse": "alpha", "tau": 10.0})
+
+
+# ---------------------------------------------------------------------------
+# Sin
+# ---------------------------------------------------------------------------
+
+class TestNMPulseFuncSin(unittest.TestCase):
+
+    def setUp(self):
+        self.f = NMPulseFuncSin(freq=0.1)   # period = 10 samples at xdelta=1
+
+    def test_name(self):
+        self.assertEqual(self.f.name, "sin")
+
+    def test_zero_at_onset(self):
+        y = _wave(self.f, amp=1.0, onset=0.0)
+        self.assertAlmostEqual(y[0], 0.0, places=10)
+
+    def test_peak_at_quarter_period(self):
+        # freq=0.25 → period=4 samples; peak at sample 1 (t=1/4 period)
+        f = NMPulseFuncSin(freq=0.25)
+        y = _wave(f, n=20, amp=2.0, onset=0.0)
+        self.assertAlmostEqual(y[1], 2.0, places=10)
+
+    def test_phase_shift(self):
+        f_cos = NMPulseFuncSin(freq=0.1, phase=math.pi / 2)
+        y = _wave(f_cos, amp=1.0, onset=0.0)
+        self.assertAlmostEqual(y[0], 1.0, places=4)   # sin(π/2) = 1
+
+    def test_zero_before_onset(self):
+        y = _wave(self.f, amp=1.0, onset=10.0)
+        self.assertAlmostEqual(y[9], 0.0)
+
+    def test_truncated_by_width(self):
+        y = _wave(self.f, amp=1.0, onset=0.0, width=5.0)
+        self.assertAlmostEqual(y[5], 0.0)
+
+    def test_to_dict(self):
+        self.assertEqual(self.f.to_dict(), {"pulse": "sin", "freq": 0.1, "phase": 0.0})
+
+    def test_bad_freq(self):
+        with self.assertRaises(ValueError):
+            NMPulseFuncSin(freq=0.0)
+        with self.assertRaises(ValueError):
+            NMPulseFuncSin(freq=-1.0)
+
+    def test_freq_setter(self):
+        f = NMPulseFuncSin(freq=1.0)
+        f.freq = 2.0
+        self.assertAlmostEqual(f.freq, 2.0)
+
+    def test_factory_roundtrip(self):
+        d = self.f.to_dict()
+        f2 = _pulse_func_from_dict(d)
+        self.assertEqual(f2, self.f)
+
+
+# ---------------------------------------------------------------------------
+# SinZap
+# ---------------------------------------------------------------------------
+
+class TestNMPulseFuncSinZap(unittest.TestCase):
+
+    def setUp(self):
+        # 100 samples at xdelta=0.01 → 1 second total
+        # f0=1 Hz, f1=10 Hz over 1 s
+        self.f = NMPulseFuncSinZap(f0=1.0, f1=10.0)
+
+    def test_name(self):
+        self.assertEqual(self.f.name, "sinzap")
+
+    def test_to_dict(self):
+        self.assertEqual(self.f.to_dict(), {"pulse": "sinzap", "f0": 1.0, "f1": 10.0})
+
+    def test_output_length(self):
+        y = self.f.waveform(100, 0.0, 0.01, 1.0, 0.0, math.inf)
+        self.assertEqual(len(y), 100)
+
+    def test_amplitude_bounded(self):
+        y = self.f.waveform(1000, 0.0, 0.001, 2.0, 0.0, math.inf)
+        self.assertLessEqual(np.max(np.abs(y)), 2.0 + 1e-10)
+
+    def test_zero_before_onset(self):
+        y = self.f.waveform(100, 0.0, 0.01, 1.0, 0.1, math.inf)
+        self.assertAlmostEqual(y[5], 0.0)   # x=0.05 < onset=0.1
+
+    def test_bad_f0(self):
+        with self.assertRaises(ValueError):
+            NMPulseFuncSinZap(f0=0.0, f1=10.0)
+
+    def test_bad_f1(self):
+        with self.assertRaises(ValueError):
+            NMPulseFuncSinZap(f0=1.0, f1=-1.0)
+
+    def test_f0_setter(self):
+        f = NMPulseFuncSinZap(f0=1.0, f1=10.0)
+        f.f0 = 2.0
+        self.assertAlmostEqual(f.f0, 2.0)
+
+    def test_factory_roundtrip(self):
+        f2 = _pulse_func_from_dict(self.f.to_dict())
+        self.assertEqual(f2, self.f)
+
+
+# ---------------------------------------------------------------------------
+# User
+# ---------------------------------------------------------------------------
+
+class TestNMPulseFuncUser(unittest.TestCase):
+
+    def setUp(self):
+        # one full sine cycle, 50 samples, xdelta_data=1.0
+        t = np.linspace(0, 2 * math.pi, 50, endpoint=False)
+        self.raw = np.sin(t)
+        self.f = NMPulseFuncUser(data=self.raw, xdelta_data=1.0)
+
+    def test_name(self):
+        self.assertEqual(self.f.name, "user")
+
+    def test_peak_matches_amp(self):
+        y = _wave(self.f, n=200, xdelta=1.0, amp=3.0, onset=0.0)
+        self.assertAlmostEqual(np.max(y), 3.0, places=3)
+
+    def test_zero_before_onset(self):
+        y = _wave(self.f, n=100, xdelta=1.0, amp=1.0, onset=20.0)
+        for i in range(20):
+            self.assertAlmostEqual(y[i], 0.0)
+
+    def test_truncated_by_width(self):
+        y = _wave(self.f, n=200, xdelta=1.0, amp=1.0, onset=0.0, width=10.0)
+        self.assertAlmostEqual(y[10], 0.0)
+        self.assertAlmostEqual(y[50], 0.0)
+
+    def test_resampled_to_target_xdelta(self):
+        # target xdelta=0.5 → twice as many samples per source sample
+        y = _wave(self.f, n=200, xdelta=0.5, amp=1.0, onset=0.0)
+        self.assertAlmostEqual(np.max(y), 1.0, places=3)
+
+    def test_to_dict_no_data(self):
+        d = self.f.to_dict()
+        self.assertEqual(d["pulse"], "user")
+        self.assertAlmostEqual(d["xdelta_data"], 1.0)
+        self.assertEqual(d["n_data"], 50)
+        self.assertNotIn("data", d)
+
+    def test_missing_data_raises(self):
+        with self.assertRaises(KeyError):
+            NMPulseFuncUser()
+
+    def test_zero_data_returns_zeros(self):
+        f = NMPulseFuncUser(data=np.zeros(10))
+        y = _wave(f, n=50, amp=2.0, onset=0.0)
+        np.testing.assert_array_equal(y, 0.0)
+
+    def test_bad_xdelta_data(self):
+        with self.assertRaises(ValueError):
+            NMPulseFuncUser(data=self.raw, xdelta_data=0.0)
+
+    def test_factory_requires_data(self):
+        with self.assertRaises(KeyError):
+            _pulse_func_from_dict({"pulse": "user"})
+
+
+# ---------------------------------------------------------------------------
+# Factory
+# ---------------------------------------------------------------------------
+
+class TestPulseFuncFactory(unittest.TestCase):
+
+    def test_string_input(self):
+        f = _pulse_func_from_dict("square")
+        self.assertIsInstance(f, NMPulseFuncSquare)
+
+    def test_all_shapes_by_name(self):
+        shapes = ["square", "ramp+", "ramp-", "exp", "alpha", "sin", "sinzap"]
+        for shape in shapes:
+            f = _pulse_func_from_dict(shape)
+            self.assertEqual(f.name, shape)
+
+    def test_user_with_data(self):
+        data = np.ones(10)
+        f = _pulse_func_from_dict({"pulse": "user", "data": data})
+        self.assertIsInstance(f, NMPulseFuncUser)
+
+    def test_missing_pulse_key(self):
+        with self.assertRaises(KeyError):
+            _pulse_func_from_dict({"amp": 1.0})
+
+    def test_unknown_shape(self):
+        with self.assertRaises(ValueError):
+            _pulse_func_from_dict("triangle")
+
+    def test_unknown_key_for_square(self):
+        with self.assertRaises(KeyError):
+            _pulse_func_from_dict({"pulse": "square", "freq": 1.0})
+
+    def test_exp_with_tau(self):
+        f = _pulse_func_from_dict({"pulse": "exp", "tau": 5.0})
+        self.assertIsInstance(f, NMPulseFuncExp)
+        self.assertAlmostEqual(f.tau, 5.0)
+
+    def test_sin_with_freq_phase(self):
+        f = _pulse_func_from_dict({"pulse": "sin", "freq": 100.0, "phase": 0.5})
+        self.assertAlmostEqual(f.freq, 100.0)
+        self.assertAlmostEqual(f.phase, 0.5)
+
+    def test_roundtrip_exp(self):
+        f1 = NMPulseFuncExp(tau=7.5)
+        f2 = _pulse_func_from_dict(f1.to_dict())
+        self.assertEqual(f1, f2)
+
+    def test_roundtrip_sinzap(self):
+        f1 = NMPulseFuncSinZap(f0=2.0, f1=20.0)
+        f2 = _pulse_func_from_dict(f1.to_dict())
+        self.assertEqual(f1, f2)
+
+    def test_not_dict_or_str_raises(self):
+        with self.assertRaises(TypeError):
+            _pulse_func_from_dict(42)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_analysis/test_nm_tool_pulse.py
+++ b/tests/test_analysis/test_nm_tool_pulse.py
@@ -1,0 +1,983 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Tests for nm_pulse and nm_tool_pulse: NMPulse, NMPulseContainer,
+NMToolPulse, NMToolPulseConfig.
+"""
+import math
+import unittest
+
+import numpy as np
+
+from pyneuromatic.analysis.nm_pulse import NMPulse, NMPulseContainer
+from pyneuromatic.analysis.nm_tool_pulse import NMToolPulse, NMToolPulseConfig
+from pyneuromatic.core.nm_data import NMData
+from pyneuromatic.core.nm_folder import NMFolder
+from pyneuromatic.core.nm_manager import NMManager, HIERARCHY_SELECT_KEYS
+
+NM = NMManager(quiet=True)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_N = 100
+_XSTART = 0.0
+_XDELTA = 1.0
+
+
+def _make_empty_data(name, n=_N, xstart=_XSTART, xdelta=_XDELTA):
+    return NMData(NM, name=name, nparray=np.zeros(n),
+                  xscale={"start": xstart, "delta": xdelta})
+
+
+def _make_targets(data_list, folder=None):
+    if folder is None:
+        folder = NMFolder(NM, name="TestFolder")
+    return [
+        {k: None for k in HIERARCHY_SELECT_KEYS} | {"folder": folder, "data": d}
+        for d in data_list
+    ], folder
+
+
+def _run_tool(tool, data_list, folder=None):
+    """Drive tool directly with a list of NMData."""
+    targets, folder = _make_targets(data_list, folder=folder)
+    tool.run_all(targets)
+    return folder
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — defaults
+# ---------------------------------------------------------------------------
+
+class TestNMPulseDefaults(unittest.TestCase):
+
+    def setUp(self):
+        self.p = NMPulse()
+
+    def test_name(self):
+        self.assertEqual(self.p.name, "NMPulse0")
+
+    def test_pulse(self):
+        self.assertEqual(self.p.pulse, "square")
+
+    def test_epoch(self):
+        self.assertEqual(self.p.epoch, 0)
+
+    def test_epoch_delta(self):
+        self.assertEqual(self.p.epoch_delta, 0)
+
+    def test_amp(self):
+        self.assertEqual(self.p.amp, 1.0)
+
+    def test_onset(self):
+        self.assertEqual(self.p.onset, 10.0)
+
+    def test_width(self):
+        self.assertTrue(math.isinf(self.p.width))
+
+    def test_amp_delta(self):
+        self.assertEqual(self.p.amp_delta, 0.0)
+
+    def test_onset_delta(self):
+        self.assertEqual(self.p.onset_delta, 0.0)
+
+    def test_width_delta(self):
+        self.assertEqual(self.p.width_delta, 0.0)
+
+    def test_amp_stdv(self):
+        self.assertEqual(self.p.amp_stdv, 0.0)
+
+    def test_onset_stdv(self):
+        self.assertEqual(self.p.onset_stdv, 0.0)
+
+    def test_width_stdv(self):
+        self.assertEqual(self.p.width_stdv, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — property validation
+# ---------------------------------------------------------------------------
+
+class TestNMPulseProperties(unittest.TestCase):
+
+    def setUp(self):
+        self.p = NMPulse()
+
+    def test_pulse_valid_shapes(self):
+        for shape in ("square", "ramp+", "ramp-", "exp", "alpha"):
+            self.p.pulse = shape
+            self.assertEqual(self.p.pulse, shape)
+
+    def test_pulse_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.pulse = "triangle"
+
+    def test_pulse_type_error(self):
+        with self.assertRaises(TypeError):
+            self.p.pulse = 42
+
+    def test_epoch_int(self):
+        self.p.epoch = 5
+        self.assertEqual(self.p.epoch, 5)
+
+    def test_epoch_all_shorthand(self):
+        self.p.epoch = "all"
+        self.assertEqual(self.p.epoch, 0)
+        self.assertEqual(self.p.epoch_delta, 1)
+
+    def test_epoch_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.epoch = -1
+
+    def test_epoch_invalid_string_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.epoch = "none"
+
+    def test_epoch_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.p.epoch = True
+
+    def test_epoch_delta_valid(self):
+        self.p.epoch_delta = 3
+        self.assertEqual(self.p.epoch_delta, 3)
+
+    def test_epoch_delta_zero_allowed(self):
+        self.p.epoch_delta = 0
+        self.assertEqual(self.p.epoch_delta, 0)
+
+    def test_epoch_delta_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.p.epoch_delta = True
+
+    def test_float_attrs_accept_int(self):
+        self.p.amp = 2
+        self.assertAlmostEqual(self.p.amp, 2.0)
+
+    def test_float_attrs_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.p.amp = True
+
+    def test_float_attrs_string_raises(self):
+        with self.assertRaises(TypeError):
+            self.p.onset = "10"
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — config dict
+# ---------------------------------------------------------------------------
+
+class TestNMPulseConfigSet(unittest.TestCase):
+
+    def test_config_via_constructor(self):
+        p = NMPulse(config={"pulse": "exp", "amp": 2.0, "onset": 5.0, "tau": 20.0})
+        self.assertEqual(p.pulse, "exp")
+        self.assertAlmostEqual(p.amp, 2.0)
+        self.assertAlmostEqual(p.onset, 5.0)
+        self.assertAlmostEqual(p.func.tau, 20.0)
+
+    def test_to_dict_round_trip(self):
+        p = NMPulse(config={"pulse": "ramp+", "epoch": 3, "epoch_delta": 2,
+                             "amp": 4.0, "onset": 1.0, "width": 5.0,
+                             "onset_delta": 0.5})
+        d = p.to_dict()
+        p2 = NMPulse.from_dict(d)
+        self.assertEqual(p, p2)
+
+    def test_unknown_key_raises(self):
+        with self.assertRaises(KeyError):
+            NMPulse(config={"bad_key": 1})
+
+    def test_name_key_ignored(self):
+        p = NMPulse(name="myp", config={"name": "ignored", "amp": 3.0})
+        self.assertEqual(p.name, "myp")
+        self.assertAlmostEqual(p.amp, 3.0)
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — epoch targeting
+# ---------------------------------------------------------------------------
+
+class TestNMPulseEpochTargeting(unittest.TestCase):
+
+    def test_default_fires_only_epoch_zero(self):
+        p = NMPulse()  # epoch=0, epoch_delta=0
+        self.assertTrue(p.targets_epoch(0))
+        for i in range(1, 5):
+            self.assertFalse(p.targets_epoch(i))
+
+    def test_all_shorthand_fires_every_epoch(self):
+        p = NMPulse(config={"epoch": "all"})  # → epoch=0, epoch_delta=1
+        self.assertEqual(p.epoch, 0)
+        self.assertEqual(p.epoch_delta, 1)
+        for i in range(5):
+            self.assertTrue(p.targets_epoch(i))
+
+    def test_int_epoch_fires_only_on_that_epoch(self):
+        # epoch=2, epoch_delta=0 (default) → fires only on epoch 2
+        p = NMPulse(config={"epoch": 2})
+        self.assertFalse(p.targets_epoch(0))
+        self.assertFalse(p.targets_epoch(1))
+        self.assertTrue(p.targets_epoch(2))
+        self.assertFalse(p.targets_epoch(3))
+        self.assertFalse(p.targets_epoch(4))
+
+    def test_int_epoch_skips_before_start(self):
+        p = NMPulse(config={"epoch": 5, "epoch_delta": 1})
+        for i in range(5):
+            self.assertFalse(p.targets_epoch(i))
+        self.assertTrue(p.targets_epoch(5))
+
+    def test_epoch_delta_stride(self):
+        p = NMPulse(config={"epoch": 0, "epoch_delta": 2})
+        self.assertTrue(p.targets_epoch(0))
+        self.assertFalse(p.targets_epoch(1))
+        self.assertTrue(p.targets_epoch(2))
+        self.assertFalse(p.targets_epoch(3))
+        self.assertTrue(p.targets_epoch(4))
+
+    def test_int_epoch_with_stride(self):
+        p = NMPulse(config={"epoch": 1, "epoch_delta": 3})
+        self.assertFalse(p.targets_epoch(0))
+        self.assertTrue(p.targets_epoch(1))
+        self.assertFalse(p.targets_epoch(2))
+        self.assertFalse(p.targets_epoch(3))
+        self.assertTrue(p.targets_epoch(4))
+        self.assertTrue(p.targets_epoch(7))
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — waveform shapes
+# ---------------------------------------------------------------------------
+
+class TestNMPulseWaveformSquare(unittest.TestCase):
+
+    def test_amp_and_width_route_from_config(self):
+        p = NMPulse(config={"pulse": "square", "amp": 2.0, "onset": 10.0, "width": 5.0})
+        y = p.waveform(100, 0.0, 1.0, 0)
+        self.assertAlmostEqual(y[10], 2.0)   # amp applied
+        self.assertAlmostEqual(y[14], 2.0)   # inside window
+        self.assertAlmostEqual(y[15], 0.0)   # width truncates
+
+
+class TestNMPulseWaveformRamp(unittest.TestCase):
+
+    def test_direction_routes_from_config(self):
+        p_plus  = NMPulse(config={"pulse": "ramp+", "amp": 1.0, "onset": 0.0, "width": 10.0})
+        p_minus = NMPulse(config={"pulse": "ramp-", "amp": 1.0, "onset": 0.0, "width": 10.0})
+        y_plus  = p_plus.waveform(20, 0.0, 1.0, 0)
+        y_minus = p_minus.waveform(20, 0.0, 1.0, 0)
+        self.assertAlmostEqual(y_plus[0],  0.0, places=5)   # ramp+ starts at 0
+        self.assertAlmostEqual(y_minus[0], 1.0, places=5)   # ramp- starts at amp
+
+
+class TestNMPulseWaveformExp(unittest.TestCase):
+
+    def test_tau_routes_from_config(self):
+        p = NMPulse(config={"pulse": "exp", "amp": 3.0, "onset": 0.0, "tau": 10.0})
+        y = p.waveform(100, 0.0, 1.0, 0)
+        self.assertAlmostEqual(y[0], 3.0)             # amp at onset
+        self.assertAlmostEqual(y[10], 3.0 * math.exp(-1.0), places=5)  # tau decay
+
+    def test_width_truncates(self):
+        p = NMPulse(config={"pulse": "exp", "amp": 1.0, "onset": 0.0, "tau": 10.0, "width": 20.0})
+        y = p.waveform(50, 0.0, 1.0, 0)
+        self.assertGreater(y[19], 0.0)
+        self.assertAlmostEqual(y[20], 0.0)
+
+
+class TestNMPulseWaveformAlpha(unittest.TestCase):
+
+    def test_tau_routes_from_config(self):
+        p = NMPulse(config={"pulse": "alpha", "amp": 1.0, "onset": 0.0, "tau": 10.0})
+        y = p.waveform(100, 0.0, 1.0, 0)
+        self.assertAlmostEqual(int(np.argmax(y)), 10, delta=1)  # peak at onset + tau
+
+    def test_width_truncates(self):
+        p = NMPulse(config={"pulse": "alpha", "amp": 1.0, "onset": 0.0, "tau": 10.0, "width": 15.0})
+        y = p.waveform(50, 0.0, 1.0, 0)
+        self.assertGreater(y[14], 0.0)
+        self.assertAlmostEqual(y[15], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — delta variation
+# ---------------------------------------------------------------------------
+
+class TestNMPulseDelta(unittest.TestCase):
+
+    def test_delta_onset_shifts_per_occurrence(self):
+        p = NMPulse(config={
+            "pulse": "square", "amp": 1.0, "onset": 10.0, "width": 5.0,
+            "onset_delta": 10.0, "epoch_delta": 1,
+        })
+        # Occurrence 0: onset=10, occurrence 1: onset=20, occurrence 2: onset=30
+        y0 = p.waveform(100, 0.0, 1.0, epoch_idx=0)
+        y1 = p.waveform(100, 0.0, 1.0, epoch_idx=1)
+        y2 = p.waveform(100, 0.0, 1.0, epoch_idx=2)
+        # value at onset
+        self.assertAlmostEqual(y0[10], 1.0)
+        self.assertAlmostEqual(y1[20], 1.0)
+        self.assertAlmostEqual(y2[30], 1.0)
+        # zero before onset
+        self.assertAlmostEqual(y0[9],  0.0)
+        self.assertAlmostEqual(y1[19], 0.0)
+        self.assertAlmostEqual(y2[29], 0.0)
+        # zero after onset + width
+        self.assertAlmostEqual(y0[15], 0.0)
+        self.assertAlmostEqual(y1[25], 0.0)
+        self.assertAlmostEqual(y2[35], 0.0)
+
+    def test_epoch_delta_stride_occurrence_index(self):
+        # epoch=0, epoch_delta=2 → fires at 0,2,4,...
+        # occurrence 0 at epoch_idx=0, occurrence 1 at epoch_idx=2
+        p = NMPulse(config={
+            "pulse": "square", "amp": 1.0, "onset": 10.0, "width": 5.0,
+            "onset_delta": 5.0, "epoch_delta": 2,
+        })
+        # epoch_idx=0 → occurrence 0 → onset=10
+        y0 = p.waveform(100, 0.0, 1.0, epoch_idx=0)
+        # epoch_idx=2 → occurrence 1 → onset=15
+        y2 = p.waveform(100, 0.0, 1.0, epoch_idx=2)
+        self.assertAlmostEqual(y0[10], 1.0)
+        self.assertAlmostEqual(y2[15], 1.0)
+
+
+# ---------------------------------------------------------------------------
+# NMPulseContainer
+# ---------------------------------------------------------------------------
+
+class TestNMPulseContainerBasic(unittest.TestCase):
+
+    def test_new_returns_pulse(self):
+        c = NMPulseContainer()
+        p = c.new()
+        self.assertIsInstance(p, NMPulse)
+
+    def test_auto_names(self):
+        c = NMPulseContainer()
+        p0 = c.new()
+        p1 = c.new()
+        self.assertEqual(p0.name, "p0")
+        self.assertEqual(p1.name, "p1")
+
+    def test_len(self):
+        c = NMPulseContainer()
+        self.assertEqual(len(c), 0)
+        c.new()
+        self.assertEqual(len(c), 1)
+        c.new()
+        self.assertEqual(len(c), 2)
+
+    def test_contains(self):
+        c = NMPulseContainer()
+        c.new()
+        self.assertIn("p0", c)
+        self.assertNotIn("p1", c)
+
+    def test_getitem(self):
+        c = NMPulseContainer()
+        p = c.new({"amp": 5.0})
+        self.assertIs(c["p0"], p)
+        self.assertAlmostEqual(c["p0"].amp, 5.0)
+
+    def test_iter(self):
+        c = NMPulseContainer()
+        c.new()
+        c.new()
+        names = [p.name for p in c]
+        self.assertEqual(names, ["p0", "p1"])
+
+    def test_new_with_config(self):
+        c = NMPulseContainer()
+        p = c.new({"pulse": "exp", "tau": 20.0})
+        self.assertEqual(p.pulse, "exp")
+        self.assertAlmostEqual(p.func.tau, 20.0)
+
+
+class TestNMPulseContainerRoundTrip(unittest.TestCase):
+
+    def test_to_dict_from_dict(self):
+        c = NMPulseContainer()
+        c.new({"pulse": "square", "amp": 2.0, "onset": 5.0, "width": 3.0})
+        c.new({"pulse": "exp", "onset": 10.0, "tau": 8.0, "epoch": 1})
+        d = c.to_dict()
+        c2 = NMPulseContainer.from_dict(d)
+        self.assertEqual(len(c2), 2)
+        self.assertEqual(c2["p0"].pulse, "square")
+        self.assertAlmostEqual(c2["p0"].amp, 2.0)
+        self.assertEqual(c2["p1"].pulse, "exp")
+        self.assertEqual(c2["p1"].epoch, 1)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — defaults
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseDefaults(unittest.TestCase):
+
+    def setUp(self):
+        self.t = NMToolPulse()
+
+    def test_n_points(self):
+        self.assertEqual(self.t.n_points, 100)
+
+    def test_xstart(self):
+        self.assertAlmostEqual(self.t.xstart, 0.0)
+
+    def test_xdelta(self):
+        self.assertAlmostEqual(self.t.xdelta, 1.0)
+
+    def test_prefix(self):
+        self.assertEqual(self.t.prefix, "PG_")
+
+    def test_chan(self):
+        self.assertEqual(self.t.chan, "")
+
+    def test_overwrite(self):
+        self.assertTrue(self.t.overwrite)
+
+    def test_results_to_numpy(self):
+        self.assertTrue(self.t.results_to_numpy)
+
+    def test_pulses_empty(self):
+        self.assertEqual(len(self.t.pulses), 0)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — property validation
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseProperties(unittest.TestCase):
+
+    def setUp(self):
+        self.t = NMToolPulse()
+
+    def test_n_points_valid(self):
+        self.t.n_points = 50
+        self.assertEqual(self.t.n_points, 50)
+
+    def test_n_points_zero_raises(self):
+        with self.assertRaises(ValueError):
+            self.t.n_points = 0
+
+    def test_n_points_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.t.n_points = True
+
+    def test_n_points_float_raises(self):
+        with self.assertRaises(TypeError):
+            self.t.n_points = 1.0
+
+    def test_xstart_valid(self):
+        self.t.xstart = -5.0
+        self.assertAlmostEqual(self.t.xstart, -5.0)
+
+    def test_xstart_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.t.xstart = True
+
+    def test_xdelta_valid(self):
+        self.t.xdelta = 0.5
+        self.assertAlmostEqual(self.t.xdelta, 0.5)
+
+    def test_xdelta_zero_raises(self):
+        with self.assertRaises(ValueError):
+            self.t.xdelta = 0.0
+
+    def test_xdelta_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.t.xdelta = -1.0
+
+    def test_xdelta_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.t.xdelta = True
+
+    def test_prefix_valid(self):
+        self.t.prefix = "DAC_0_"
+        self.assertEqual(self.t.prefix, "DAC_0_")
+
+    def test_prefix_empty_raises(self):
+        with self.assertRaises(ValueError):
+            self.t.prefix = ""
+
+    def test_prefix_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.t.prefix = True
+
+    def test_channel_valid(self):
+        self.t.chan = "A"
+        self.assertEqual(self.t.chan, "A")
+
+    def test_channel_empty_ok(self):
+        self.t.chan = ""
+        self.assertEqual(self.t.chan, "")
+
+    def test_channel_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.t.chan = True
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — pipeline output
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseOutput(unittest.TestCase):
+
+    def setUp(self):
+        self.t = NMToolPulse()
+        self.t.n_points = 100
+        self.t.xstart = 0.0
+        self.t.xdelta = 1.0
+        self.t.pulses.new({"pulse": "square", "amp": 2.0, "onset": 10.0, "width": 5.0})
+
+    def test_output_inside_window(self):
+        folder = _run_tool(self.t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[10], 2.0)
+        self.assertAlmostEqual(y[14], 2.0)
+
+    def test_output_outside_window(self):
+        folder = _run_tool(self.t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[9], 0.0)
+        self.assertAlmostEqual(y[15], 0.0)
+
+    def test_output_length(self):
+        folder = _run_tool(self.t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertEqual(len(y), 100)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — multi-pulse summing
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseMultiPulse(unittest.TestCase):
+
+    def test_overlapping_pulses_sum(self):
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 10.0, "width": 5.0})
+        t.pulses.new({"pulse": "square", "amp": 3.0, "onset": 10.0, "width": 5.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[10], 4.0)
+
+    def test_non_overlapping_pulses_dont_sum(self):
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "width": 5.0})
+        t.pulses.new({"pulse": "square", "amp": 2.0, "onset": 20.0, "width": 5.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[5], 1.0)
+        self.assertAlmostEqual(y[20], 2.0)
+        self.assertAlmostEqual(y[0], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — epoch=0 targeting
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseEpochZeroOnly(unittest.TestCase):
+
+    def test_epoch_zero_pulse_absent_in_later_epochs(self):
+        t = NMToolPulse()
+        t.n_points = 50
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        # pulse only fires on epoch 0
+        t.pulses.new({"pulse": "square", "amp": 5.0, "onset": 5.0, "width": 5.0,
+                      "epoch": 0, "epoch_delta": 100})
+        data = [_make_empty_data("w%d" % i) for i in range(3)]
+        folder = _run_tool(t, data)
+        y0 = folder.data["PG_0"].nparray
+        y1 = folder.data["PG_1"].nparray
+        y2 = folder.data["PG_2"].nparray
+        self.assertAlmostEqual(y0[5], 5.0)
+        self.assertAlmostEqual(y1[5], 0.0)
+        self.assertAlmostEqual(y2[5], 0.0)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — output arrays (names, xscale, notes)
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseOutputArrays(unittest.TestCase):
+
+    def setUp(self):
+        self.t = NMToolPulse()
+        self.t.n_points = 50
+        self.t.xstart = 2.0
+        self.t.xdelta = 0.5
+        self.t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "width": 2.0})
+        data = [_make_empty_data("rec0")]
+        self.folder = _run_tool(self.t, data)
+
+    def test_arrays_written_to_folder(self):
+        self.assertIn("PG_0", self.folder.data)
+
+    def test_array_length(self):
+        y = self.folder.data["PG_0"].nparray
+        self.assertEqual(len(y), 50)
+
+    def test_xscale_start(self):
+        d = self.folder.data["PG_0"]
+        self.assertAlmostEqual(d.xscale.start, 2.0)
+
+    def test_xscale_delta(self):
+        d = self.folder.data["PG_0"]
+        self.assertAlmostEqual(d.xscale.delta, 0.5)
+
+    def test_epoch_names_array(self):
+        names = self.folder.data["PG_epoch_names"].nparray
+        self.assertEqual(list(names), ["rec0"])
+
+    def test_channel_in_array_names(self):
+        t = NMToolPulse()
+        t.n_points = 20
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.chan = "A"
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "width": 2.0})
+        folder = _run_tool(t, [_make_empty_data("w0"), _make_empty_data("w1")])
+        self.assertIn("PG_A0", folder.data)
+        self.assertIn("PG_A1", folder.data)
+        self.assertIn("PG_A_epoch_names", folder.data)
+
+    def test_note_contains_pulse_config(self):
+        d = self.folder.data["PG_0"]
+        notes = getattr(d, "notes", None)
+        if notes is None:
+            return  # notes not supported on this NMData — skip
+        note_text = " ".join(str(n) for n in notes)
+        self.assertIn("pulses", note_text)
+        # note must include pulse shape
+        self.assertIn("square", note_text)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — prefix and channel naming
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulsePrefix(unittest.TestCase):
+
+    def _run(self, prefix, channel, n_epochs=2):
+        t = NMToolPulse()
+        t.n_points = 20
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.prefix = prefix
+        t.chan = channel
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "width": 2.0})
+        data = [_make_empty_data("d%d" % i) for i in range(n_epochs)]
+        return _run_tool(t, data)
+
+    def test_default_prefix(self):
+        folder = self._run("PG_", "")
+        self.assertIn("PG_0", folder.data)
+        self.assertIn("PG_1", folder.data)
+        self.assertIn("PG_epoch_names", folder.data)
+
+    def test_record_channel(self):
+        folder = self._run("Record", "A")
+        self.assertIn("RecordA0", folder.data)
+        self.assertIn("RecordA1", folder.data)
+        self.assertIn("RecordA_epoch_names", folder.data)
+
+    def test_dac_prefix(self):
+        folder = self._run("DAC_0_", "")
+        self.assertIn("DAC_0_0", folder.data)
+        self.assertIn("DAC_0_1", folder.data)
+        self.assertIn("DAC_0_epoch_names", folder.data)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — multi-epoch
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseMultiEpoch(unittest.TestCase):
+
+    def test_two_epochs_two_arrays(self):
+        t = NMToolPulse()
+        t.n_points = 30
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "width": 3.0})
+        data = [_make_empty_data("e0"), _make_empty_data("e1")]
+        folder = _run_tool(t, data)
+        self.assertIn("PG_0", folder.data)
+        self.assertIn("PG_1", folder.data)
+        self.assertEqual(len(folder.data["PG_epoch_names"].nparray), 2)
+        self.assertEqual(list(folder.data["PG_epoch_names"].nparray), ["e0", "e1"])
+
+    def test_delta_onset_across_epochs(self):
+        t = NMToolPulse()
+        t.n_points = 60
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        # onset shifts by 10 per epoch
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 10.0, "width": 5.0,
+                      "onset_delta": 10.0, "epoch_delta": 1})
+        data = [_make_empty_data("e%d" % i) for i in range(3)]
+        folder = _run_tool(t, data)
+        self.assertAlmostEqual(folder.data["PG_0"].nparray[10], 1.0)
+        self.assertAlmostEqual(folder.data["PG_1"].nparray[20], 1.0)
+        self.assertAlmostEqual(folder.data["PG_2"].nparray[30], 1.0)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulseConfig
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseConfig(unittest.TestCase):
+
+    def test_defaults(self):
+        c = NMToolPulseConfig()
+        self.assertEqual(c.n_points, 100)
+        self.assertAlmostEqual(c.xstart, 0.0)
+        self.assertAlmostEqual(c.xdelta, 1.0)
+        self.assertEqual(c.prefix, "PG_")
+        self.assertEqual(c.chan, "")
+        self.assertTrue(c.overwrite)
+
+    def test_toml_type(self):
+        self.assertEqual(NMToolPulseConfig._TOML_TYPE, "pulse_config")
+
+    def test_set_validates(self):
+        c = NMToolPulseConfig()
+        with self.assertRaises(ValueError):
+            c.n_points = 0
+        with self.assertRaises(ValueError):
+            c.xdelta = -1.0
+
+    def test_round_trip(self):
+        c = NMToolPulseConfig()
+        c.n_points = 200
+        c.xstart = -5.0
+        c.xdelta = 0.5
+        c.prefix = "DAC_1_"
+        c.chan = "B"
+        d = c.to_dict()
+        c2 = NMToolPulseConfig.from_dict(d)
+        self.assertEqual(c, c2)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — overwrite flag
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseOverwrite(unittest.TestCase):
+
+    def test_overwrite_replaces_arrays(self):
+        t = NMToolPulse()
+        t.n_points = 20
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.overwrite = True
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "width": 2.0})
+        folder = NMFolder(NM, name="TestFolder")
+        data = [_make_empty_data("w0")]
+        targets, _ = _make_targets(data, folder=folder)
+        t.run_all(targets)
+        t.run_all(targets)  # second run with overwrite=True
+        # arrays should be replaced, not duplicated
+        self.assertIn("PG_0", folder.data)
+        self.assertIn("PG_epoch_names", folder.data)
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — sin / cos / sinzap / user waveforms
+# ---------------------------------------------------------------------------
+
+class TestNMPulseWaveformSin(unittest.TestCase):
+
+    def test_freq_phase_route_from_config(self):
+        p = NMPulse(config={"pulse": "sin", "freq": 0.25, "phase": math.pi / 2,
+                             "amp": 1.0, "onset": 0.0})
+        y = p.waveform(20, 0.0, 1.0, 0)
+        self.assertAlmostEqual(y[0], 1.0, places=5)   # phase=π/2 → cos(0)=1
+
+    def test_width_truncates(self):
+        p = NMPulse(config={"pulse": "sin", "freq": 0.25,
+                             "amp": 1.0, "onset": 5.0, "width": 4.0})
+        y = p.waveform(30, 0.0, 1.0, 0)
+        self.assertAlmostEqual(y[9], 0.0)
+
+    def test_func_property_accessible(self):
+        p = NMPulse(config={"pulse": "sin"})
+        from pyneuromatic.analysis.nm_pulse_func import NMPulseFuncSin
+        self.assertIsInstance(p.func, NMPulseFuncSin)
+
+    def test_round_trip_dict(self):
+        p = NMPulse(config={"pulse": "sin", "freq": 0.5, "phase": 0.1,
+                             "amp": 1.0, "onset": 0.0})
+        d = p.to_dict()
+        self.assertEqual(d["pulse"], "sin")
+        self.assertAlmostEqual(d["freq"], 0.5)
+        self.assertAlmostEqual(d["phase"], 0.1)
+        p2 = NMPulse(config=d)
+        self.assertAlmostEqual(p2.func._freq, 0.5)
+        self.assertAlmostEqual(p2.func._phase, 0.1)
+
+
+class TestNMPulseWaveformSinZap(unittest.TestCase):
+
+    def test_truncated_by_width(self):
+        p = NMPulse(config={"pulse": "sinzap", "f0": 0.05, "f1": 0.2,
+                             "amp": 1.0, "onset": 0.0, "width": 50.0})
+        y = p.waveform(100, 0.0, 1.0, 0)
+        self.assertAlmostEqual(y[50], 0.0)
+
+    def test_round_trip_dict(self):
+        p = NMPulse(config={"pulse": "sinzap", "f0": 0.1, "f1": 0.5,
+                             "amp": 1.0, "onset": 0.0})
+        d = p.to_dict()
+        self.assertEqual(d["pulse"], "sinzap")
+        self.assertAlmostEqual(d["f0"], 0.1)
+        self.assertAlmostEqual(d["f1"], 0.5)
+        p2 = NMPulse(config=d)
+        self.assertAlmostEqual(p2.func._f0, 0.1)
+        self.assertAlmostEqual(p2.func._f1, 0.5)
+
+
+_USER_RAW = np.sin(np.linspace(0, 2 * math.pi, 50))
+
+
+class TestNMPulseWaveformUser(unittest.TestCase):
+
+    def _make_user_pulse(self, onset=0.0, amp=1.0, width=math.inf):
+        return NMPulse(config={"pulse": "user", "amp": amp, "onset": onset,
+                                "width": width, "data": _USER_RAW,
+                                "xdelta_data": 1.0})
+
+    def test_onset_shifts_waveform(self):
+        p0 = self._make_user_pulse(onset=0.0, amp=1.0)
+        p10 = self._make_user_pulse(onset=10.0, amp=1.0)
+        y0 = p0.waveform(100, 0.0, 1.0, 0)
+        y10 = p10.waveform(100, 0.0, 1.0, 0)
+        # peak of shifted wave is 10 samples later
+        self.assertAlmostEqual(np.argmax(y0) + 10, np.argmax(y10), delta=1)
+
+    def test_func_property_accessible(self):
+        p = self._make_user_pulse()
+        from pyneuromatic.analysis.nm_pulse_func import NMPulseFuncUser
+        self.assertIsInstance(p.func, NMPulseFuncUser)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — sin / cos / sinzap / user shapes via run_all
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseSin(unittest.TestCase):
+
+    def setUp(self):
+        self.t = NMToolPulse()
+        self.t.n_points = 100
+        self.t.xstart = 0.0
+        self.t.xdelta = 1.0
+        self.t.pulses.new({"pulse": "sin", "freq": 0.25, "phase": 0.0,
+                           "amp": 2.0, "onset": 0.0})
+
+    def test_peak_at_quarter_period(self):
+        folder = _run_tool(self.t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[1], 2.0, places=5)
+
+    def test_output_length(self):
+        folder = _run_tool(self.t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertEqual(len(y), 100)
+
+    def test_zero_before_onset(self):
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "sin", "freq": 0.1, "amp": 1.0, "onset": 20.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[19], 0.0)
+
+
+class TestNMToolPulseSinZap(unittest.TestCase):
+
+    def setUp(self):
+        self.t = NMToolPulse()
+        self.t.n_points = 200
+        self.t.xstart = 0.0
+        self.t.xdelta = 1.0
+        self.t.pulses.new({"pulse": "sinzap", "f0": 0.05, "f1": 0.2,
+                           "amp": 1.0, "onset": 0.0})
+
+    def test_zero_at_onset(self):
+        folder = _run_tool(self.t, [_make_empty_data("w0", n=200)])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[0], 0.0, places=10)
+
+    def test_nonzero_in_sweep(self):
+        folder = _run_tool(self.t, [_make_empty_data("w0", n=200)])
+        y = folder.data["PG_0"].nparray
+        self.assertGreater(np.max(np.abs(y)), 0.5)
+
+    def test_output_length(self):
+        folder = _run_tool(self.t, [_make_empty_data("w0", n=200)])
+        y = folder.data["PG_0"].nparray
+        self.assertEqual(len(y), 200)
+
+    def test_truncated_by_width(self):
+        t = NMToolPulse()
+        t.n_points = 200
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "sinzap", "f0": 0.05, "f1": 0.2,
+                      "amp": 1.0, "onset": 0.0, "width": 50.0})
+        folder = _run_tool(t, [_make_empty_data("w0", n=200)])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[50], 0.0)
+
+
+class TestNMToolPulseUser(unittest.TestCase):
+
+    def _make_tool(self, onset=0.0, amp=1.0, width=math.inf, n=100):
+        t = NMToolPulse()
+        t.n_points = n
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "user", "amp": amp, "onset": onset,
+                      "width": width, "data": _USER_RAW, "xdelta_data": 1.0})
+        return t
+
+    def test_peak_equals_amp(self):
+        t = self._make_tool(amp=2.0)
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(np.max(y), 2.0, places=4)
+
+    def test_zero_before_onset(self):
+        t = self._make_tool(onset=20.0)
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[19], 0.0)
+
+    def test_truncation_by_width(self):
+        t = self._make_tool(onset=0.0, width=20.0)
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[20], 0.0)
+
+    def test_output_length(self):
+        t = self._make_tool()
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertEqual(len(y), 100)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `NMPulseFuncX` shape hierarchy (square, ramp+/-, exp, alpha, sin, sinzap, user) following the `NMStatFunc` pattern — each subclass owns its shape-specific params and implements `waveform()`; shared validation via `_build_masked_x()` in the base class
- Add `NMPulse` / `NMPulseContainer` with universal params `amp`, `onset`, `width` and per-epoch variation (`amp_delta`, `onset_delta`, `width_delta`, `amp_stdv`, `onset_stdv`, `width_stdv`)
- Epoch targeting via `epoch` / `epoch_delta`: default `epoch=0, epoch_delta=0` fires only on epoch 0; `epoch="all"` is accepted as sugar for `epoch=0, epoch_delta=1`
- Add `NMToolPulse` — writes output directly to `NMFolder.data` (no subfolder); prefix acts as namespace (e.g. `PG_A0`, `PG_A_epoch_names`). Generator tools write primary data, not derived results — see architectural decision in memory
- Note string follows the concise format used by other tools (`NMSpike`, `NMFit`)

## Test plan

- [ ] `pytest tests/test_analysis/test_nm_pulse_func.py` — NMPulseFunc hierarchy and factory
- [ ] `pytest tests/test_analysis/test_nm_tool_pulse.py` — NMPulse, NMPulseContainer, NMToolPulse pipeline
- [ ] `pytest tests/` — full suite (3300 tests passing)

