### PR TITLE
feat(analysis): add pulse train and stochastic interval support to NMPulse

### DIFF
--- a/pyneuromatic/analysis/nm_pulse.py
+++ b/pyneuromatic/analysis/nm_pulse.py
@@ -37,33 +37,41 @@ from pyneuromatic.analysis.nm_pulse_func import (
 )
 
 _FLOAT_ATTRS: tuple[str, ...] = (
-    "amp", "onset", "width",
-    "amp_delta", "onset_delta", "width_delta",
-    "amp_stdv", "onset_stdv", "width_stdv",
+    "amp", "onset", "duration",
+    "amp_delta", "onset_delta", "duration_delta",
+    "amp_stdv", "onset_stdv", "duration_stdv",
+    "interval", "interval_stdv", "interval_min", "interval_max", "train_duration",
 )
 
 # Keys that belong to the NMPulseFunc subclass, not to NMPulse directly.
 _FUNC_ONLY_KEYS: frozenset[str] = frozenset({
-    "tau", "freq", "phase", "f0", "f1", "data", "xdelta_data",
+    "tau", "freq", "phase", "f0", "f1", "data", "data_xdelta",
 })
+
+_VALID_INTERVAL_TYPES: frozenset[str] = frozenset({"fixed", "gaussian", "poisson"})
 
 
 class NMPulse:
-    """Single pulse component: shape, parameters, and epoch targeting.
+    """Pulse component: shape, parameters, epoch targeting, and optional train.
 
     Lightweight class (does not inherit NMObject) following the NMStatWin
     pattern. Each NMPulse defines one waveform component that can be added
     to an output epoch array.
 
-    Epoch targeting:
-        - ``epoch="all"`` (default): fires on every epoch (stride controlled
-          by ``epoch_delta``).
-        - ``epoch=N``: fires starting at epoch N, then every ``epoch_delta``
-          epochs.
+    When ``n_pulses=1`` (default) a single pulse is generated.  When
+    ``n_pulses>1`` a train of that pulse shape is generated with inter-pulse
+    intervals controlled by ``interval`` and ``interval_type``.
 
-    Parameter variation per occurrence (0-based firing count):
-        - ``delta_<param>``: linear shift per occurrence.
-        - ``stdv_<param>``: Gaussian noise σ added each occurrence.
+    Epoch targeting:
+        - ``epoch=0, epoch_delta=0`` (default): fires only on epoch 0.
+        - ``epoch="all"``: shorthand for ``epoch=0, epoch_delta=1``.
+
+    Train parameters (ignored when ``n_pulses=1``):
+        - ``interval``: mean inter-pulse interval (> 0). Default 100.0.
+        - ``interval_type``: ``"fixed"`` (default), ``"gaussian"``, or
+          ``"poisson"``.
+        - ``interval_stdv``: stdv for Gaussian jitter (``interval_type="gaussian"``
+          only). Default 0.0.
 
     Args:
         name: Pulse name (default ``"NMPulse0"``).
@@ -83,17 +91,26 @@ class NMPulse:
         self._nm_path = nm_path
 
         self._func: NMPulseFunc = NMPulseFuncSquare()
+        self._enabled: bool = True
         self._epoch: int = 0
         self._epoch_delta: int = 0
         self._amp: float = 1.0
-        self._onset: float = 10.0
-        self._width: float = math.inf
         self._amp_delta: float = 0.0
-        self._onset_delta: float = 0.0
-        self._width_delta: float = 0.0
         self._amp_stdv: float = 0.0
+        self._onset: float = 10.0
+        self._onset_delta: float = 0.0
         self._onset_stdv: float = 0.0
-        self._width_stdv: float = 0.0
+        self._duration: float = math.inf
+        self._duration_delta: float = 0.0
+        self._duration_stdv: float = 0.0
+        self._n_pulses: int = 1
+        self._interval: float = 100.0
+        self._interval_stdv: float = 0.0
+        self._interval_min: float = 0.0
+        self._interval_max: float = math.inf
+        self._interval_type: str = "fixed"
+        self._seed: int | None = None
+        self._train_duration: float = math.inf
 
         if config is not None:
             self._config_set(config, quiet=True)
@@ -107,6 +124,19 @@ class NMPulse:
     def name(self) -> str:
         """Pulse name string."""
         return self._name
+
+    @property
+    def enabled(self) -> bool:
+        """Whether this pulse contributes to the output waveform. Default True."""
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "enabled", "bool"))
+        self._enabled = value
+        nmh.history("set enabled=%s" % value, path=self._name)
+        add_nm_command("%s[%r].enabled = %r" % (self._nm_path, self._name, self._enabled))
 
     # ------------------------------------------------------------------
     # pulse shape / func
@@ -187,13 +217,24 @@ class NMPulse:
         nmh.history("set epoch_delta=%d" % self._epoch_delta, path=self._name, quiet=quiet)
 
     # ------------------------------------------------------------------
-    # float parameters (amp, onset, width, delta_*, stdv_*)
+    # float parameters (amp, onset, duration, *_delta, *_stdv, interval*)
 
     def _float_set(self, attr: str, value: float, quiet: bool = nmc.QUIET) -> None:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise TypeError(nmu.type_error_str(value, attr, "float"))
-        setattr(self, "_" + attr, float(value))
-        nmh.history("set %s=%g" % (attr, float(value)), path=self._name, quiet=quiet)
+        v = float(value)
+        if attr == "interval" and v <= 0:
+            raise ValueError("interval must be > 0, got %s" % v)
+        if attr == "interval_stdv" and v < 0:
+            raise ValueError("interval_stdv must be >= 0, got %s" % v)
+        if attr == "interval_min" and v < 0:
+            raise ValueError("interval_min must be >= 0, got %s" % v)
+        if attr == "interval_max" and v <= 0:
+            raise ValueError("interval_max must be > 0, got %s" % v)
+        if attr == "train_duration" and v <= 0:
+            raise ValueError("train_duration must be > 0, got %s" % v)
+        setattr(self, "_" + attr, v)
+        nmh.history("set %s=%g" % (attr, v), path=self._name, quiet=quiet)
 
     @property
     def amp(self) -> float:
@@ -214,13 +255,13 @@ class NMPulse:
         add_nm_command("%s[%r].onset = %r" % (self._nm_path, self._name, self._onset))
 
     @property
-    def width(self) -> float:
-        return self._width
+    def duration(self) -> float:
+        return self._duration
 
-    @width.setter
-    def width(self, value: float) -> None:
-        self._float_set("width", value)
-        add_nm_command("%s[%r].width = %r" % (self._nm_path, self._name, self._width))
+    @duration.setter
+    def duration(self, value: float) -> None:
+        self._float_set("duration", value)
+        add_nm_command("%s[%r].duration = %r" % (self._nm_path, self._name, self._duration))
 
     @property
     def amp_delta(self) -> float:
@@ -245,14 +286,14 @@ class NMPulse:
         )
 
     @property
-    def width_delta(self) -> float:
-        return self._width_delta
+    def duration_delta(self) -> float:
+        return self._duration_delta
 
-    @width_delta.setter
-    def width_delta(self, value: float) -> None:
-        self._float_set("width_delta", value)
+    @duration_delta.setter
+    def duration_delta(self, value: float) -> None:
+        self._float_set("duration_delta", value)
         add_nm_command(
-            "%s[%r].width_delta = %r" % (self._nm_path, self._name, self._width_delta)
+            "%s[%r].duration_delta = %r" % (self._nm_path, self._name, self._duration_delta)
         )
 
     @property
@@ -278,15 +319,127 @@ class NMPulse:
         )
 
     @property
-    def width_stdv(self) -> float:
-        return self._width_stdv
+    def duration_stdv(self) -> float:
+        return self._duration_stdv
 
-    @width_stdv.setter
-    def width_stdv(self, value: float) -> None:
-        self._float_set("width_stdv", value)
+    @duration_stdv.setter
+    def duration_stdv(self, value: float) -> None:
+        self._float_set("duration_stdv", value)
         add_nm_command(
-            "%s[%r].width_stdv = %r" % (self._nm_path, self._name, self._width_stdv)
+            "%s[%r].duration_stdv = %r" % (self._nm_path, self._name, self._duration_stdv)
         )
+
+    @property
+    def n_pulses(self) -> int:
+        """Number of pulses in train. ``0`` means unlimited (use ``train_duration`` to bound)."""
+        return self._n_pulses
+
+    @n_pulses.setter
+    def n_pulses(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "n_pulses", "int"))
+        if value < 0:
+            raise ValueError("n_pulses must be >= 0, got %d" % value)
+        self._n_pulses = value
+        add_nm_command("%s[%r].n_pulses = %r" % (self._nm_path, self._name, self._n_pulses))
+
+    @property
+    def interval(self) -> float:
+        """Mean inter-pulse interval (> 0). Used when n_pulses > 1."""
+        return self._interval
+
+    @interval.setter
+    def interval(self, value: float) -> None:
+        self._float_set("interval", value)
+        add_nm_command("%s[%r].interval = %r" % (self._nm_path, self._name, self._interval))
+
+    @property
+    def interval_stdv(self) -> float:
+        """Gaussian stdv on interval (interval_type='gaussian' only)."""
+        return self._interval_stdv
+
+    @interval_stdv.setter
+    def interval_stdv(self, value: float) -> None:
+        self._float_set("interval_stdv", value)
+        add_nm_command(
+            "%s[%r].interval_stdv = %r" % (self._nm_path, self._name, self._interval_stdv)
+        )
+
+    @property
+    def interval_min(self) -> float:
+        """Minimum interval after sampling (>= 0). Clamps random draws. Default 0.0."""
+        return self._interval_min
+
+    @interval_min.setter
+    def interval_min(self, value: float) -> None:
+        self._float_set("interval_min", value)
+        add_nm_command(
+            "%s[%r].interval_min = %r" % (self._nm_path, self._name, self._interval_min)
+        )
+
+    @property
+    def interval_max(self) -> float:
+        """Maximum interval after sampling (> 0). Clamps random draws. Default inf."""
+        return self._interval_max
+
+    @interval_max.setter
+    def interval_max(self, value: float) -> None:
+        self._float_set("interval_max", value)
+        add_nm_command(
+            "%s[%r].interval_max = %r" % (self._nm_path, self._name, self._interval_max)
+        )
+
+    @property
+    def interval_type(self) -> str:
+        """Interval distribution: ``'fixed'``, ``'gaussian'``, or ``'poisson'``."""
+        return self._interval_type
+
+    @interval_type.setter
+    def interval_type(self, value: str) -> None:
+        self._interval_type_set(value)
+        add_nm_command(
+            "%s[%r].interval_type = %r" % (self._nm_path, self._name, self._interval_type)
+        )
+
+    @property
+    def seed(self) -> int | None:
+        """Optional RNG seed for stochastic interval types. ``None`` uses the global state."""
+        return self._seed
+
+    @seed.setter
+    def seed(self, value: int | None) -> None:
+        if value is not None:
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(nmu.type_error_str(value, "seed", "int or None"))
+            if value < 0:
+                raise ValueError("seed must be >= 0, got %d" % value)
+        self._seed = value
+        nmh.history("set seed=%r" % value, path=self._name)
+        add_nm_command("%s[%r].seed = %r" % (self._nm_path, self._name, self._seed))
+
+    @property
+    def train_duration(self) -> float:
+        """Duration of the train window. Pulses stop when onset_i >= onset + train_duration.
+        Default ``inf`` (no window limit). Requires ``n_pulses=0`` or a large count."""
+        return self._train_duration
+
+    @train_duration.setter
+    def train_duration(self, value: float) -> None:
+        self._float_set("train_duration", value)
+        add_nm_command(
+            "%s[%r].train_duration = %r" % (self._nm_path, self._name, self._train_duration)
+        )
+
+    def _interval_type_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "interval_type", "string"))
+        if value not in _VALID_INTERVAL_TYPES:
+            raise ValueError(
+                "interval_type must be one of %s, got %r"
+                % (sorted(_VALID_INTERVAL_TYPES), value)
+            )
+        self._interval_type = value
+        nmh.history("set interval_type=%r" % value, path=self._name, quiet=quiet)
 
     # ------------------------------------------------------------------
     # Epoch targeting
@@ -304,7 +457,7 @@ class NMPulse:
         return (epoch_idx - self._epoch) % self._epoch_delta == 0
 
     def _occurrence_idx(self, epoch_idx: int) -> int:
-        """Return the 0-based firing count for *epoch_idx* (used to scale delta_*)."""
+        """Return the 0-based firing count for *epoch_idx* (used to scale *_delta)."""
         if self._epoch_delta == 0:
             return 0
         return (epoch_idx - self._epoch) // self._epoch_delta
@@ -321,7 +474,7 @@ class NMPulse:
     ) -> np.ndarray:
         """Compute this pulse's contribution for *epoch_idx*.
 
-        Scales delta_* by occurrence index and adds stdv noise, then
+        Scales *_delta by occurrence index and adds stdv noise, then
         delegates to the appropriate nm_math.pulse_* function.
 
         Args:
@@ -338,10 +491,38 @@ class NMPulse:
             _rng.normal(0.0, self._amp_stdv)   if self._amp_stdv   > 0 else 0.0)
         onset = self._onset + self._onset_delta * occ + (
             _rng.normal(0.0, self._onset_stdv) if self._onset_stdv > 0 else 0.0)
-        width = self._width + self._width_delta * occ + (
-            _rng.normal(0.0, self._width_stdv) if self._width_stdv > 0 else 0.0)
+        duration = self._duration + self._duration_delta * occ + (
+            _rng.normal(0.0, self._duration_stdv) if self._duration_stdv > 0 else 0.0)
 
-        return self._func.waveform(n_points, xstart, xdelta, amp, onset, width)
+        if self._n_pulses == 1:
+            self._last_onset_times: list[float] = [onset]
+            return self._func.waveform(n_points, xstart, xdelta, amp, onset, duration)
+
+        rng = np.random.default_rng(self._seed) if self._seed is not None else _rng
+        y = np.zeros(n_points, dtype=float)
+        onset_i = onset
+        count = 0
+        train_end = onset + self._train_duration
+        onset_times: list[float] = []
+        while True:
+            if self._n_pulses > 0 and count >= self._n_pulses:
+                break
+            if not math.isinf(self._train_duration) and onset_i >= train_end:
+                break
+            onset_times.append(onset_i)
+            y += self._func.waveform(n_points, xstart, xdelta, amp, onset_i, duration)
+            count += 1
+            if self._interval_type == "poisson":
+                iv = rng.exponential(scale=self._interval)
+            elif self._interval_type == "gaussian":
+                iv = rng.normal(self._interval, self._interval_stdv)
+            else:
+                iv = self._interval
+            iv = max(iv, self._interval_min)
+            iv = min(iv, self._interval_max)
+            onset_i += iv
+        self._last_onset_times = onset_times
+        return y
 
     # ------------------------------------------------------------------
     # Serialisation
@@ -350,8 +531,8 @@ class NMPulse:
         """Set multiple parameters from a dict. Unknown keys raise KeyError.
 
         Two-phase: shape name + func-only keys (tau, freq, phase, f0, f1,
-        data, xdelta_data) are used to create/update the NMPulseFunc; all
-        other keys (amp, onset, width, delta_*, stdv_*, epoch, epoch_delta)
+        data, data_xdelta) are used to create/update the NMPulseFunc; all
+        other keys (amp, onset, duration, *_delta, *_stdv, epoch, epoch_delta)
         are applied to NMPulse attrs directly.
         """
         if not isinstance(config, dict):
@@ -365,13 +546,14 @@ class NMPulse:
             if not isinstance(k, str):
                 raise TypeError(nmu.type_error_str(k, "key", "string"))
             kl = k.lower()
-            if kl == "name":
+            if kl in ("name", "type"):
                 continue
             elif kl == "pulse":
                 pulse_name = v
             elif kl in _FUNC_ONLY_KEYS:
                 func_kwargs[kl] = v
-            elif kl in ("epoch", "epoch_delta") or kl in _FLOAT_ATTRS:
+            elif kl in ("epoch", "epoch_delta", "n_pulses", "interval_type", "enabled", "seed") \
+                    or kl in _FLOAT_ATTRS:  # includes interval, interval_stdv, train_duration
                 nm_attrs[kl] = v
             else:
                 raise KeyError("NMPulse: unknown config key %r" % k)
@@ -387,6 +569,14 @@ class NMPulse:
                 self._epoch_set(v, quiet=True)
             elif kl == "epoch_delta":
                 self._epoch_delta_set(v, quiet=True)
+            elif kl == "n_pulses":
+                self.n_pulses = v
+            elif kl == "interval_type":
+                self._interval_type_set(v, quiet=True)
+            elif kl == "enabled":
+                self.enabled = v
+            elif kl == "seed":
+                self.seed = v
             else:
                 self._float_set(kl, v, quiet=True)
 
@@ -397,23 +587,32 @@ class NMPulse:
 
         The ``"pulse"`` key and any shape-specific keys (e.g. ``"freq"``,
         ``"tau"``) come from the embedded :class:`NMPulseFunc`.  Universal
-        parameters (amp, onset, width, tau) and variation parameters are
+        parameters (amp, onset, duration, tau) and variation parameters are
         stored directly on NMPulse and take precedence over any overlapping
         values in the func's dict.
         """
         d: dict = {
-            "name":          self._name,
-            "epoch":         self._epoch,
-            "epoch_delta":   self._epoch_delta,
-            "amp":           self._amp,
-            "onset":         self._onset,
-            "width":         self._width,
-            "amp_delta":     self._amp_delta,
-            "onset_delta":   self._onset_delta,
-            "width_delta":   self._width_delta,
-            "amp_stdv":      self._amp_stdv,
-            "onset_stdv":    self._onset_stdv,
-            "width_stdv":    self._width_stdv,
+            "name":           self._name,
+            "enabled":        self._enabled,
+            "seed":           self._seed,
+            "epoch":          self._epoch,
+            "epoch_delta":    self._epoch_delta,
+            "amp":            self._amp,
+            "amp_delta":      self._amp_delta,
+            "amp_stdv":       self._amp_stdv,
+            "onset":          self._onset,
+            "onset_delta":    self._onset_delta,
+            "onset_stdv":     self._onset_stdv,
+            "duration":       self._duration,
+            "duration_delta": self._duration_delta,
+            "duration_stdv":  self._duration_stdv,
+            "n_pulses":       self._n_pulses,
+            "interval":       self._interval,
+            "interval_stdv":  self._interval_stdv,
+            "interval_min":   self._interval_min,
+            "interval_max":   self._interval_max,
+            "interval_type":  self._interval_type,
+            "train_duration":    self._train_duration,
         }
         # Merge func-specific entries (pulse name + shape params like tau/freq/phase).
         d.update(self._func.to_dict())
@@ -431,7 +630,7 @@ class NMPulse:
 class NMPulseContainer:
     """Ordered container of NMPulse objects with auto-naming.
 
-    Pulses are created via ``new()`` and named ``"p0"``, ``"p1"``, etc.
+    Items are created via ``new()`` and named ``"p0"``, ``"p1"``, etc.
 
     Args:
         nm_path: Dot-path used in command history entries.
@@ -450,8 +649,8 @@ class NMPulseContainer:
         """Create, register, and return a new NMPulse with an auto-name.
 
         Args:
-            config: Optional dict of initial parameter values (passed to
-                ``NMPulse._config_set()``).
+            config: Optional dict of initial parameter values.  Set
+                ``n_pulses > 1`` for a train.
 
         Returns:
             The new NMPulse.
@@ -465,7 +664,7 @@ class NMPulseContainer:
         return p
 
     def __iter__(self):
-        """Iterate over NMPulse objects in insertion order."""
+        """Iterate over pulses in insertion order."""
         return iter(self._pulses.values())
 
     def __len__(self) -> int:

--- a/pyneuromatic/analysis/nm_pulse_func.py
+++ b/pyneuromatic/analysis/nm_pulse_func.py
@@ -42,9 +42,9 @@ class NMPulseFunc:
 
     Lightweight class (following NMStatFunc pattern) that represents a pulse
     shape with its shape-specific parameters.  Universal parameters
-    (``amp``, ``onset``, ``width``) are passed as arguments to
+    (``amp``, ``onset``, ``duration``) are passed as arguments to
     :meth:`waveform` by the caller (:class:`~pyneuromatic.analysis.nm_pulse.NMPulse`)
-    so that per-epoch variation (``delta_*``/``stdv_*``) can be applied
+    so that per-epoch variation (``*_delta``/``*_stdv``) can be applied
     before dispatch.
 
     Each subclass stores only its own shape-specific parameters and
@@ -86,27 +86,27 @@ class NMPulseFunc:
         xstart: float,
         xdelta: float,
         onset: float,
-        width: float,
+        duration: float,
     ) -> tuple:
         """Validate args and build the x-axis, zero output array, and window mask.
 
         Returns:
             ``(x, y, mask)`` — x-axis array, zero-filled output array, and
-            boolean mask selecting samples in ``[onset, onset + width)``.
-            When ``width`` is ``inf`` the mask selects ``x >= onset``.
+            boolean mask selecting samples in ``[onset, onset + duration)``.
+            When ``duration`` is ``inf`` the mask selects ``x >= onset``.
         """
         if n_points < 1:
             raise ValueError("n_points must be >= 1, got %d" % n_points)
         if xdelta <= 0:
             raise ValueError("xdelta must be > 0, got %s" % xdelta)
-        if width <= 0:
-            raise ValueError("width must be > 0, got %s" % width)
+        if duration <= 0:
+            raise ValueError("duration must be > 0, got %s" % duration)
         x = xstart + np.arange(n_points) * xdelta
         y = np.zeros(n_points, dtype=float)
-        if math.isinf(width):
+        if math.isinf(duration):
             mask = x >= onset
         else:
-            mask = (x >= onset) & (x < onset + width)
+            mask = (x >= onset) & (x < onset + duration)
         return x, y, mask
 
     def waveform(
@@ -116,7 +116,7 @@ class NMPulseFunc:
         xdelta: float,
         amp: float,
         onset: float,
-        width: float,
+        duration: float,
         **kwargs,
     ) -> np.ndarray:
         """Generate the waveform for this pulse shape.
@@ -127,7 +127,7 @@ class NMPulseFunc:
             xdelta: Sample interval.
             amp: Pulse amplitude (already varied by caller).
             onset: Pulse start x-value (already varied by caller).
-            width: Pulse duration (already varied by caller).
+            duration: Pulse duration (already varied by caller).
             **kwargs: Shape-specific overrides (e.g. ``tau=`` for exp/alpha).
 
         Returns:
@@ -155,8 +155,8 @@ class NMPulseFuncSquare(NMPulseFunc):
             raise ValueError("name must be 'square', got %r" % name)
         super().__init__(name)
 
-    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
-        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+    def waveform(self, n_points, xstart, xdelta, amp, onset, duration, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, duration)
         y[mask] = amp
         return y
 
@@ -174,16 +174,16 @@ class NMPulseFuncRamp(NMPulseFunc):
         super().__init__(name)
         self._direction: str = name[-1]
 
-    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
-        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+    def waveform(self, n_points, xstart, xdelta, amp, onset, duration, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, duration)
         if not np.any(mask):
             return y
-        if math.isinf(width):
+        if math.isinf(duration):
             ew = xstart + (n_points - 1) * xdelta - onset
             if ew <= 0:
                 return y
         else:
-            ew = width
+            ew = duration
         t = (x[mask] - onset) / ew
         y[mask] = amp * t if self._direction == "+" else amp * (1.0 - t)
         return y
@@ -218,8 +218,8 @@ class NMPulseFuncExp(NMPulseFunc):
     def to_dict(self) -> dict:
         return {"pulse": self._name, "tau": self._tau}
 
-    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
-        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+    def waveform(self, n_points, xstart, xdelta, amp, onset, duration, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, duration)
         y[mask] = amp * np.exp(-(x[mask] - onset) / self._tau)
         return y
 
@@ -253,8 +253,8 @@ class NMPulseFuncAlpha(NMPulseFunc):
     def to_dict(self) -> dict:
         return {"pulse": self._name, "tau": self._tau}
 
-    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
-        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+    def waveform(self, n_points, xstart, xdelta, amp, onset, duration, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, duration)
         t = (x[mask] - onset) / self._tau
         y[mask] = amp * t * np.exp(1.0 - t)
         return y
@@ -302,8 +302,8 @@ class NMPulseFuncSin(NMPulseFunc):
     def to_dict(self) -> dict:
         return {"pulse": self._name, "freq": self._freq, "phase": self._phase}
 
-    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
-        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+    def waveform(self, n_points, xstart, xdelta, amp, onset, duration, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, duration)
         y[mask] = amp * np.sin(2.0 * math.pi * self._freq * (x[mask] - onset) + self._phase)
         return y
 
@@ -353,16 +353,16 @@ class NMPulseFuncSinZap(NMPulseFunc):
     def to_dict(self) -> dict:
         return {"pulse": self._name, "f0": self._f0, "f1": self._f1}
 
-    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
-        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+    def waveform(self, n_points, xstart, xdelta, amp, onset, duration, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, duration)
         if not np.any(mask):
             return y
-        if math.isinf(width):
+        if math.isinf(duration):
             ew = xstart + (n_points - 1) * xdelta - onset
             if ew <= 0:
                 return y
         else:
-            ew = width
+            ew = duration
         t = x[mask] - onset
         phi = 2.0 * math.pi * (self._f0 * t + (self._f1 - self._f0) / (2.0 * ew) * t ** 2)
         y[mask] = amp * np.sin(phi)
@@ -375,7 +375,7 @@ class NMPulseFuncUser(NMPulseFunc):
     The stored numpy array is treated as a template: at ``waveform()`` time it
     is normalised so its absolute peak maps to *amp*, shifted to start at
     *onset*, resampled to the target x-scale via ``np.interp``, and truncated
-    at ``onset + width``.
+    at ``onset + duration``.
 
     .. note::
         The data array is **not** included in :meth:`to_dict` output (JSON /
@@ -386,17 +386,17 @@ class NMPulseFuncUser(NMPulseFunc):
         name: Must be ``"user"``.
         data: 1-D numpy array representing the waveform template (any
             sampling rate).
-        xdelta_data: Sample interval of *data* in the same x-units as the
+        data_xdelta: Sample interval of *data* in the same x-units as the
             target waveform. Default 1.0.
     """
 
-    _VALID_KEYS: frozenset[str] = frozenset({"data", "xdelta_data"})
+    _VALID_KEYS: frozenset[str] = frozenset({"data", "data_xdelta"})
 
     def __init__(
         self,
         name: str = "user",
         data: np.ndarray | None = None,
-        xdelta_data: float = 1.0,
+        data_xdelta: float = 1.0,
     ) -> None:
         if name != "user":
             raise ValueError("name must be 'user', got %r" % name)
@@ -405,14 +405,14 @@ class NMPulseFuncUser(NMPulseFunc):
         data = np.asarray(data, dtype=float)
         if data.ndim != 1 or len(data) == 0:
             raise ValueError("data must be a non-empty 1-D array")
-        if isinstance(xdelta_data, bool) or not isinstance(xdelta_data, (int, float)):
-            raise TypeError(nmu.type_error_str(xdelta_data, "xdelta_data", "float"))
-        xdelta_data = float(xdelta_data)
-        if xdelta_data <= 0:
-            raise ValueError("xdelta_data must be > 0, got %s" % xdelta_data)
+        if isinstance(data_xdelta, bool) or not isinstance(data_xdelta, (int, float)):
+            raise TypeError(nmu.type_error_str(data_xdelta, "data_xdelta", "float"))
+        data_xdelta = float(data_xdelta)
+        if data_xdelta <= 0:
+            raise ValueError("data_xdelta must be > 0, got %s" % data_xdelta)
         super().__init__(name)
         self._data: np.ndarray = data
-        self._xdelta_data: float = xdelta_data
+        self._data_xdelta: float = data_xdelta
 
     @property
     def data(self) -> np.ndarray:
@@ -420,19 +420,19 @@ class NMPulseFuncUser(NMPulseFunc):
         return self._data
 
     @property
-    def xdelta_data(self) -> float:
+    def data_xdelta(self) -> float:
         """Sample interval of the template array."""
-        return self._xdelta_data
+        return self._data_xdelta
 
     def to_dict(self) -> dict:
         return {
             "pulse": self._name,
-            "xdelta_data": self._xdelta_data,
+            "data_xdelta": self._data_xdelta,
             "n_data": len(self._data),
         }
 
-    def waveform(self, n_points, xstart, xdelta, amp, onset, width, **_):
-        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, width)
+    def waveform(self, n_points, xstart, xdelta, amp, onset, duration, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, duration)
         if not np.any(mask):
             return y
 
@@ -441,7 +441,7 @@ class NMPulseFuncUser(NMPulseFunc):
             return y
         data_norm = self._data / peak
 
-        x_src = np.arange(len(self._data)) * self._xdelta_data
+        x_src = np.arange(len(self._data)) * self._data_xdelta
         x_tgt = x[mask] - onset
         y_interp = np.interp(x_tgt, x_src, data_norm, left=0.0, right=0.0)
         y[mask] = amp * y_interp

--- a/pyneuromatic/analysis/nm_tool_pulse.py
+++ b/pyneuromatic/analysis/nm_tool_pulse.py
@@ -73,7 +73,7 @@ class NMToolPulse(NMTool):
     Examples::
 
         t = NMToolPulse()
-        t.pulses.new({"pulse": "square", "amp": 1, "onset": 5, "width": 10})
+        t.pulses.new({"pulse": "square", "amp": 1, "onset": 5, "duration": 10})
         t.pulses.new({"pulse": "exp", "amp": 0.5, "onset": 5, "tau": 20})
         # drive directly (no NMManager)
         t.run_all([{}])
@@ -87,15 +87,16 @@ class NMToolPulse(NMTool):
         self.__xstart:   float = self._config.xstart
         self.__xdelta:   float = self._config.xdelta
         self.__prefix:   str   = self._config.prefix
-        self.__chan:  str   = self._config.chan
+        self.__chan:     str   = self._config.chan
         self._overwrite        = self._config.overwrite
         self._results_to_numpy = True
 
         self.__pulses: NMPulseContainer = NMPulseContainer(
             nm_path=self._name + ".pulses"
         )
-        self._waveforms:   list[np.ndarray] = []
-        self._epoch_names: list[str]        = []
+        self._waveforms:   list[np.ndarray]   = []
+        self._epoch_names: list[str]          = []
+        self._pulse_times: list[list[float]]  = []
 
     # ------------------------------------------------------------------
     # Properties
@@ -204,6 +205,7 @@ class NMToolPulse(NMTool):
             raise ValueError("prefix must be non-empty")
         self._waveforms = []
         self._epoch_names = []
+        self._pulse_times = []
         return True
 
     def run(self) -> bool:
@@ -220,14 +222,17 @@ class NMToolPulse(NMTool):
         epoch_name = self.data.name if self.data else "wave_%d" % epoch_idx
 
         y = np.zeros(self.__n_points, dtype=float)
+        epoch_times: list[float] = []
         for p in self.__pulses:
-            if p.targets_epoch(epoch_idx):
+            if p.enabled and p.targets_epoch(epoch_idx):
                 y += p.waveform(
                     self.__n_points, self.__xstart, self.__xdelta, epoch_idx
                 )
+                epoch_times.extend(getattr(p, "_last_onset_times", []))
 
         self._waveforms.append(y)
         self._epoch_names.append(epoch_name)
+        self._pulse_times.append(sorted(epoch_times))
         return True
 
     def run_finish(self) -> bool:
@@ -252,11 +257,22 @@ class NMToolPulse(NMTool):
             parts = [d["pulse"]]
             parts.append("amp=%g" % p.amp)
             parts.append("onset=%g" % p.onset)
-            if not math.isinf(p.width):
-                parts.append("width=%g" % p.width)
+            if not math.isinf(p.duration):
+                parts.append("duration=%g" % p.duration)
             for key in ("tau", "freq", "phase", "f0", "f1"):
                 if key in d:
                     parts.append("%s=%g" % (key, d[key]))
+            if p.n_pulses != 1 or not math.isinf(p.train_duration):
+                parts.append("n_pulses=%d" % p.n_pulses)
+                parts.append("interval=%g" % p.interval)
+                if not math.isinf(p.train_duration):
+                    parts.append("train_duration=%g" % p.train_duration)
+                if p.interval_type != "fixed":
+                    parts.append("interval_type=%r" % p.interval_type)
+                if p.interval_stdv > 0:
+                    parts.append("interval_stdv=%g" % p.interval_stdv)
+                if p.seed is not None:
+                    parts.append("seed=%d" % p.seed)
             if p.epoch != 0 or p.epoch_delta != 0:
                 parts.append("epoch=%d" % p.epoch)
                 parts.append("epoch_delta=%d" % p.epoch_delta)
@@ -314,4 +330,17 @@ class NMToolPulse(NMTool):
             nparray=np.array(self._epoch_names, dtype=object),
         )
 
+        self._write_times_to_toolfolder(note)
         return f
+
+    def _write_times_to_toolfolder(self, note: str) -> None:
+        """Write per-epoch onset times to a ``Pulse`` toolfolder with ``PGT_`` prefix."""
+        tf = self._make_toolfolder("Pulse", overwrite=self._overwrite)
+        times_stem = "PGT_" + self.__chan
+        for idx, times in enumerate(self._pulse_times):
+            name = times_stem + str(idx)
+            d = tf.data.new(
+                name,
+                nparray=np.array(times, dtype=float),
+            )
+            self._add_note(d, note)

--- a/pyneuromatic/core/nm_folder.py
+++ b/pyneuromatic/core/nm_folder.py
@@ -525,7 +525,7 @@ class NMFolder(NMObject):
             folder.new_dataseries("Record", n_channels=2, n_epochs=3, ep_start=5)
 
         Args:
-            prefix: Wave prefix (e.g. ``"Record"``). Must satisfy
+            prefix: Data array name prefix (e.g. ``"Record"``). Must satisfy
                 ``nmu.name_ok()``.
             n_channels: Number of channels to generate.
             n_epochs: Number of epochs to generate.

--- a/tests/test_analysis/test_nm_pulse_func.py
+++ b/tests/test_analysis/test_nm_pulse_func.py
@@ -23,8 +23,8 @@ from pyneuromatic.analysis.nm_pulse_func import (
 # helpers
 # ---------------------------------------------------------------------------
 
-def _wave(func, n=100, xstart=0.0, xdelta=1.0, amp=1.0, onset=0.0, width=math.inf):
-    return func.waveform(n, xstart, xdelta, amp, onset, width)
+def _wave(func, n=100, xstart=0.0, xdelta=1.0, amp=1.0, onset=0.0, duration=math.inf):
+    return func.waveform(n, xstart, xdelta, amp, onset, duration)
 
 
 # ---------------------------------------------------------------------------
@@ -43,16 +43,16 @@ class TestNMPulseFuncSquare(unittest.TestCase):
         self.assertEqual(self.f.to_dict(), {"pulse": "square"})
 
     def test_waveform_inside_window(self):
-        y = _wave(self.f, amp=2.0, onset=10.0, width=5.0)
+        y = _wave(self.f, amp=2.0, onset=10.0, duration=5.0)
         self.assertAlmostEqual(y[10], 2.0)
         self.assertAlmostEqual(y[14], 2.0)
 
     def test_waveform_outside_window(self):
-        y = _wave(self.f, amp=2.0, onset=10.0, width=5.0)
+        y = _wave(self.f, amp=2.0, onset=10.0, duration=5.0)
         self.assertAlmostEqual(y[9], 0.0)
         self.assertAlmostEqual(y[15], 0.0)
 
-    def test_inf_width_step(self):
+    def test_inf_duration_step(self):
         y = _wave(self.f, amp=1.0, onset=10.0)
         self.assertAlmostEqual(y[9], 0.0)
         self.assertAlmostEqual(y[10], 1.0)
@@ -78,19 +78,19 @@ class TestNMPulseFuncRamp(unittest.TestCase):
 
     def test_ramp_plus_rises(self):
         f = NMPulseFuncRamp("ramp+")
-        y = _wave(f, n=11, amp=1.0, onset=0.0, width=10.0)
+        y = _wave(f, n=11, amp=1.0, onset=0.0, duration=10.0)
         self.assertAlmostEqual(y[0], 0.0, places=5)
         self.assertAlmostEqual(y[9], 0.9, places=5)
         self.assertAlmostEqual(y[10], 0.0)
 
     def test_ramp_minus_falls(self):
         f = NMPulseFuncRamp("ramp-")
-        y = _wave(f, n=11, amp=1.0, onset=0.0, width=10.0)
+        y = _wave(f, n=11, amp=1.0, onset=0.0, duration=10.0)
         self.assertAlmostEqual(y[0], 1.0, places=5)
         self.assertAlmostEqual(y[9], 0.1, places=5)
         self.assertAlmostEqual(y[10], 0.0)
 
-    def test_inf_width_reaches_amp_at_end(self):
+    def test_inf_duration_reaches_amp_at_end(self):
         f = NMPulseFuncRamp("ramp+")
         y = _wave(f, n=11, xdelta=1.0, amp=1.0, onset=0.0)
         self.assertAlmostEqual(y[0], 0.0, places=5)
@@ -194,8 +194,8 @@ class TestNMPulseFuncSin(unittest.TestCase):
         y = _wave(self.f, amp=1.0, onset=10.0)
         self.assertAlmostEqual(y[9], 0.0)
 
-    def test_truncated_by_width(self):
-        y = _wave(self.f, amp=1.0, onset=0.0, width=5.0)
+    def test_truncated_by_duration(self):
+        y = _wave(self.f, amp=1.0, onset=0.0, duration=5.0)
         self.assertAlmostEqual(y[5], 0.0)
 
     def test_to_dict(self):
@@ -272,10 +272,10 @@ class TestNMPulseFuncSinZap(unittest.TestCase):
 class TestNMPulseFuncUser(unittest.TestCase):
 
     def setUp(self):
-        # one full sine cycle, 50 samples, xdelta_data=1.0
+        # one full sine cycle, 50 samples, data_xdelta=1.0
         t = np.linspace(0, 2 * math.pi, 50, endpoint=False)
         self.raw = np.sin(t)
-        self.f = NMPulseFuncUser(data=self.raw, xdelta_data=1.0)
+        self.f = NMPulseFuncUser(data=self.raw, data_xdelta=1.0)
 
     def test_name(self):
         self.assertEqual(self.f.name, "user")
@@ -289,8 +289,8 @@ class TestNMPulseFuncUser(unittest.TestCase):
         for i in range(20):
             self.assertAlmostEqual(y[i], 0.0)
 
-    def test_truncated_by_width(self):
-        y = _wave(self.f, n=200, xdelta=1.0, amp=1.0, onset=0.0, width=10.0)
+    def test_truncated_by_duration(self):
+        y = _wave(self.f, n=200, xdelta=1.0, amp=1.0, onset=0.0, duration=10.0)
         self.assertAlmostEqual(y[10], 0.0)
         self.assertAlmostEqual(y[50], 0.0)
 
@@ -302,7 +302,7 @@ class TestNMPulseFuncUser(unittest.TestCase):
     def test_to_dict_no_data(self):
         d = self.f.to_dict()
         self.assertEqual(d["pulse"], "user")
-        self.assertAlmostEqual(d["xdelta_data"], 1.0)
+        self.assertAlmostEqual(d["data_xdelta"], 1.0)
         self.assertEqual(d["n_data"], 50)
         self.assertNotIn("data", d)
 
@@ -315,9 +315,9 @@ class TestNMPulseFuncUser(unittest.TestCase):
         y = _wave(f, n=50, amp=2.0, onset=0.0)
         np.testing.assert_array_equal(y, 0.0)
 
-    def test_bad_xdelta_data(self):
+    def test_bad_data_xdelta(self):
         with self.assertRaises(ValueError):
-            NMPulseFuncUser(data=self.raw, xdelta_data=0.0)
+            NMPulseFuncUser(data=self.raw, data_xdelta=0.0)
 
     def test_factory_requires_data(self):
         with self.assertRaises(KeyError):

--- a/tests/test_analysis/test_nm_tool_pulse.py
+++ b/tests/test_analysis/test_nm_tool_pulse.py
@@ -59,6 +59,9 @@ class TestNMPulseDefaults(unittest.TestCase):
     def test_name(self):
         self.assertEqual(self.p.name, "NMPulse0")
 
+    def test_enabled(self):
+        self.assertTrue(self.p.enabled)
+
     def test_pulse(self):
         self.assertEqual(self.p.pulse, "square")
 
@@ -74,8 +77,8 @@ class TestNMPulseDefaults(unittest.TestCase):
     def test_onset(self):
         self.assertEqual(self.p.onset, 10.0)
 
-    def test_width(self):
-        self.assertTrue(math.isinf(self.p.width))
+    def test_duration(self):
+        self.assertTrue(math.isinf(self.p.duration))
 
     def test_amp_delta(self):
         self.assertEqual(self.p.amp_delta, 0.0)
@@ -83,8 +86,8 @@ class TestNMPulseDefaults(unittest.TestCase):
     def test_onset_delta(self):
         self.assertEqual(self.p.onset_delta, 0.0)
 
-    def test_width_delta(self):
-        self.assertEqual(self.p.width_delta, 0.0)
+    def test_duration_delta(self):
+        self.assertEqual(self.p.duration_delta, 0.0)
 
     def test_amp_stdv(self):
         self.assertEqual(self.p.amp_stdv, 0.0)
@@ -92,8 +95,8 @@ class TestNMPulseDefaults(unittest.TestCase):
     def test_onset_stdv(self):
         self.assertEqual(self.p.onset_stdv, 0.0)
 
-    def test_width_stdv(self):
-        self.assertEqual(self.p.width_stdv, 0.0)
+    def test_duration_stdv(self):
+        self.assertEqual(self.p.duration_stdv, 0.0)
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +166,16 @@ class TestNMPulseProperties(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.p.onset = "10"
 
+    def test_enabled_toggle(self):
+        self.p.enabled = False
+        self.assertFalse(self.p.enabled)
+        self.p.enabled = True
+        self.assertTrue(self.p.enabled)
+
+    def test_enabled_non_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.p.enabled = 1
+
 
 # ---------------------------------------------------------------------------
 # NMPulse — config dict
@@ -179,7 +192,7 @@ class TestNMPulseConfigSet(unittest.TestCase):
 
     def test_to_dict_round_trip(self):
         p = NMPulse(config={"pulse": "ramp+", "epoch": 3, "epoch_delta": 2,
-                             "amp": 4.0, "onset": 1.0, "width": 5.0,
+                             "amp": 4.0, "onset": 1.0, "duration": 5.0,
                              "onset_delta": 0.5})
         d = p.to_dict()
         p2 = NMPulse.from_dict(d)
@@ -253,19 +266,19 @@ class TestNMPulseEpochTargeting(unittest.TestCase):
 
 class TestNMPulseWaveformSquare(unittest.TestCase):
 
-    def test_amp_and_width_route_from_config(self):
-        p = NMPulse(config={"pulse": "square", "amp": 2.0, "onset": 10.0, "width": 5.0})
+    def test_amp_and_duration_route_from_config(self):
+        p = NMPulse(config={"pulse": "square", "amp": 2.0, "onset": 10.0, "duration": 5.0})
         y = p.waveform(100, 0.0, 1.0, 0)
         self.assertAlmostEqual(y[10], 2.0)   # amp applied
         self.assertAlmostEqual(y[14], 2.0)   # inside window
-        self.assertAlmostEqual(y[15], 0.0)   # width truncates
+        self.assertAlmostEqual(y[15], 0.0)   # duration truncates
 
 
 class TestNMPulseWaveformRamp(unittest.TestCase):
 
     def test_direction_routes_from_config(self):
-        p_plus  = NMPulse(config={"pulse": "ramp+", "amp": 1.0, "onset": 0.0, "width": 10.0})
-        p_minus = NMPulse(config={"pulse": "ramp-", "amp": 1.0, "onset": 0.0, "width": 10.0})
+        p_plus  = NMPulse(config={"pulse": "ramp+", "amp": 1.0, "onset": 0.0, "duration": 10.0})
+        p_minus = NMPulse(config={"pulse": "ramp-", "amp": 1.0, "onset": 0.0, "duration": 10.0})
         y_plus  = p_plus.waveform(20, 0.0, 1.0, 0)
         y_minus = p_minus.waveform(20, 0.0, 1.0, 0)
         self.assertAlmostEqual(y_plus[0],  0.0, places=5)   # ramp+ starts at 0
@@ -280,8 +293,8 @@ class TestNMPulseWaveformExp(unittest.TestCase):
         self.assertAlmostEqual(y[0], 3.0)             # amp at onset
         self.assertAlmostEqual(y[10], 3.0 * math.exp(-1.0), places=5)  # tau decay
 
-    def test_width_truncates(self):
-        p = NMPulse(config={"pulse": "exp", "amp": 1.0, "onset": 0.0, "tau": 10.0, "width": 20.0})
+    def test_duration_truncates(self):
+        p = NMPulse(config={"pulse": "exp", "amp": 1.0, "onset": 0.0, "tau": 10.0, "duration": 20.0})
         y = p.waveform(50, 0.0, 1.0, 0)
         self.assertGreater(y[19], 0.0)
         self.assertAlmostEqual(y[20], 0.0)
@@ -294,8 +307,8 @@ class TestNMPulseWaveformAlpha(unittest.TestCase):
         y = p.waveform(100, 0.0, 1.0, 0)
         self.assertAlmostEqual(int(np.argmax(y)), 10, delta=1)  # peak at onset + tau
 
-    def test_width_truncates(self):
-        p = NMPulse(config={"pulse": "alpha", "amp": 1.0, "onset": 0.0, "tau": 10.0, "width": 15.0})
+    def test_duration_truncates(self):
+        p = NMPulse(config={"pulse": "alpha", "amp": 1.0, "onset": 0.0, "tau": 10.0, "duration": 15.0})
         y = p.waveform(50, 0.0, 1.0, 0)
         self.assertGreater(y[14], 0.0)
         self.assertAlmostEqual(y[15], 0.0)
@@ -309,7 +322,7 @@ class TestNMPulseDelta(unittest.TestCase):
 
     def test_delta_onset_shifts_per_occurrence(self):
         p = NMPulse(config={
-            "pulse": "square", "amp": 1.0, "onset": 10.0, "width": 5.0,
+            "pulse": "square", "amp": 1.0, "onset": 10.0, "duration": 5.0,
             "onset_delta": 10.0, "epoch_delta": 1,
         })
         # Occurrence 0: onset=10, occurrence 1: onset=20, occurrence 2: onset=30
@@ -324,7 +337,7 @@ class TestNMPulseDelta(unittest.TestCase):
         self.assertAlmostEqual(y0[9],  0.0)
         self.assertAlmostEqual(y1[19], 0.0)
         self.assertAlmostEqual(y2[29], 0.0)
-        # zero after onset + width
+        # zero after onset + duration
         self.assertAlmostEqual(y0[15], 0.0)
         self.assertAlmostEqual(y1[25], 0.0)
         self.assertAlmostEqual(y2[35], 0.0)
@@ -333,7 +346,7 @@ class TestNMPulseDelta(unittest.TestCase):
         # epoch=0, epoch_delta=2 → fires at 0,2,4,...
         # occurrence 0 at epoch_idx=0, occurrence 1 at epoch_idx=2
         p = NMPulse(config={
-            "pulse": "square", "amp": 1.0, "onset": 10.0, "width": 5.0,
+            "pulse": "square", "amp": 1.0, "onset": 10.0, "duration": 5.0,
             "onset_delta": 5.0, "epoch_delta": 2,
         })
         # epoch_idx=0 → occurrence 0 → onset=10
@@ -400,7 +413,7 @@ class TestNMPulseContainerRoundTrip(unittest.TestCase):
 
     def test_to_dict_from_dict(self):
         c = NMPulseContainer()
-        c.new({"pulse": "square", "amp": 2.0, "onset": 5.0, "width": 3.0})
+        c.new({"pulse": "square", "amp": 2.0, "onset": 5.0, "duration": 3.0})
         c.new({"pulse": "exp", "onset": 10.0, "tau": 8.0, "epoch": 1})
         d = c.to_dict()
         c2 = NMPulseContainer.from_dict(d)
@@ -530,7 +543,7 @@ class TestNMToolPulseOutput(unittest.TestCase):
         self.t.n_points = 100
         self.t.xstart = 0.0
         self.t.xdelta = 1.0
-        self.t.pulses.new({"pulse": "square", "amp": 2.0, "onset": 10.0, "width": 5.0})
+        self.t.pulses.new({"pulse": "square", "amp": 2.0, "onset": 10.0, "duration": 5.0})
 
     def test_output_inside_window(self):
         folder = _run_tool(self.t, [_make_empty_data("w0")])
@@ -561,8 +574,8 @@ class TestNMToolPulseMultiPulse(unittest.TestCase):
         t.n_points = 100
         t.xstart = 0.0
         t.xdelta = 1.0
-        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 10.0, "width": 5.0})
-        t.pulses.new({"pulse": "square", "amp": 3.0, "onset": 10.0, "width": 5.0})
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 10.0, "duration": 5.0})
+        t.pulses.new({"pulse": "square", "amp": 3.0, "onset": 10.0, "duration": 5.0})
         folder = _run_tool(t, [_make_empty_data("w0")])
         y = folder.data["PG_0"].nparray
         self.assertAlmostEqual(y[10], 4.0)
@@ -572,8 +585,8 @@ class TestNMToolPulseMultiPulse(unittest.TestCase):
         t.n_points = 100
         t.xstart = 0.0
         t.xdelta = 1.0
-        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "width": 5.0})
-        t.pulses.new({"pulse": "square", "amp": 2.0, "onset": 20.0, "width": 5.0})
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "duration": 5.0})
+        t.pulses.new({"pulse": "square", "amp": 2.0, "onset": 20.0, "duration": 5.0})
         folder = _run_tool(t, [_make_empty_data("w0")])
         y = folder.data["PG_0"].nparray
         self.assertAlmostEqual(y[5], 1.0)
@@ -593,7 +606,7 @@ class TestNMToolPulseEpochZeroOnly(unittest.TestCase):
         t.xstart = 0.0
         t.xdelta = 1.0
         # pulse only fires on epoch 0
-        t.pulses.new({"pulse": "square", "amp": 5.0, "onset": 5.0, "width": 5.0,
+        t.pulses.new({"pulse": "square", "amp": 5.0, "onset": 5.0, "duration": 5.0,
                       "epoch": 0, "epoch_delta": 100})
         data = [_make_empty_data("w%d" % i) for i in range(3)]
         folder = _run_tool(t, data)
@@ -616,7 +629,7 @@ class TestNMToolPulseOutputArrays(unittest.TestCase):
         self.t.n_points = 50
         self.t.xstart = 2.0
         self.t.xdelta = 0.5
-        self.t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "width": 2.0})
+        self.t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "duration": 2.0})
         data = [_make_empty_data("rec0")]
         self.folder = _run_tool(self.t, data)
 
@@ -645,7 +658,7 @@ class TestNMToolPulseOutputArrays(unittest.TestCase):
         t.xstart = 0.0
         t.xdelta = 1.0
         t.chan = "A"
-        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "width": 2.0})
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "duration": 2.0})
         folder = _run_tool(t, [_make_empty_data("w0"), _make_empty_data("w1")])
         self.assertIn("PG_A0", folder.data)
         self.assertIn("PG_A1", folder.data)
@@ -675,7 +688,7 @@ class TestNMToolPulsePrefix(unittest.TestCase):
         t.xdelta = 1.0
         t.prefix = prefix
         t.chan = channel
-        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "width": 2.0})
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "duration": 2.0})
         data = [_make_empty_data("d%d" % i) for i in range(n_epochs)]
         return _run_tool(t, data)
 
@@ -709,7 +722,7 @@ class TestNMToolPulseMultiEpoch(unittest.TestCase):
         t.n_points = 30
         t.xstart = 0.0
         t.xdelta = 1.0
-        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "width": 3.0})
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "duration": 3.0})
         data = [_make_empty_data("e0"), _make_empty_data("e1")]
         folder = _run_tool(t, data)
         self.assertIn("PG_0", folder.data)
@@ -723,7 +736,7 @@ class TestNMToolPulseMultiEpoch(unittest.TestCase):
         t.xstart = 0.0
         t.xdelta = 1.0
         # onset shifts by 10 per epoch
-        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 10.0, "width": 5.0,
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 10.0, "duration": 5.0,
                       "onset_delta": 10.0, "epoch_delta": 1})
         data = [_make_empty_data("e%d" % i) for i in range(3)]
         folder = _run_tool(t, data)
@@ -781,15 +794,181 @@ class TestNMToolPulseOverwrite(unittest.TestCase):
         t.xstart = 0.0
         t.xdelta = 1.0
         t.overwrite = True
-        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "width": 2.0})
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "duration": 2.0})
         folder = NMFolder(NM, name="TestFolder")
         data = [_make_empty_data("w0")]
         targets, _ = _make_targets(data, folder=folder)
         t.run_all(targets)
+        count_after_first = len(folder.data)
         t.run_all(targets)  # second run with overwrite=True
-        # arrays should be replaced, not duplicated
-        self.assertIn("PG_0", folder.data)
-        self.assertIn("PG_epoch_names", folder.data)
+        # array count must be identical — arrays replaced, not duplicated
+        self.assertEqual(len(folder.data), count_after_first)
+
+    def test_seed_reproduces_gaussian_times(self):
+        cfg = {"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 3.0,
+               "n_pulses": 8, "interval": 50.0, "interval_stdv": 10.0,
+               "interval_type": "gaussian", "seed": 99}
+        folder = NMFolder(NM, name="TestFolder")
+        data = [_make_empty_data("w0", n=500)]
+        targets, _ = _make_targets(data, folder=folder)
+        t = NMToolPulse()
+        t.n_points = 500
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.overwrite = True
+        t.pulses.new(cfg)
+        t.run_all(targets)
+        times_first = list(folder.toolfolders["Pulse_0"].data["PGT_0"].nparray)
+        t.run_all(targets)
+        times_second = list(folder.toolfolders["Pulse_0"].data["PGT_0"].nparray)
+        self.assertEqual(times_first, times_second)
+
+    def test_overwrite_true_gaussian_times_change(self):
+        t = NMToolPulse()
+        t.n_points = 500
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.overwrite = True
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 3.0,
+                      "n_pulses": 5, "interval": 50.0, "interval_stdv": 10.0,
+                      "interval_type": "gaussian"})
+        folder = NMFolder(NM, name="TestFolder")
+        data = [_make_empty_data("w0", n=500)]
+        targets, _ = _make_targets(data, folder=folder)
+        np.random.seed(1)
+        t.run_all(targets)
+        times_first = list(folder.toolfolders["Pulse_0"].data["PGT_0"].nparray)
+        np.random.seed(2)
+        t.run_all(targets)
+        times_second = list(folder.toolfolders["Pulse_0"].data["PGT_0"].nparray)
+        self.assertNotEqual(times_first, times_second)
+
+    def test_overwrite_false_raises_on_second_run(self):
+        t = NMToolPulse()
+        t.n_points = 20
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.overwrite = False
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 2.0, "duration": 2.0})
+        folder = NMFolder(NM, name="TestFolder")
+        data = [_make_empty_data("w0")]
+        targets, _ = _make_targets(data, folder=folder)
+        t.run_all(targets)
+        with self.assertRaises(KeyError):
+            t.run_all(targets)  # second run raises — name already exists
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — pulse times toolfolder
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseTimes(unittest.TestCase):
+
+    def test_times_toolfolder_created(self):
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 10.0, "duration": 5.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        self.assertIn("Pulse_0", folder.toolfolders)
+
+    def test_times_single_pulse_onset(self):
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 10.0, "duration": 5.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        times = folder.toolfolders["Pulse_0"].data["PGT_0"].nparray
+        self.assertEqual(len(times), 1)
+        self.assertAlmostEqual(times[0], 10.0)
+
+    def test_times_fixed_train(self):
+        # 3 pulses at onset=0, interval=20 → times [0, 20, 40]
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+                      "n_pulses": 3, "interval": 20.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        times = folder.toolfolders["Pulse_0"].data["PGT_0"].nparray
+        self.assertEqual(len(times), 3)
+        self.assertAlmostEqual(times[0], 0.0)
+        self.assertAlmostEqual(times[1], 20.0)
+        self.assertAlmostEqual(times[2], 40.0)
+
+    def test_times_multiple_epochs(self):
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "duration": 3.0,
+                      "epoch": "all"})
+        folder = _run_tool(t, [_make_empty_data("w0"), _make_empty_data("w1")])
+        tf = folder.toolfolders["Pulse_0"]
+        self.assertIn("PGT_0", tf.data)
+        self.assertIn("PGT_1", tf.data)
+
+    def test_times_sorted_across_pulses(self):
+        # two pulses with different onsets — times should be sorted
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 30.0, "duration": 3.0})
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 10.0, "duration": 3.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        times = folder.toolfolders["Pulse_0"].data["PGT_0"].nparray
+        self.assertEqual(list(times), sorted(times))
+
+    def test_times_channel_prefix(self):
+        t = NMToolPulse()
+        t.n_points = 50
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.chan = "A"
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "duration": 3.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        self.assertIn("PGT_A0", folder.toolfolders["Pulse_0"].data)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — enabled flag
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseEnabled(unittest.TestCase):
+
+    def test_disabled_pulse_produces_zeros(self):
+        t = NMToolPulse()
+        t.n_points = 50
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 2.0, "onset": 10.0, "duration": 5.0,
+                      "enabled": False})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        np.testing.assert_array_equal(y, 0.0)
+
+    def test_disabled_pulse_skipped_other_active(self):
+        t = NMToolPulse()
+        t.n_points = 50
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 5.0, "duration": 5.0})
+        t.pulses.new({"pulse": "square", "amp": 3.0, "onset": 5.0, "duration": 5.0,
+                      "enabled": False})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertAlmostEqual(y[5], 1.0)   # only first pulse contributes
+
+    def test_round_trip_enabled_false(self):
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 5.0,
+                             "enabled": False})
+        self.assertFalse(p.enabled)
+        p2 = NMPulse.from_dict(p.to_dict())
+        self.assertFalse(p2.enabled)
 
 
 # ---------------------------------------------------------------------------
@@ -804,9 +983,9 @@ class TestNMPulseWaveformSin(unittest.TestCase):
         y = p.waveform(20, 0.0, 1.0, 0)
         self.assertAlmostEqual(y[0], 1.0, places=5)   # phase=π/2 → cos(0)=1
 
-    def test_width_truncates(self):
+    def test_duration_truncates(self):
         p = NMPulse(config={"pulse": "sin", "freq": 0.25,
-                             "amp": 1.0, "onset": 5.0, "width": 4.0})
+                             "amp": 1.0, "onset": 5.0, "duration": 4.0})
         y = p.waveform(30, 0.0, 1.0, 0)
         self.assertAlmostEqual(y[9], 0.0)
 
@@ -829,9 +1008,9 @@ class TestNMPulseWaveformSin(unittest.TestCase):
 
 class TestNMPulseWaveformSinZap(unittest.TestCase):
 
-    def test_truncated_by_width(self):
+    def test_truncated_by_duration(self):
         p = NMPulse(config={"pulse": "sinzap", "f0": 0.05, "f1": 0.2,
-                             "amp": 1.0, "onset": 0.0, "width": 50.0})
+                             "amp": 1.0, "onset": 0.0, "duration": 50.0})
         y = p.waveform(100, 0.0, 1.0, 0)
         self.assertAlmostEqual(y[50], 0.0)
 
@@ -852,10 +1031,10 @@ _USER_RAW = np.sin(np.linspace(0, 2 * math.pi, 50))
 
 class TestNMPulseWaveformUser(unittest.TestCase):
 
-    def _make_user_pulse(self, onset=0.0, amp=1.0, width=math.inf):
+    def _make_user_pulse(self, onset=0.0, amp=1.0, duration=math.inf):
         return NMPulse(config={"pulse": "user", "amp": amp, "onset": onset,
-                                "width": width, "data": _USER_RAW,
-                                "xdelta_data": 1.0})
+                                "duration": duration, "data": _USER_RAW,
+                                "data_xdelta": 1.0})
 
     def test_onset_shifts_waveform(self):
         p0 = self._make_user_pulse(onset=0.0, amp=1.0)
@@ -931,13 +1110,13 @@ class TestNMToolPulseSinZap(unittest.TestCase):
         y = folder.data["PG_0"].nparray
         self.assertEqual(len(y), 200)
 
-    def test_truncated_by_width(self):
+    def test_truncated_by_duration(self):
         t = NMToolPulse()
         t.n_points = 200
         t.xstart = 0.0
         t.xdelta = 1.0
         t.pulses.new({"pulse": "sinzap", "f0": 0.05, "f1": 0.2,
-                      "amp": 1.0, "onset": 0.0, "width": 50.0})
+                      "amp": 1.0, "onset": 0.0, "duration": 50.0})
         folder = _run_tool(t, [_make_empty_data("w0", n=200)])
         y = folder.data["PG_0"].nparray
         self.assertAlmostEqual(y[50], 0.0)
@@ -945,13 +1124,13 @@ class TestNMToolPulseSinZap(unittest.TestCase):
 
 class TestNMToolPulseUser(unittest.TestCase):
 
-    def _make_tool(self, onset=0.0, amp=1.0, width=math.inf, n=100):
+    def _make_tool(self, onset=0.0, amp=1.0, duration=math.inf, n=100):
         t = NMToolPulse()
         t.n_points = n
         t.xstart = 0.0
         t.xdelta = 1.0
         t.pulses.new({"pulse": "user", "amp": amp, "onset": onset,
-                      "width": width, "data": _USER_RAW, "xdelta_data": 1.0})
+                      "duration": duration, "data": _USER_RAW, "data_xdelta": 1.0})
         return t
 
     def test_peak_equals_amp(self):
@@ -966,8 +1145,8 @@ class TestNMToolPulseUser(unittest.TestCase):
         y = folder.data["PG_0"].nparray
         self.assertAlmostEqual(y[19], 0.0)
 
-    def test_truncation_by_width(self):
-        t = self._make_tool(onset=0.0, width=20.0)
+    def test_truncation_by_duration(self):
+        t = self._make_tool(onset=0.0, duration=20.0)
         folder = _run_tool(t, [_make_empty_data("w0")])
         y = folder.data["PG_0"].nparray
         self.assertAlmostEqual(y[20], 0.0)
@@ -977,6 +1156,346 @@ class TestNMToolPulseUser(unittest.TestCase):
         folder = _run_tool(t, [_make_empty_data("w0")])
         y = folder.data["PG_0"].nparray
         self.assertEqual(len(y), 100)
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — train defaults and properties
+# ---------------------------------------------------------------------------
+
+class TestNMPulseTrainDefaults(unittest.TestCase):
+
+    def setUp(self):
+        self.p = NMPulse()
+
+    def test_n_pulses(self):
+        self.assertEqual(self.p.n_pulses, 1)
+
+    def test_interval(self):
+        self.assertAlmostEqual(self.p.interval, 100.0)
+
+    def test_interval_stdv(self):
+        self.assertAlmostEqual(self.p.interval_stdv, 0.0)
+
+    def test_interval_type(self):
+        self.assertEqual(self.p.interval_type, "fixed")
+
+    def test_train_duration(self):
+        self.assertTrue(math.isinf(self.p.train_duration))
+
+
+class TestNMPulseTrainProperties(unittest.TestCase):
+
+    def setUp(self):
+        self.p = NMPulse()
+
+    def test_n_pulses_valid(self):
+        self.p.n_pulses = 5
+        self.assertEqual(self.p.n_pulses, 5)
+
+    def test_n_pulses_zero_allowed(self):
+        self.p.n_pulses = 0
+        self.assertEqual(self.p.n_pulses, 0)
+
+    def test_n_pulses_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.n_pulses = -1
+
+    def test_n_pulses_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.p.n_pulses = True
+
+    def test_interval_valid(self):
+        self.p.interval = 50.0
+        self.assertAlmostEqual(self.p.interval, 50.0)
+
+    def test_interval_zero_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.interval = 0.0
+
+    def test_interval_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.interval = -10.0
+
+    def test_interval_stdv_valid(self):
+        self.p.interval_stdv = 5.0
+        self.assertAlmostEqual(self.p.interval_stdv, 5.0)
+
+    def test_interval_stdv_zero_allowed(self):
+        self.p.interval_stdv = 0.0
+        self.assertAlmostEqual(self.p.interval_stdv, 0.0)
+
+    def test_interval_stdv_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.interval_stdv = -1.0
+
+    def test_interval_type_valid(self):
+        for t in ("fixed", "gaussian", "poisson"):
+            self.p.interval_type = t
+            self.assertEqual(self.p.interval_type, t)
+
+    def test_interval_type_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.interval_type = "random"
+
+    def test_interval_type_bool_raises(self):
+        with self.assertRaises(TypeError):
+            self.p.interval_type = True
+
+    def test_interval_min_valid(self):
+        self.p.interval_min = 5.0
+        self.assertAlmostEqual(self.p.interval_min, 5.0)
+
+    def test_interval_min_zero_allowed(self):
+        self.p.interval_min = 0.0
+        self.assertAlmostEqual(self.p.interval_min, 0.0)
+
+    def test_interval_min_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.interval_min = -1.0
+
+    def test_interval_max_valid(self):
+        self.p.interval_max = 200.0
+        self.assertAlmostEqual(self.p.interval_max, 200.0)
+
+    def test_interval_max_zero_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.interval_max = 0.0
+
+    def test_train_duration_valid(self):
+        self.p.train_duration = 500.0
+        self.assertAlmostEqual(self.p.train_duration, 500.0)
+
+    def test_train_duration_zero_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.train_duration = 0.0
+
+    def test_train_duration_negative_raises(self):
+        with self.assertRaises(ValueError):
+            self.p.train_duration = -1.0
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — train waveform
+# ---------------------------------------------------------------------------
+
+class TestNMPulseTrainWaveform(unittest.TestCase):
+
+    def test_single_pulse_n_pulses_one(self):
+        # n_pulses=1 (default) produces same result as without train params
+        p1 = NMPulse(config={"pulse": "square", "amp": 2.0, "onset": 10.0, "duration": 5.0})
+        p2 = NMPulse(config={"pulse": "square", "amp": 2.0, "onset": 10.0, "duration": 5.0,
+                              "n_pulses": 1, "interval": 100.0})
+        y1 = p1.waveform(50, 0.0, 1.0, 0)
+        y2 = p2.waveform(50, 0.0, 1.0, 0)
+        np.testing.assert_array_almost_equal(y1, y2)
+
+    def test_fixed_train_pulse_positions(self):
+        # 3 pulses: onset=0, interval=20 → pulses at 0, 20, 40
+        p = NMPulse(config={
+            "pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+            "n_pulses": 3, "interval": 20.0,
+        })
+        y = p.waveform(100, 0.0, 1.0, 0)
+        for start in (0, 20, 40):
+            self.assertAlmostEqual(y[start], 1.0)
+            self.assertAlmostEqual(y[start + 4], 1.0)
+            self.assertAlmostEqual(y[start + 5], 0.0)
+
+    def test_pulses_sum_when_overlapping(self):
+        p = NMPulse(config={
+            "pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 15.0,
+            "n_pulses": 2, "interval": 10.0,
+        })
+        y = p.waveform(50, 0.0, 1.0, 0)
+        self.assertAlmostEqual(y[10], 2.0)
+
+    def test_output_length(self):
+        p = NMPulse(config={
+            "pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 3.0,
+            "n_pulses": 4, "interval": 10.0,
+        })
+        y = p.waveform(80, 0.0, 1.0, 0)
+        self.assertEqual(len(y), 80)
+
+    def test_gaussian_interval_differs_from_fixed(self):
+        cfg = {"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+               "n_pulses": 5, "interval": 20.0}
+        np.random.seed(42)
+        p1 = NMPulse(config={**cfg, "interval_type": "fixed"})
+        p2 = NMPulse(config={**cfg, "interval_type": "gaussian", "interval_stdv": 5.0})
+        y_fixed    = p1.waveform(200, 0.0, 1.0, 0)
+        y_gaussian = p2.waveform(200, 0.0, 1.0, 0)
+        self.assertFalse(np.array_equal(y_fixed, y_gaussian))
+
+    def test_interval_min_enforced(self):
+        # interval_min=15 on a gaussian train with mean=10, large stdv
+        # all intervals should be >= 15
+        np.random.seed(42)
+        p = NMPulse(config={
+            "pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 3.0,
+            "n_pulses": 10, "interval": 10.0, "interval_stdv": 8.0,
+            "interval_type": "gaussian", "interval_min": 15.0,
+        })
+        p.waveform(200, 0.0, 1.0, 0)
+        times = p._last_onset_times
+        for i in range(1, len(times)):
+            self.assertGreaterEqual(times[i] - times[i - 1], 15.0)
+
+    def test_interval_max_enforced(self):
+        # interval_max=25 on a poisson train with mean=100 (very long gaps)
+        # all intervals should be <= 25
+        np.random.seed(42)
+        p = NMPulse(config={
+            "pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 3.0,
+            "n_pulses": 5, "interval": 100.0,
+            "interval_type": "poisson", "interval_max": 25.0,
+        })
+        p.waveform(200, 0.0, 1.0, 0)
+        times = p._last_onset_times
+        for i in range(1, len(times)):
+            self.assertLessEqual(times[i] - times[i - 1], 25.0)
+
+    def test_train_duration_limits_pulses(self):
+        # interval=20, train_duration=50 → pulses at 0, 20, 40; onset=60 excluded
+        p = NMPulse(config={
+            "pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+            "n_pulses": 0, "interval": 20.0, "train_duration": 50.0,
+        })
+        y = p.waveform(100, 0.0, 1.0, 0)
+        for start in (0, 20, 40):
+            self.assertAlmostEqual(y[start], 1.0)
+        self.assertAlmostEqual(y[60], 0.0)   # pulse at onset=60 excluded
+        self.assertAlmostEqual(y[80], 0.0)   # pulse at onset=80 excluded
+
+    def test_n_pulses_and_train_duration_both_cap(self):
+        # n_pulses=2 wins over train_duration=100 (only 2 pulses generated)
+        p = NMPulse(config={
+            "pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+            "n_pulses": 2, "interval": 20.0, "train_duration": 100.0,
+        })
+        y = p.waveform(150, 0.0, 1.0, 0)
+        self.assertAlmostEqual(y[0],  1.0)
+        self.assertAlmostEqual(y[20], 1.0)
+        self.assertAlmostEqual(y[40], 0.0)   # third pulse not generated
+        self.assertAlmostEqual(y[60], 0.0)   # fourth pulse not generated
+        self.assertAlmostEqual(y[80], 0.0)   # fifth pulse not generated
+
+    def test_to_dict_round_trip(self):
+        p = NMPulse(config={
+            "pulse": "exp", "tau": 5.0, "amp": 2.0, "onset": 10.0,
+            "n_pulses": 0, "interval": 30.0, "train_duration": 200.0,
+            "interval_type": "gaussian", "interval_stdv": 1.0,
+        })
+        d = p.to_dict()
+        self.assertEqual(d["n_pulses"], 0)
+        self.assertAlmostEqual(d["train_duration"], 200.0)
+        self.assertEqual(d["interval_type"], "gaussian")
+        p2 = NMPulse.from_dict(d)
+        self.assertEqual(p, p2)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — Poisson train via PGT_ times
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulsePoisson(unittest.TestCase):
+
+    def _run_poisson(self, n_pulses, mean_interval, seed=0):
+        np.random.seed(seed)
+        t = NMToolPulse()
+        t.n_points = 5000
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 3.0,
+                      "n_pulses": n_pulses, "interval": mean_interval,
+                      "interval_type": "poisson"})
+        folder = _run_tool(t, [_make_empty_data("w0", n=5000)])
+        return folder.toolfolders["Pulse_0"].data["PGT_0"].nparray
+
+    def test_correct_number_of_pulses(self):
+        times = self._run_poisson(n_pulses=10, mean_interval=50.0)
+        self.assertEqual(len(times), 10)
+
+    def test_all_intervals_positive(self):
+        times = self._run_poisson(n_pulses=20, mean_interval=50.0)
+        for i in range(1, len(times)):
+            self.assertGreater(times[i] - times[i - 1], 0.0)
+
+    def test_intervals_differ_from_fixed(self):
+        # Poisson intervals should not all equal the mean interval
+        np.random.seed(42)
+        times = self._run_poisson(n_pulses=10, mean_interval=50.0, seed=42)
+        intervals = [times[i] - times[i - 1] for i in range(1, len(times))]
+        self.assertFalse(all(abs(iv - 50.0) < 1e-10 for iv in intervals))
+
+    def test_times_sorted(self):
+        times = self._run_poisson(n_pulses=15, mean_interval=30.0)
+        self.assertEqual(list(times), sorted(times))
+
+
+# ---------------------------------------------------------------------------
+# NMPulseContainer — train via n_pulses
+# ---------------------------------------------------------------------------
+
+class TestNMPulseContainerTrain(unittest.TestCase):
+
+    def test_new_train_returns_nmPulse(self):
+        c = NMPulseContainer()
+        p = c.new({"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+                   "n_pulses": 3, "interval": 20.0})
+        self.assertIsInstance(p, NMPulse)
+        self.assertEqual(p.n_pulses, 3)
+
+    def test_container_round_trip(self):
+        c = NMPulseContainer()
+        c.new({"pulse": "exp", "amp": 1.0, "onset": 5.0, "tau": 10.0})
+        c.new({"pulse": "square", "amp": 2.0, "onset": 0.0, "duration": 5.0,
+               "n_pulses": 3, "interval": 20.0})
+        d = c.to_dict()
+        c2 = NMPulseContainer.from_dict(d)
+        self.assertIsInstance(c2["p0"], NMPulse)
+        self.assertIsInstance(c2["p1"], NMPulse)
+        self.assertEqual(c2["p0"].n_pulses, 1)
+        self.assertEqual(c2["p1"].n_pulses, 3)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — train via run_all
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseTrain(unittest.TestCase):
+
+    def test_fixed_train_output(self):
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"type": "train", "pulse": "square",
+                      "amp": 1.0, "onset": 0.0, "duration": 5.0,
+                      "n_pulses": 3, "interval": 20.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        y = folder.data["PG_0"].nparray
+        self.assertEqual(len(y), 100)
+        for start in (0, 20, 40):
+            self.assertAlmostEqual(y[start], 1.0)
+            self.assertAlmostEqual(y[start + 5], 0.0)
+
+    def test_train_note_contains_n_pulses(self):
+        t = NMToolPulse()
+        t.n_points = 100
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"type": "train", "pulse": "square",
+                      "amp": 1.0, "onset": 0.0, "duration": 5.0,
+                      "n_pulses": 4, "interval": 20.0})
+        folder = _run_tool(t, [_make_empty_data("w0")])
+        d = folder.data["PG_0"]
+        notes = getattr(d, "notes", None)
+        if notes is None:
+            return
+        note_text = " ".join(str(n) for n in notes)
+        self.assertIn("n_pulses=4", note_text)
+        self.assertIn("interval=20", note_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **Train support**: `NMPulse` now generates fixed or stochastic pulse trains via `n_pulses`, `interval`, and `interval_type` (`"fixed"`, `"gaussian"`, `"poisson"`). A single pulse is the default (`n_pulses=1`); no separate class needed.
- **Train control**: `interval_min`/`interval_max` clamp random draws; `train_duration` bounds the window for random trains; `n_pulses=0` means unlimited count (fill window)
- **Reproducibility**: optional `seed` parameter for stochastic trains; stored in `to_dict()` and output array notes so the exact train can be regenerated
- **Enabled flag**: `enabled=False` disables a pulse without removing it from the container (matches Igor NeuroMatic `off` behaviour)
- **Onset times**: `NMToolPulse` writes per-epoch onset times to a `Pulse_N` toolfolder with `PGT_` prefix, separate from waveforms in `NMFolder.data`, avoiding prefix collisions
- **Renames**: `width` → `duration`, `train_width` → `train_duration`, `xdelta_data` → `data_xdelta`, `NMPulseTrain` merged into `NMPulse`
- **Epoch targeting**: `epoch="all"` accepted as input shorthand for `epoch=0, epoch_delta=1`; default `epoch_delta=0` fires only once on the specified epoch
- Closes #309 

## Test plan

- [ ] `pytest tests/test_analysis/test_nm_pulse_func.py` — NMPulseFunc hierarchy
- [ ] `pytest tests/test_analysis/test_nm_tool_pulse.py` — NMPulse, NMPulseContainer, NMToolPulse (171 tests)
- [ ] `pytest tests/` — full suite (3359 tests passing)

