### PR TITLE
feat(analysis): add binomial quantal release model to NMPulse (issue #312)

### DIFF
--- a/pyneuromatic/analysis/nm_pulse.py
+++ b/pyneuromatic/analysis/nm_pulse.py
@@ -111,6 +111,8 @@ class NMPulse:
         self._interval_type: str = "fixed"
         self._seed: int | None = None
         self._train_duration: float = math.inf
+        self._binomial_n: int = 0
+        self._binomial_p: float = 1.0
 
         if config is not None:
             self._config_set(config, quiet=True)
@@ -430,6 +432,37 @@ class NMPulse:
             "%s[%r].train_duration = %r" % (self._nm_path, self._name, self._train_duration)
         )
 
+    @property
+    def binomial_n(self) -> int:
+        """Number of release sites for binomial quantal release. 0 = disabled."""
+        return self._binomial_n
+
+    @binomial_n.setter
+    def binomial_n(self, value: int) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "binomial_n", "int"))
+        if value < 0:
+            raise ValueError("binomial_n must be >= 0, got %d" % value)
+        self._binomial_n = value
+        nmh.history("set binomial_n=%d" % value, path=self._name)
+        add_nm_command("%s[%r].binomial_n = %d" % (self._nm_path, self._name, self._binomial_n))
+
+    @property
+    def binomial_p(self) -> float:
+        """Probability of release per site (0 < p <= 1). Used when binomial_n > 0."""
+        return self._binomial_p
+
+    @binomial_p.setter
+    def binomial_p(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "binomial_p", "float"))
+        value = float(value)
+        if value <= 0 or value > 1:
+            raise ValueError("binomial_p must be in (0, 1], got %g" % value)
+        self._binomial_p = value
+        nmh.history("set binomial_p=%g" % value, path=self._name)
+        add_nm_command("%s[%r].binomial_p = %g" % (self._nm_path, self._name, self._binomial_p))
+
     def _interval_type_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
         if isinstance(value, bool) or not isinstance(value, str):
             raise TypeError(nmu.type_error_str(value, "interval_type", "string"))
@@ -494,23 +527,39 @@ class NMPulse:
         duration = self._duration + self._duration_delta * occ + (
             _rng.normal(0.0, self._duration_stdv) if self._duration_stdv > 0 else 0.0)
 
+        rng = np.random.default_rng(self._seed) if self._seed is not None else _rng
+
         if self._n_pulses == 1:
             self._last_onset_times: list[float] = [onset]
+            if self._binomial_n > 0:
+                k = int(rng.binomial(self._binomial_n, self._binomial_p))
+                self._last_quantal_content: list[int] = [k]
+                if k == 0:
+                    return np.zeros(n_points, dtype=float)
+                return k * self._func.waveform(n_points, xstart, xdelta, amp, onset, duration)
+            self._last_quantal_content = [1]
             return self._func.waveform(n_points, xstart, xdelta, amp, onset, duration)
 
-        rng = np.random.default_rng(self._seed) if self._seed is not None else _rng
         y = np.zeros(n_points, dtype=float)
         onset_i = onset
         count = 0
         train_end = onset + self._train_duration
         onset_times: list[float] = []
+        quantal_content: list[int] = []
         while True:
             if self._n_pulses > 0 and count >= self._n_pulses:
                 break
             if not math.isinf(self._train_duration) and onset_i >= train_end:
                 break
             onset_times.append(onset_i)
-            y += self._func.waveform(n_points, xstart, xdelta, amp, onset_i, duration)
+            if self._binomial_n > 0:
+                k = int(rng.binomial(self._binomial_n, self._binomial_p))
+                quantal_content.append(k)
+                if k > 0:
+                    y += k * self._func.waveform(n_points, xstart, xdelta, amp, onset_i, duration)
+            else:
+                quantal_content.append(1)
+                y += self._func.waveform(n_points, xstart, xdelta, amp, onset_i, duration)
             count += 1
             if self._interval_type == "poisson":
                 iv = rng.exponential(scale=self._interval)
@@ -522,6 +571,7 @@ class NMPulse:
             iv = min(iv, self._interval_max)
             onset_i += iv
         self._last_onset_times = onset_times
+        self._last_quantal_content = quantal_content
         return y
 
     # ------------------------------------------------------------------
@@ -552,7 +602,8 @@ class NMPulse:
                 pulse_name = v
             elif kl in _FUNC_ONLY_KEYS:
                 func_kwargs[kl] = v
-            elif kl in ("epoch", "epoch_delta", "n_pulses", "interval_type", "enabled", "seed") \
+            elif kl in ("epoch", "epoch_delta", "n_pulses", "interval_type", "enabled", "seed",
+                        "binomial_n", "binomial_p") \
                     or kl in _FLOAT_ATTRS:  # includes interval, interval_stdv, train_duration
                 nm_attrs[kl] = v
             else:
@@ -577,6 +628,10 @@ class NMPulse:
                 self.enabled = v
             elif kl == "seed":
                 self.seed = v
+            elif kl == "binomial_n":
+                self.binomial_n = v
+            elif kl == "binomial_p":
+                self.binomial_p = v
             else:
                 self._float_set(kl, v, quiet=True)
 
@@ -613,6 +668,8 @@ class NMPulse:
             "interval_max":   self._interval_max,
             "interval_type":  self._interval_type,
             "train_duration":    self._train_duration,
+            "binomial_n":        self._binomial_n,
+            "binomial_p":        self._binomial_p,
         }
         # Merge func-specific entries (pulse name + shape params like tau/freq/phase).
         d.update(self._func.to_dict())

--- a/pyneuromatic/analysis/nm_tool_pulse.py
+++ b/pyneuromatic/analysis/nm_tool_pulse.py
@@ -94,9 +94,10 @@ class NMToolPulse(NMTool):
         self.__pulses: NMPulseContainer = NMPulseContainer(
             nm_path=self._name + ".pulses"
         )
-        self._waveforms:   list[np.ndarray]   = []
-        self._epoch_names: list[str]          = []
-        self._pulse_times: list[list[float]]  = []
+        self._waveforms:       list[np.ndarray]  = []
+        self._epoch_names:     list[str]         = []
+        self._pulse_times:     list[list[float]] = []
+        self._quantal_content: list[list[int]]   = []
 
     # ------------------------------------------------------------------
     # Properties
@@ -206,6 +207,7 @@ class NMToolPulse(NMTool):
         self._waveforms = []
         self._epoch_names = []
         self._pulse_times = []
+        self._quantal_content = []
         return True
 
     def run(self) -> bool:
@@ -223,16 +225,24 @@ class NMToolPulse(NMTool):
 
         y = np.zeros(self.__n_points, dtype=float)
         epoch_times: list[float] = []
+        epoch_quantal: list[int] = []
         for p in self.__pulses:
             if p.enabled and p.targets_epoch(epoch_idx):
                 y += p.waveform(
                     self.__n_points, self.__xstart, self.__xdelta, epoch_idx
                 )
                 epoch_times.extend(getattr(p, "_last_onset_times", []))
+                epoch_quantal.extend(getattr(p, "_last_quantal_content", []))
+
+        # sort times and quantal content together by onset time
+        if epoch_times:
+            paired = sorted(zip(epoch_times, epoch_quantal))
+            epoch_times, epoch_quantal = [list(x) for x in zip(*paired)]
 
         self._waveforms.append(y)
         self._epoch_names.append(epoch_name)
-        self._pulse_times.append(sorted(epoch_times))
+        self._pulse_times.append(epoch_times)
+        self._quantal_content.append(epoch_quantal)
         return True
 
     def run_finish(self) -> bool:
@@ -273,6 +283,9 @@ class NMToolPulse(NMTool):
                     parts.append("interval_stdv=%g" % p.interval_stdv)
                 if p.seed is not None:
                     parts.append("seed=%d" % p.seed)
+            if p.binomial_n > 0:
+                parts.append("binomial_n=%d" % p.binomial_n)
+                parts.append("binomial_p=%g" % p.binomial_p)
             if p.epoch != 0 or p.epoch_delta != 0:
                 parts.append("epoch=%d" % p.epoch)
                 parts.append("epoch_delta=%d" % p.epoch_delta)
@@ -334,13 +347,20 @@ class NMToolPulse(NMTool):
         return f
 
     def _write_times_to_toolfolder(self, note: str) -> None:
-        """Write per-epoch onset times to a ``Pulse`` toolfolder with ``PGT_`` prefix."""
+        """Write per-epoch onset times (PGT_) and quantal content (PGQ_) to a Pulse toolfolder."""
         tf = self._make_toolfolder("Pulse", overwrite=self._overwrite)
-        times_stem = "PGT_" + self.__chan
-        for idx, times in enumerate(self._pulse_times):
-            name = times_stem + str(idx)
+        times_stem   = "PGT_" + self.__chan
+        quantal_stem = "PGQ_" + self.__chan
+        for idx, (times, quantal) in enumerate(
+            zip(self._pulse_times, self._quantal_content)
+        ):
             d = tf.data.new(
-                name,
+                times_stem + str(idx),
                 nparray=np.array(times, dtype=float),
+            )
+            self._add_note(d, note)
+            d = tf.data.new(
+                quantal_stem + str(idx),
+                nparray=np.array(quantal, dtype=int),
             )
             self._add_note(d, note)

--- a/tests/test_analysis/test_nm_tool_pulse.py
+++ b/tests/test_analysis/test_nm_tool_pulse.py
@@ -1429,6 +1429,169 @@ class TestNMToolPulsePoisson(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# NMPulse — binomial release
+# ---------------------------------------------------------------------------
+
+class TestNMPulseBinomial(unittest.TestCase):
+
+    def test_defaults(self):
+        p = NMPulse()
+        self.assertEqual(p.binomial_n, 0)
+        self.assertAlmostEqual(p.binomial_p, 1.0)
+
+    def test_binomial_n_setter(self):
+        p = NMPulse()
+        p.binomial_n = 5
+        self.assertEqual(p.binomial_n, 5)
+
+    def test_binomial_n_negative_raises(self):
+        p = NMPulse()
+        with self.assertRaises(ValueError):
+            p.binomial_n = -1
+
+    def test_binomial_n_bool_raises(self):
+        p = NMPulse()
+        with self.assertRaises(TypeError):
+            p.binomial_n = True
+
+    def test_binomial_p_setter(self):
+        p = NMPulse()
+        p.binomial_p = 0.3
+        self.assertAlmostEqual(p.binomial_p, 0.3)
+
+    def test_binomial_p_zero_raises(self):
+        p = NMPulse()
+        with self.assertRaises(ValueError):
+            p.binomial_p = 0.0
+
+    def test_binomial_p_above_one_raises(self):
+        p = NMPulse()
+        with self.assertRaises(ValueError):
+            p.binomial_p = 1.1
+
+    def test_binomial_p_bool_raises(self):
+        p = NMPulse()
+        with self.assertRaises(TypeError):
+            p.binomial_p = True
+
+    def test_config_set(self):
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "binomial_n": 10, "binomial_p": 0.5})
+        self.assertEqual(p.binomial_n, 10)
+        self.assertAlmostEqual(p.binomial_p, 0.5)
+
+    def test_to_dict_round_trip(self):
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "binomial_n": 8, "binomial_p": 0.4, "seed": 7})
+        p2 = NMPulse.from_dict(p.to_dict())
+        self.assertEqual(p, p2)
+
+    def test_disabled_when_n_zero(self):
+        # binomial_n=0 → quantal content always 1
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 5.0, "seed": 1})
+        p.waveform(50, 0.0, 1.0, 0)
+        self.assertEqual(p._last_quantal_content, [1])
+
+    def test_failure_produces_zeros(self):
+        # binomial_p so low that with seed all trials fail
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 5.0, "binomial_n": 1, "binomial_p": 0.01,
+                             "seed": 99})
+        # run many epochs until a failure occurs
+        failed = False
+        for epoch in range(20):
+            y = p.waveform(50, 0.0, 1.0, epoch)
+            if p._last_quantal_content[0] == 0:
+                np.testing.assert_array_equal(y, 0.0)
+                failed = True
+                break
+        self.assertTrue(failed, "expected at least one failure in 20 trials")
+
+    def test_quantal_content_bounded(self):
+        # k must be in [0, binomial_n]
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 3.0, "binomial_n": 5, "binomial_p": 0.5,
+                             "seed": 42})
+        for epoch in range(20):
+            p.waveform(50, 0.0, 1.0, epoch)
+            k = p._last_quantal_content[0]
+            self.assertGreaterEqual(k, 0)
+            self.assertLessEqual(k, 5)
+
+    def test_amplitude_scales_with_k(self):
+        # k=2 → peak amplitude = 2 * amp
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 5.0, "binomial_n": 5, "binomial_p": 1.0})
+        # p=1.0 → k always equals binomial_n=5
+        y = p.waveform(50, 0.0, 1.0, 0)
+        self.assertAlmostEqual(np.max(y), 5.0)
+        self.assertEqual(p._last_quantal_content[0], 5)
+
+    def test_train_quantal_content_length(self):
+        # one quantal content value per pulse in the train
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 3.0, "n_pulses": 6, "interval": 10.0,
+                             "binomial_n": 4, "binomial_p": 0.5, "seed": 1})
+        p.waveform(100, 0.0, 1.0, 0)
+        self.assertEqual(len(p._last_quantal_content), 6)
+
+    def test_train_quantal_content_bounded(self):
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 3.0, "n_pulses": 10, "interval": 10.0,
+                             "binomial_n": 3, "binomial_p": 0.6, "seed": 5})
+        p.waveform(200, 0.0, 1.0, 0)
+        for k in p._last_quantal_content:
+            self.assertGreaterEqual(k, 0)
+            self.assertLessEqual(k, 3)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — binomial toolfolder output
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseBinomialOutput(unittest.TestCase):
+
+    def _run_binomial(self, binomial_n, binomial_p, seed=42):
+        t = NMToolPulse()
+        t.n_points = 200
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+                      "n_pulses": 5, "interval": 20.0,
+                      "binomial_n": binomial_n, "binomial_p": binomial_p, "seed": seed})
+        folder = _run_tool(t, [_make_empty_data("w0", n=200)])
+        return folder.toolfolders["Pulse_0"]
+
+    def test_pgq_array_created(self):
+        tf = self._run_binomial(4, 0.5)
+        self.assertIn("PGQ_0", tf.data)
+
+    def test_pgt_and_pgq_same_length(self):
+        tf = self._run_binomial(4, 0.5)
+        times   = tf.data["PGT_0"].nparray
+        quantal = tf.data["PGQ_0"].nparray
+        self.assertEqual(len(times), len(quantal))
+
+    def test_quantal_content_bounded(self):
+        tf = self._run_binomial(binomial_n=3, binomial_p=0.7)
+        quantal = tf.data["PGQ_0"].nparray
+        self.assertTrue(np.all(quantal >= 0))
+        self.assertTrue(np.all(quantal <= 3))
+
+    def test_p_one_always_full_release(self):
+        tf = self._run_binomial(binomial_n=4, binomial_p=1.0)
+        quantal = tf.data["PGQ_0"].nparray
+        np.testing.assert_array_equal(quantal, 4)
+
+    def test_note_contains_binomial_params(self):
+        tf = self._run_binomial(5, 0.3)
+        note_text = tf.data["PGT_0"].notes.note
+        self.assertIn("binomial_n=5", note_text)
+        self.assertIn("binomial_p=0.3", note_text)
+
+
+# ---------------------------------------------------------------------------
 # NMPulseContainer — train via n_pulses
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds stochastic quantal release simulation to `NMPulse`, based on the
Igor NeuroMatic binomial model.

- `binomial_n` (int, default 0): number of release sites. 0 = disabled,
  preserving all existing behaviour.
- `binomial_p` (float, default 1.0): probability of release per site
  (0 < p ≤ 1).
- At each pulse onset, `k ~ Binomial(n, p)` is drawn; the waveform
  contribution is `k * amp * pulse_shape`. `k=0` is a complete failure —
  no waveform added at that onset.
- Works for both single pulses and trains; combined with Poisson/Gaussian
  interval trains this enables full stochastic synaptic input simulation
  (e.g. for IAF model inputs).
- `_last_quantal_content: list[int]` stored after each `waveform()` call,
  one value per pulse in the train.
- `NMToolPulse` writes per-epoch quantal content as `PGQ_` arrays to the
  `Pulse_N` toolfolder alongside the existing `PGT_` onset times, sorted
  by onset time. Both arrays are written to notes for reproducibility.
- `binomial_n` and `binomial_p` stored in `to_dict()`, `from_dict()`,
  and output array notes.
- Uses the same local RNG as interval draws — respects the `seed`
  parameter for reproducibility.
- Closes #312.

## Test plan

- [ ] `pytest tests/test_analysis/test_nm_tool_pulse.py` — 21 new tests
      covering defaults, validation, waveform scaling, train quantal
      content, and toolfolder output
- [ ] `pytest tests/` — full suite (3380 tests passing)
