### PR TITLE
feat(analysis): add D*F short-term plasticity model to NMPulse

### DIFF
--- a/pyneuromatic/analysis/nm_pulse.py
+++ b/pyneuromatic/analysis/nm_pulse.py
@@ -42,6 +42,7 @@ _FLOAT_ATTRS: tuple[str, ...] = (
     "amp_stdv", "onset_stdv", "duration_stdv",
     "interval", "interval_stdv", "interval_min", "interval_max", "train_duration",
     "rp_taur", "rp_rinf", "rp_rmin", "rp_taup", "rp_pinf", "rp_pmax", "rp_pscale",
+    "df_taud", "df_dinf", "df_dmin", "df_dscale", "df_tauf", "df_finf", "df_fmax", "df_fscale",
 )
 
 # Keys that belong to the NMPulseFunc subclass, not to NMPulse directly.
@@ -125,6 +126,16 @@ class NMPulse:
         self._rp_pmax:   float = math.inf  # ceiling on P
         self._rp_taup:   float = 0.0     # recovery tau for P (>0 enables P dynamics)
         self._rp_pscale: float = 0.0     # post-pulse P increment scale (>0 enables facilitation)
+        # D*F short-term plasticity model (multiplicative depression and facilitation).
+        # df_taud > 0 enables the model.
+        self._df_taud:  float = 0.0      # recovery tau for D (>0 enables model)
+        self._df_dinf:  float = 1.0      # steady-state D
+        self._df_dmin:  float = 0.0      # minimum D after depletion
+        self._df_dscale: float = 1.0     # post-pulse D multiplier (<1 causes depression)
+        self._df_tauf:  float = 0.0      # recovery tau for F (>0 enables F dynamics)
+        self._df_finf:  float = 1.0      # steady-state F
+        self._df_fmax:  float = math.inf # ceiling on F
+        self._df_fscale: float = 1.0     # post-pulse F multiplier (>1 causes facilitation)
 
         if config is not None:
             self._config_set(config, quiet=True)
@@ -548,6 +559,86 @@ class NMPulse:
         self._float_set("rp_pscale", value)
         add_nm_command("%s[%r].rp_pscale = %g" % (self._nm_path, self._name, self._rp_pscale))
 
+    @property
+    def df_taud(self) -> float:
+        """Recovery time constant for D. >0 enables the D*F model; 0 = disabled."""
+        return self._df_taud
+
+    @df_taud.setter
+    def df_taud(self, value: float) -> None:
+        self._float_set("df_taud", value)
+        add_nm_command("%s[%r].df_taud = %g" % (self._nm_path, self._name, self._df_taud))
+
+    @property
+    def df_dinf(self) -> float:
+        """Steady-state value of D. Default 1.0."""
+        return self._df_dinf
+
+    @df_dinf.setter
+    def df_dinf(self, value: float) -> None:
+        self._float_set("df_dinf", value)
+        add_nm_command("%s[%r].df_dinf = %g" % (self._nm_path, self._name, self._df_dinf))
+
+    @property
+    def df_dmin(self) -> float:
+        """Minimum D after depletion. Default 0.0."""
+        return self._df_dmin
+
+    @df_dmin.setter
+    def df_dmin(self, value: float) -> None:
+        self._float_set("df_dmin", value)
+        add_nm_command("%s[%r].df_dmin = %g" % (self._nm_path, self._name, self._df_dmin))
+
+    @property
+    def df_dscale(self) -> float:
+        """Post-pulse D multiplier. <1 causes depression; 1 = no change. Default 1.0."""
+        return self._df_dscale
+
+    @df_dscale.setter
+    def df_dscale(self, value: float) -> None:
+        self._float_set("df_dscale", value)
+        add_nm_command("%s[%r].df_dscale = %g" % (self._nm_path, self._name, self._df_dscale))
+
+    @property
+    def df_tauf(self) -> float:
+        """Recovery time constant for F. >0 enables F dynamics; 0 = F fixed at df_finf."""
+        return self._df_tauf
+
+    @df_tauf.setter
+    def df_tauf(self, value: float) -> None:
+        self._float_set("df_tauf", value)
+        add_nm_command("%s[%r].df_tauf = %g" % (self._nm_path, self._name, self._df_tauf))
+
+    @property
+    def df_finf(self) -> float:
+        """Steady-state value of F. Default 1.0."""
+        return self._df_finf
+
+    @df_finf.setter
+    def df_finf(self, value: float) -> None:
+        self._float_set("df_finf", value)
+        add_nm_command("%s[%r].df_finf = %g" % (self._nm_path, self._name, self._df_finf))
+
+    @property
+    def df_fmax(self) -> float:
+        """Ceiling on F (prevents F exceeding this after facilitation). Default inf."""
+        return self._df_fmax
+
+    @df_fmax.setter
+    def df_fmax(self, value: float) -> None:
+        self._float_set("df_fmax", value)
+        add_nm_command("%s[%r].df_fmax = %g" % (self._nm_path, self._name, self._df_fmax))
+
+    @property
+    def df_fscale(self) -> float:
+        """Post-pulse F multiplier. >1 causes facilitation; 1 = no change. Default 1.0."""
+        return self._df_fscale
+
+    @df_fscale.setter
+    def df_fscale(self, value: float) -> None:
+        self._float_set("df_fscale", value)
+        add_nm_command("%s[%r].df_fscale = %g" % (self._nm_path, self._name, self._df_fscale))
+
     def _interval_type_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
         if isinstance(value, bool) or not isinstance(value, str):
             raise TypeError(nmu.type_error_str(value, "interval_type", "string"))
@@ -628,9 +719,19 @@ class NMPulse:
         # train of pulses...
 
         rp_active = self._rp_taur > 0
+        df_active = self._df_taud > 0
+        if rp_active and df_active:
+            raise ValueError(
+                "rp_taur and df_taud cannot both be > 0: "
+                "R*P and D*F are alternative plasticity models, not combinable"
+            )
         R = self._rp_rinf
         P = self._rp_pinf
-        intvl = self._interval  # dummy interval for pulse 0: R=R_inf so exp term is 0, recovery formula gives R_inf unchanged
+        D = self._df_dinf
+        F = self._df_finf
+        # dummy interval for pulse 0: all state vars start at steady-state so
+        # the exp recovery terms evaluate to zero — same result as skipping recovery.
+        intvl = self._interval
 
         y = np.zeros(n_points, dtype=float)
         onset_i = onset
@@ -640,23 +741,31 @@ class NMPulse:
         quantal_content: list[int] = []
         rp_R: list[float] = []
         rp_P: list[float] = []
+        df_D: list[float] = []
+        df_F: list[float] = []
         while True:
             if self._n_pulses > 0 and count >= self._n_pulses:
                 break
             if not math.isinf(self._train_duration) and onset_i >= train_end:
                 break
 
+            effective_amp = amp
             if rp_active:
                 R = self._rp_rinf + (R - self._rp_rinf) * math.exp(-intvl / self._rp_taur)
                 if self._rp_taup > 0:
                     P = self._rp_pinf + (P - self._rp_pinf) * math.exp(-intvl / self._rp_taup)
-                effective_amp = amp * R * P
-            else:
-                effective_amp = amp
+                effective_amp *= R * P
+            if df_active:
+                D = self._df_dinf + (D - self._df_dinf) * math.exp(-intvl / self._df_taud)
+                if self._df_tauf > 0:
+                    F = self._df_finf + (F - self._df_finf) * math.exp(-intvl / self._df_tauf)
+                effective_amp *= D * F
 
             onset_times.append(onset_i)
             rp_R.append(R)
             rp_P.append(P)
+            df_D.append(D)
+            df_F.append(F)
 
             if self._binomial_n > 0:
                 k = int(rng.binomial(self._binomial_n, self._binomial_p))
@@ -669,11 +778,12 @@ class NMPulse:
             count += 1
 
             if rp_active:
-                R = R * (1.0 - P)
-                R = max(self._rp_rmin, R)
+                R = max(self._rp_rmin, R * (1.0 - P))
                 if self._rp_pscale > 0:
-                    P = P + self._rp_pscale * (1.0 - P)
-                    P = min(self._rp_pmax, P)
+                    P = min(self._rp_pmax, P + self._rp_pscale * (1.0 - P))
+            if df_active:
+                D = max(self._df_dmin, D * self._df_dscale)
+                F = min(self._df_fmax, F * self._df_fscale)
 
             if self._interval_type == "poisson":
                 intvl = rng.exponential(scale=self._interval)
@@ -689,6 +799,8 @@ class NMPulse:
         self._last_quantal_content = quantal_content
         self._last_rp_R: list[float] = rp_R
         self._last_rp_P: list[float] = rp_P
+        self._last_df_D: list[float] = df_D
+        self._last_df_F: list[float] = df_F
         return y
 
     # ------------------------------------------------------------------
@@ -794,6 +906,14 @@ class NMPulse:
             "rp_pinf":           self._rp_pinf,
             "rp_pmax":           self._rp_pmax,
             "rp_pscale":         self._rp_pscale,
+            "df_taud":           self._df_taud,
+            "df_dinf":           self._df_dinf,
+            "df_dmin":           self._df_dmin,
+            "df_dscale":         self._df_dscale,
+            "df_tauf":           self._df_tauf,
+            "df_finf":           self._df_finf,
+            "df_fmax":           self._df_fmax,
+            "df_fscale":         self._df_fscale,
         }
         # Merge func-specific entries (pulse name + shape params like tau/freq/phase).
         d.update(self._func.to_dict())

--- a/pyneuromatic/analysis/nm_tool_pulse.py
+++ b/pyneuromatic/analysis/nm_tool_pulse.py
@@ -100,6 +100,8 @@ class NMToolPulse(NMTool):
         self._quantal_content: list[list[int]]   = []
         self._rp_R:            list[list[float]] = []
         self._rp_P:            list[list[float]] = []
+        self._df_D:            list[list[float]] = []
+        self._df_F:            list[list[float]] = []
 
     # ------------------------------------------------------------------
     # Properties
@@ -212,6 +214,8 @@ class NMToolPulse(NMTool):
         self._quantal_content = []
         self._rp_R = []
         self._rp_P = []
+        self._df_D = []
+        self._df_F = []
         return True
 
     def run(self) -> bool:
@@ -232,6 +236,8 @@ class NMToolPulse(NMTool):
         epoch_quantal: list[int]   = []
         epoch_rp_R:    list[float] = []
         epoch_rp_P:    list[float] = []
+        epoch_df_D:    list[float] = []
+        epoch_df_F:    list[float] = []
         for p in self.__pulses:
             if p.enabled and p.targets_epoch(epoch_idx):
                 y += p.waveform(
@@ -241,17 +247,20 @@ class NMToolPulse(NMTool):
                 epoch_quantal.extend(getattr(p, "_last_quantal_content", []))
                 epoch_rp_R.extend(getattr(p, "_last_rp_R", []))
                 epoch_rp_P.extend(getattr(p, "_last_rp_P", []))
+                epoch_df_D.extend(getattr(p, "_last_df_D", []))
+                epoch_df_F.extend(getattr(p, "_last_df_F", []))
 
-        # sort all per-pulse arrays together by onset time
+        # sort all per-pulse metadata arrays by onset time using a common permutation
         if epoch_times:
+            order = sorted(range(len(epoch_times)), key=lambda i: epoch_times[i])
+            epoch_times   = [epoch_times[i]   for i in order]
+            epoch_quantal = [epoch_quantal[i] for i in order]
             if epoch_rp_R:
-                paired = sorted(zip(epoch_times, epoch_quantal, epoch_rp_R, epoch_rp_P))
-                epoch_times, epoch_quantal, epoch_rp_R, epoch_rp_P = [
-                    list(x) for x in zip(*paired)
-                ]
-            else:
-                paired2 = sorted(zip(epoch_times, epoch_quantal))
-                epoch_times, epoch_quantal = [list(x) for x in zip(*paired2)]
+                epoch_rp_R = [epoch_rp_R[i] for i in order]
+                epoch_rp_P = [epoch_rp_P[i] for i in order]
+            if epoch_df_D:
+                epoch_df_D = [epoch_df_D[i] for i in order]
+                epoch_df_F = [epoch_df_F[i] for i in order]
 
         self._waveforms.append(y)
         self._epoch_names.append(epoch_name)
@@ -259,6 +268,8 @@ class NMToolPulse(NMTool):
         self._quantal_content.append(epoch_quantal)
         self._rp_R.append(epoch_rp_R)
         self._rp_P.append(epoch_rp_P)
+        self._df_D.append(epoch_df_D)
+        self._df_F.append(epoch_df_F)
         return True
 
     def run_finish(self) -> bool:
@@ -315,6 +326,20 @@ class NMToolPulse(NMTool):
                     parts.append("rp_pscale=%g" % p.rp_pscale)
                 if not math.isinf(p.rp_pmax):
                     parts.append("rp_pmax=%g" % p.rp_pmax)
+            if p.df_taud > 0:
+                parts.append("df_taud=%g" % p.df_taud)
+                parts.append("df_dscale=%g" % p.df_dscale)
+                if p.df_dinf != 1.0:
+                    parts.append("df_dinf=%g" % p.df_dinf)
+                if p.df_dmin != 0.0:
+                    parts.append("df_dmin=%g" % p.df_dmin)
+                if p.df_tauf > 0:
+                    parts.append("df_tauf=%g" % p.df_tauf)
+                    parts.append("df_fscale=%g" % p.df_fscale)
+                if p.df_finf != 1.0:
+                    parts.append("df_finf=%g" % p.df_finf)
+                if not math.isinf(p.df_fmax):
+                    parts.append("df_fmax=%g" % p.df_fmax)
             if p.epoch != 0 or p.epoch_delta != 0:
                 parts.append("epoch=%d" % p.epoch)
                 parts.append("epoch_delta=%d" % p.epoch_delta)
@@ -376,12 +401,14 @@ class NMToolPulse(NMTool):
         return f
 
     def _write_times_to_toolfolder(self, note: str) -> None:
-        """Write PGT_, PGQ_, PGR_, PGP_ per-epoch arrays to a Pulse toolfolder."""
+        """Write PGT_, PGQ_, PGR_, PGP_, PGD_, PGF_ per-epoch arrays to a Pulse toolfolder."""
         tf = self._make_toolfolder("Pulse", overwrite=self._overwrite)
         chan = self.__chan
         rp_active = any(p.rp_taur > 0 for p in self.__pulses)
-        for idx, (times, quantal, rp_R, rp_P) in enumerate(
-            zip(self._pulse_times, self._quantal_content, self._rp_R, self._rp_P)
+        df_active = any(p.df_taud > 0 for p in self.__pulses)
+        for idx, (times, quantal, rp_R, rp_P, df_D, df_F) in enumerate(
+            zip(self._pulse_times, self._quantal_content,
+                self._rp_R, self._rp_P, self._df_D, self._df_F)
         ):
             for stem, arr, dtype in (
                 ("PGT_" + chan, times,   float),
@@ -393,6 +420,13 @@ class NMToolPulse(NMTool):
                 for stem, arr in (
                     ("PGR_" + chan, rp_R),
                     ("PGP_" + chan, rp_P),
+                ):
+                    d = tf.data.new(stem + str(idx), nparray=np.array(arr, dtype=float))
+                    self._add_note(d, note)
+            if df_active:
+                for stem, arr in (
+                    ("PGD_" + chan, df_D),
+                    ("PGF_" + chan, df_F),
                 ):
                     d = tf.data.new(stem + str(idx), nparray=np.array(arr, dtype=float))
                     self._add_note(d, note)

--- a/tests/test_analysis/test_nm_tool_pulse.py
+++ b/tests/test_analysis/test_nm_tool_pulse.py
@@ -1765,6 +1765,15 @@ class TestNMPulseRPWaveform(unittest.TestCase):
         p = NMPulse(config=cfg)
         return p.waveform(self._N, 0.0, self._XDELTA, 0)
 
+    def test_rp_and_df_both_active_raises(self):
+        # R*P and D*F are alternative models — enabling both is an error
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 5.0, "n_pulses": 3, "interval": 20.0,
+                             "rp_taur": 100.0, "rp_pinf": 0.5,
+                             "df_taud": 100.0, "df_dscale": 0.5})
+        with self.assertRaises(ValueError):
+            p.waveform(self._N, 0.0, self._XDELTA, 0)
+
     def test_rp_inactive_when_taur_zero(self):
         # taur=0 means model off: waveform must equal plain unscaled pulse
         y_rp  = self._waveform(rp_taur=0.0)
@@ -1937,6 +1946,275 @@ class TestNMToolPulseRPOutput(unittest.TestCase):
         note_text = tf.data["PGT_0"].notes.note
         self.assertIn("rp_taur=75", note_text)
         self.assertIn("rp_pinf=0.4", note_text)
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — D*F short-term plasticity model (properties and validation)
+# ---------------------------------------------------------------------------
+
+class TestNMPulseDF(unittest.TestCase):
+
+    def _make_df_pulse(self, **kwargs):
+        cfg = {"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+               "n_pulses": 3, "interval": 20.0,
+               "df_taud": 100.0, "df_dscale": 0.5}
+        cfg.update(kwargs)
+        return NMPulse(config=cfg)
+
+    def test_defaults(self):
+        p = NMPulse()
+        self.assertEqual(p.df_taud,   0.0)
+        self.assertEqual(p.df_dinf,   1.0)
+        self.assertEqual(p.df_dmin,   0.0)
+        self.assertEqual(p.df_dscale, 1.0)
+        self.assertEqual(p.df_tauf,   0.0)
+        self.assertEqual(p.df_finf,   1.0)
+        self.assertTrue(math.isinf(p.df_fmax))
+        self.assertEqual(p.df_fscale, 1.0)
+
+    def test_df_taud_setter(self):
+        p = NMPulse()
+        p.df_taud = 50.0
+        self.assertEqual(p.df_taud, 50.0)
+
+    def test_df_taud_bool_raises(self):
+        p = NMPulse()
+        with self.assertRaises(TypeError):
+            p.df_taud = True
+
+    def test_df_dinf_setter(self):
+        p = NMPulse()
+        p.df_dinf = 0.8
+        self.assertAlmostEqual(p.df_dinf, 0.8)
+
+    def test_df_dmin_setter(self):
+        p = NMPulse()
+        p.df_dmin = 0.1
+        self.assertAlmostEqual(p.df_dmin, 0.1)
+
+    def test_df_dscale_setter(self):
+        p = NMPulse()
+        p.df_dscale = 0.6
+        self.assertAlmostEqual(p.df_dscale, 0.6)
+
+    def test_df_tauf_setter(self):
+        p = NMPulse()
+        p.df_tauf = 200.0
+        self.assertAlmostEqual(p.df_tauf, 200.0)
+
+    def test_df_finf_setter(self):
+        p = NMPulse()
+        p.df_finf = 0.5
+        self.assertAlmostEqual(p.df_finf, 0.5)
+
+    def test_df_fmax_setter(self):
+        p = NMPulse()
+        p.df_fmax = 2.0
+        self.assertAlmostEqual(p.df_fmax, 2.0)
+
+    def test_df_fscale_setter(self):
+        p = NMPulse()
+        p.df_fscale = 1.5
+        self.assertAlmostEqual(p.df_fscale, 1.5)
+
+    def test_config_set(self):
+        p = self._make_df_pulse(df_dinf=0.9, df_dmin=0.05,
+                                 df_tauf=150.0, df_fscale=1.3, df_fmax=2.0)
+        self.assertAlmostEqual(p.df_taud,   100.0)
+        self.assertAlmostEqual(p.df_dscale, 0.5)
+        self.assertAlmostEqual(p.df_dinf,   0.9)
+        self.assertAlmostEqual(p.df_dmin,   0.05)
+        self.assertAlmostEqual(p.df_tauf,   150.0)
+        self.assertAlmostEqual(p.df_fscale, 1.3)
+        self.assertAlmostEqual(p.df_fmax,   2.0)
+
+    def test_to_dict_round_trip(self):
+        p = self._make_df_pulse(df_tauf=150.0, df_fscale=1.3)
+        d = p.to_dict()
+        self.assertIn("df_taud",  d)
+        self.assertIn("df_dscale", d)
+        self.assertIn("df_tauf",  d)
+        self.assertIn("df_fscale", d)
+        p2 = NMPulse(config=d)
+        self.assertAlmostEqual(p2.df_taud,   p.df_taud)
+        self.assertAlmostEqual(p2.df_dscale, p.df_dscale)
+        self.assertAlmostEqual(p2.df_tauf,   p.df_tauf)
+        self.assertAlmostEqual(p2.df_fscale, p.df_fscale)
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — D*F waveform behaviour
+# ---------------------------------------------------------------------------
+
+class TestNMPulseDFWaveform(unittest.TestCase):
+    """Tests for the D*F depression/facilitation model in waveform().
+
+    Setup: square pulses, amp=1, onset=0, duration=5, n_points=100,
+    interval=20 → pulses land at t=0, 20, 40.  Peak of each is y[0], y[20],
+    y[40].
+    """
+
+    _N = 100
+    _XDELTA = 1.0
+
+    def _waveform(self, **kwargs):
+        cfg = {"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+               "n_pulses": 3, "interval": 20.0}
+        cfg.update(kwargs)
+        p = NMPulse(config=cfg)
+        return p.waveform(self._N, 0.0, self._XDELTA, 0)
+
+    def test_df_inactive_when_taud_zero(self):
+        # taud=0 means model off: waveform must equal plain unscaled pulse
+        y_df  = self._waveform(df_taud=0.0)
+        y_ref = self._waveform()
+        np.testing.assert_array_almost_equal(y_df, y_ref)
+
+    def test_first_pulse_amplitude(self):
+        # Pulse 0: D=Dinf=1, F=Finf=1 → effective_amp = amp * 1 * 1 = 1.0
+        y = self._waveform(df_taud=100.0, df_dscale=0.5)
+        self.assertAlmostEqual(y[0], 1.0)
+
+    def test_depression_reduces_successive_pulses(self):
+        # D decreases multiplicatively after each pulse → amplitudes decrease
+        y = self._waveform(df_taud=100.0, df_dscale=0.5)
+        self.assertGreater(y[0], y[20])
+        self.assertGreater(y[20], y[40])
+
+    def test_depression_amplitude_at_one_time_constant(self):
+        # With interval == df_taud (one time constant) and F=1 (no facilitation):
+        #   pulse 0: D=Dinf=1 → effective_amp = amp * 1 = 1.0
+        #   after:   D = max(Dmin, Dinf * Dscale) = Dscale
+        #   pulse 1: D = Dinf + (Dscale - Dinf)*exp(-1) = 1 + (Dscale-1)*exp(-1)
+        #            effective_amp = amp * D
+        amp    = 1.0
+        dscale = 0.5
+        tau    = 20.0  # df_taud == interval → one time constant between pulses
+        y = self._waveform(df_taud=tau, df_dscale=dscale)
+        expected_amp0 = amp * 1.0  # D starts at Dinf=1
+        expected_amp1 = amp * (1.0 + (dscale - 1.0) * math.exp(-1.0))
+        self.assertAlmostEqual(y[0],  expected_amp0, places=10)
+        self.assertAlmostEqual(y[20], expected_amp1, places=10)
+
+    def test_facilitation_amplitude_at_one_time_constant(self):
+        # D clamped to 1 (df_dscale=1, df_dmin=1 or just df_dscale=1 keeps D=1).
+        # With df_dscale=1 → D stays at Dinf=1 every pulse; only F changes.
+        # interval == df_tauf → one time constant between pulses:
+        #   pulse 0: F=Finf=1 → effective_amp = amp * 1 * 1 = 1.0
+        #   after:   F = min(Fmax, Finf * Fscale) = Fscale
+        #   pulse 1: F = Finf + (Fscale - Finf)*exp(-1) = 1 + (Fscale-1)*exp(-1)
+        #            effective_amp = amp * 1 * F
+        amp    = 1.0
+        fscale = 1.5
+        tau    = 20.0  # df_tauf == interval → one time constant
+        y = self._waveform(df_taud=1000.0, df_dscale=1.0,
+                           df_tauf=tau, df_fscale=fscale)
+        expected_amp0 = amp * 1.0  # F starts at Finf=1
+        expected_amp1 = amp * (1.0 + (fscale - 1.0) * math.exp(-1.0))
+        self.assertAlmostEqual(y[0],  expected_amp0, places=10)
+        self.assertAlmostEqual(y[20], expected_amp1, places=10)
+        self.assertGreater(y[20], y[0])  # facilitation increases amplitude
+
+    def test_df_D_length_matches_n_pulses(self):
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 5.0, "n_pulses": 4, "interval": 20.0,
+                             "df_taud": 100.0, "df_dscale": 0.5})
+        p.waveform(self._N, 0.0, self._XDELTA, 0)
+        self.assertEqual(len(p._last_df_D), 4)
+        self.assertEqual(len(p._last_df_F), 4)
+
+    def test_df_F_fixed_when_fscale_one(self):
+        # fscale=1 → F stays at Finf=1 for every pulse
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 5.0, "n_pulses": 3, "interval": 20.0,
+                             "df_taud": 100.0, "df_dscale": 0.5,
+                             "df_tauf": 50.0,  "df_fscale": 1.0})
+        p.waveform(self._N, 0.0, self._XDELTA, 0)
+        for fval in p._last_df_F:
+            self.assertAlmostEqual(fval, 1.0)
+
+    def test_df_dmin_clamps_D(self):
+        # dmin=0.3 → D never falls below 0.3
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 5.0, "n_pulses": 5, "interval": 5.0,
+                             "df_taud": 10.0, "df_dscale": 0.1, "df_dmin": 0.3})
+        p.waveform(self._N, 0.0, self._XDELTA, 0)
+        for d in p._last_df_D:
+            self.assertGreaterEqual(d, 0.3)
+
+    def test_df_fmax_clamps_F(self):
+        # fmax=1.8 → F never exceeds 1.8
+        p = NMPulse(config={"pulse": "square", "amp": 1.0, "onset": 0.0,
+                             "duration": 5.0, "n_pulses": 5, "interval": 5.0,
+                             "df_taud": 100.0, "df_dscale": 1.0,
+                             "df_tauf": 1000.0, "df_fscale": 1.5, "df_fmax": 1.8})
+        p.waveform(self._N, 0.0, self._XDELTA, 0)
+        for fval in p._last_df_F:
+            self.assertLessEqual(fval, 1.8)
+
+
+# ---------------------------------------------------------------------------
+# NMToolPulse — D*F toolfolder output
+# ---------------------------------------------------------------------------
+
+class TestNMToolPulseDFOutput(unittest.TestCase):
+
+    def _run_df(self, n_pulses=3, df_taud=100.0, df_dscale=0.5, **kwargs):
+        t = NMToolPulse()
+        t.n_points = 200
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        cfg = {"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+               "n_pulses": n_pulses, "interval": 20.0,
+               "df_taud": df_taud, "df_dscale": df_dscale}
+        cfg.update(kwargs)
+        t.pulses.new(cfg)
+        folder = _run_tool(t, [_make_empty_data("w0", n=200)])
+        return folder.toolfolders["Pulse_0"]
+
+    def test_pgd_array_created(self):
+        tf = self._run_df()
+        self.assertIn("PGD_0", tf.data)
+
+    def test_pgf_array_created(self):
+        tf = self._run_df()
+        self.assertIn("PGF_0", tf.data)
+
+    def test_pgd_pgf_absent_when_df_inactive(self):
+        t = NMToolPulse()
+        t.n_points = 200
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "onset": 0.0, "duration": 5.0,
+                      "n_pulses": 3, "interval": 20.0})
+        folder = _run_tool(t, [_make_empty_data("w0", n=200)])
+        tf = folder.toolfolders["Pulse_0"]
+        self.assertNotIn("PGD_0", tf.data)
+        self.assertNotIn("PGF_0", tf.data)
+
+    def test_pgd_length_matches_pgt(self):
+        tf = self._run_df(n_pulses=4)
+        times  = tf.data["PGT_0"].nparray
+        d_vals = tf.data["PGD_0"].nparray
+        self.assertEqual(len(d_vals), len(times))
+
+    def test_first_d_equals_dinf(self):
+        # D initialised to Dinf=1.0, so PGD_[0] must equal df_dinf
+        tf = self._run_df()
+        d_vals = tf.data["PGD_0"].nparray
+        self.assertAlmostEqual(d_vals[0], 1.0)  # df_dinf default = 1.0
+
+    def test_d_values_decrease_with_depression(self):
+        tf = self._run_df(n_pulses=3, df_taud=50.0, df_dscale=0.3)
+        d_vals = tf.data["PGD_0"].nparray
+        self.assertGreater(d_vals[0], d_vals[1])
+        self.assertGreater(d_vals[1], d_vals[2])
+
+    def test_note_contains_df_params(self):
+        tf = self._run_df(df_taud=75.0, df_dscale=0.4)
+        note_text = tf.data["PGT_0"].notes.note
+        self.assertIn("df_taud=75", note_text)
+        self.assertIn("df_dscale=0.4", note_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Implements the D*F multiplicative depression/facilitation model in `NMPulse` pulse train generation (issue #315)
- D (depression) and F (facilitation) each recover exponentially between pulses and are scaled multiplicatively after each pulse — an alternative formulation to the R*P model added in #314
- R*P and D*F are enforced as mutually exclusive: enabling both raises `ValueError` (they model the same phenomenon differently and combining them has no physical meaning)
- Per-epoch `PGD_` and `PGF_` arrays written to the `Pulse_N` toolfolder alongside `PGT_` and `PGQ_`
- Refactors the multi-pulse sort in `run()` from a branching zip approach to an argsort permutation, making it cleaner and trivially extensible for future models

## Parameters added to `NMPulse`

| Parameter | Default | Description |
|-----------|---------|-------------|
| `df_taud` | 0.0 | Recovery τ for D; > 0 enables model |
| `df_dinf` | 1.0 | Steady-state D |
| `df_dmin` | 0.0 | Minimum D after depletion |
| `df_dscale` | 1.0 | Post-pulse D multiplier (< 1 → depression) |
| `df_tauf` | 0.0 | Recovery τ for F; > 0 enables F dynamics |
| `df_finf` | 1.0 | Steady-state F |
| `df_fmax` | inf | Ceiling on F |
| `df_fscale` | 1.0 | Post-pulse F multiplier (> 1 → facilitation) |

## Test plan

- [x] 29 new tests across `TestNMPulseDF`, `TestNMPulseDFWaveform`, `TestNMToolPulseDFOutput`
- [x] Analytic amplitude checks at one time constant for both depression and facilitation
- [x] `df_dmin` and `df_fmax` clamping; `PGD_`/`PGF_` absent when model inactive
- [x] `ValueError` raised when both R*P and D*F are enabled simultaneously
- [x] Full suite passes (3437 tests)
