### PR TITLE
feat(analysis): gamma distribution option for NMPulse amplitude noise (amp_dist)

### DIFF
--- a/pyneuromatic/analysis/nm_pulse.py
+++ b/pyneuromatic/analysis/nm_pulse.py
@@ -51,6 +51,27 @@ _FUNC_ONLY_KEYS: frozenset[str] = frozenset({
 })
 
 _VALID_INTERVAL_TYPES: frozenset[str] = frozenset({"fixed", "gaussian", "poisson"})
+_VALID_AMP_DISTS:     frozenset[str] = frozenset({"gaussian", "gamma"})
+
+
+def gamma_params_from_moments(mean: float, stdv: float) -> tuple[float, float]:
+    """Return (shape k, scale θ) for a Gamma with the given mean and stdv.
+
+    Inverse of :func:`gamma_moments_from_params`. Use to convert ``amp`` and
+    ``amp_stdv`` values into Gamma distribution parameters.
+    """
+    k = (mean / stdv) ** 2
+    theta = stdv ** 2 / mean
+    return k, theta
+
+
+def gamma_moments_from_params(k: float, theta: float) -> tuple[float, float]:
+    """Return (mean, stdv) for a Gamma with shape k and scale θ.
+
+    Inverse of :func:`gamma_params_from_moments`. Use to find the ``amp`` and
+    ``amp_stdv`` values that correspond to known Gamma parameters.
+    """
+    return k * theta, math.sqrt(k) * theta
 
 
 class NMPulse:
@@ -99,6 +120,7 @@ class NMPulse:
         self._amp: float = 1.0
         self._amp_delta: float = 0.0
         self._amp_stdv: float = 0.0
+        self._amp_dist: str = "gaussian"
         self._onset: float = 10.0
         self._onset_delta: float = 0.0
         self._onset_stdv: float = 0.0
@@ -639,6 +661,34 @@ class NMPulse:
         self._float_set("df_fscale", value)
         add_nm_command("%s[%r].df_fscale = %g" % (self._nm_path, self._name, self._df_fscale))
 
+    @property
+    def amp_dist(self) -> str:
+        """Amplitude noise distribution: ``"gaussian"`` (default) or ``"gamma"``.
+
+        When ``amp_stdv > 0`` and ``amp_dist="gamma"``, amplitude is drawn from
+        a Gamma distribution with the same mean (``amp``) and stdv (``amp_stdv``)
+        as the Gaussian case — always positive, right-skewed.  Use
+        :func:`gamma_params_from_moments` to inspect the implied k and θ.
+
+        Requires ``amp > 0`` at waveform generation time.
+        """
+        return self._amp_dist
+
+    @amp_dist.setter
+    def amp_dist(self, value: str) -> None:
+        self._amp_dist_set(value)
+        add_nm_command("%s[%r].amp_dist = %r" % (self._nm_path, self._name, self._amp_dist))
+
+    def _amp_dist_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "amp_dist", "string"))
+        if value not in _VALID_AMP_DISTS:
+            raise ValueError(
+                "amp_dist must be one of %s, got %r" % (sorted(_VALID_AMP_DISTS), value)
+            )
+        self._amp_dist = value
+        nmh.history("set amp_dist=%r" % value, path=self._name, quiet=quiet)
+
     def _interval_type_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
         if isinstance(value, bool) or not isinstance(value, str):
             raise TypeError(nmu.type_error_str(value, "interval_type", "string"))
@@ -695,15 +745,26 @@ class NMPulse:
         Returns:
             1-D float64 array of length *n_points*.
         """
+        rng = np.random.default_rng(self._seed) if self._seed is not None else _rng
+
         occ = self._occurrence_idx(epoch_idx)
-        amp   = self._amp   + self._amp_delta   * occ + (
-            _rng.normal(0.0, self._amp_stdv)   if self._amp_stdv   > 0 else 0.0)
+        amp_mean = self._amp + self._amp_delta * occ
+        if self._amp_stdv > 0:
+            if self._amp_dist == "gamma":
+                if amp_mean <= 0:
+                    raise ValueError(
+                        "amp must be > 0 for gamma distribution, got %g" % amp_mean
+                    )
+                shape, scale = gamma_params_from_moments(amp_mean, self._amp_stdv)
+                amp = float(rng.gamma(shape, scale))
+            else:
+                amp = amp_mean + float(_rng.normal(0.0, self._amp_stdv))
+        else:
+            amp = amp_mean
         onset = self._onset + self._onset_delta * occ + (
             _rng.normal(0.0, self._onset_stdv) if self._onset_stdv > 0 else 0.0)
         duration = self._duration + self._duration_delta * occ + (
             _rng.normal(0.0, self._duration_stdv) if self._duration_stdv > 0 else 0.0)
-
-        rng = np.random.default_rng(self._seed) if self._seed is not None else _rng
 
         if self._n_pulses == 1:
             self._last_onset_times: list[float] = [onset]
@@ -831,8 +892,8 @@ class NMPulse:
                 pulse_name = v
             elif kl in _FUNC_ONLY_KEYS:
                 func_kwargs[kl] = v
-            elif kl in ("epoch", "epoch_delta", "n_pulses", "interval_type", "enabled", "seed",
-                        "binomial_n", "binomial_p") \
+            elif kl in ("epoch", "epoch_delta", "n_pulses", "interval_type", "amp_dist",
+                        "enabled", "seed", "binomial_n", "binomial_p") \
                     or kl in _FLOAT_ATTRS:  # includes interval, interval_stdv, train_duration
                 nm_attrs[kl] = v
             else:
@@ -853,6 +914,8 @@ class NMPulse:
                 self.n_pulses = v
             elif kl == "interval_type":
                 self._interval_type_set(v, quiet=True)
+            elif kl == "amp_dist":
+                self._amp_dist_set(v, quiet=True)
             elif kl == "enabled":
                 self.enabled = v
             elif kl == "seed":
@@ -884,6 +947,7 @@ class NMPulse:
             "amp":            self._amp,
             "amp_delta":      self._amp_delta,
             "amp_stdv":       self._amp_stdv,
+            "amp_dist":       self._amp_dist,
             "onset":          self._onset,
             "onset_delta":    self._onset_delta,
             "onset_stdv":     self._onset_stdv,

--- a/pyneuromatic/analysis/nm_tool_pulse.py
+++ b/pyneuromatic/analysis/nm_tool_pulse.py
@@ -310,6 +310,8 @@ class NMToolPulse(NMTool):
                     parts.append("interval_stdv=%g" % p.interval_stdv)
                 if p.seed is not None:
                     parts.append("seed=%d" % p.seed)
+            if p.amp_dist != "gaussian":
+                parts.append("amp_dist=%r" % p.amp_dist)
             if p.binomial_n > 0:
                 parts.append("binomial_n=%d" % p.binomial_n)
                 parts.append("binomial_p=%g" % p.binomial_p)

--- a/tests/test_analysis/test_nm_tool_pulse.py
+++ b/tests/test_analysis/test_nm_tool_pulse.py
@@ -9,7 +9,10 @@ import unittest
 
 import numpy as np
 
-from pyneuromatic.analysis.nm_pulse import NMPulse, NMPulseContainer
+from pyneuromatic.analysis.nm_pulse import (
+    NMPulse, NMPulseContainer,
+    gamma_params_from_moments, gamma_moments_from_params,
+)
 from pyneuromatic.analysis.nm_tool_pulse import NMToolPulse, NMToolPulseConfig
 from pyneuromatic.core.nm_data import NMData
 from pyneuromatic.core.nm_folder import NMFolder
@@ -2215,6 +2218,169 @@ class TestNMToolPulseDFOutput(unittest.TestCase):
         note_text = tf.data["PGT_0"].notes.note
         self.assertIn("df_taud=75", note_text)
         self.assertIn("df_dscale=0.4", note_text)
+
+
+# ---------------------------------------------------------------------------
+# Gamma helper functions
+# ---------------------------------------------------------------------------
+
+class TestGammaHelpers(unittest.TestCase):
+
+    def test_params_from_moments_round_trip(self):
+        mean, stdv = 2.0, 0.5
+        k, theta = gamma_params_from_moments(mean, stdv)
+        mean2, stdv2 = gamma_moments_from_params(k, theta)
+        self.assertAlmostEqual(mean2, mean, places=12)
+        self.assertAlmostEqual(stdv2, stdv, places=12)
+
+    def test_params_from_moments_values(self):
+        # mean=2, stdv=0.5 → k=(2/0.5)²=16, theta=0.5²/2=0.125
+        k, theta = gamma_params_from_moments(2.0, 0.5)
+        self.assertAlmostEqual(k,     16.0,   places=12)
+        self.assertAlmostEqual(theta,  0.125, places=12)
+
+    def test_moments_from_params_values(self):
+        # k=4, theta=0.5 → mean=2, stdv=sqrt(4)*0.5=1.0
+        mean, stdv = gamma_moments_from_params(4.0, 0.5)
+        self.assertAlmostEqual(mean, 2.0, places=12)
+        self.assertAlmostEqual(stdv, 1.0, places=12)
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — amp_dist property and validation
+# ---------------------------------------------------------------------------
+
+class TestNMPulseAmpDist(unittest.TestCase):
+
+    def test_default_is_gaussian(self):
+        p = NMPulse()
+        self.assertEqual(p.amp_dist, "gaussian")
+
+    def test_setter_gaussian(self):
+        p = NMPulse()
+        p.amp_dist = "gaussian"
+        self.assertEqual(p.amp_dist, "gaussian")
+
+    def test_setter_gamma(self):
+        p = NMPulse()
+        p.amp_dist = "gamma"
+        self.assertEqual(p.amp_dist, "gamma")
+
+    def test_invalid_raises(self):
+        p = NMPulse()
+        with self.assertRaises(ValueError):
+            p.amp_dist = "poisson"
+
+    def test_bool_raises(self):
+        p = NMPulse()
+        with self.assertRaises(TypeError):
+            p.amp_dist = True
+
+    def test_config_set(self):
+        p = NMPulse(config={"amp_dist": "gamma"})
+        self.assertEqual(p.amp_dist, "gamma")
+
+    def test_to_dict_round_trip(self):
+        p = NMPulse(config={"amp_dist": "gamma"})
+        d = p.to_dict()
+        self.assertIn("amp_dist", d)
+        self.assertEqual(d["amp_dist"], "gamma")
+        p2 = NMPulse(config=d)
+        self.assertEqual(p2.amp_dist, "gamma")
+
+    def test_gamma_requires_positive_amp(self):
+        # amp <= 0 raises ValueError at waveform time
+        p = NMPulse(config={"amp": -1.0, "amp_stdv": 0.1, "amp_dist": "gamma"})
+        with self.assertRaises(ValueError):
+            p.waveform(100, 0.0, 1.0, 0)
+
+
+# ---------------------------------------------------------------------------
+# NMPulse — amp_dist="gamma" waveform behaviour
+# ---------------------------------------------------------------------------
+
+class TestNMPulseAmpDistGamma(unittest.TestCase):
+
+    _N = 1000  # epochs for statistical tests
+    _N_POINTS = 10
+
+    def _sample_amps(self, amp, amp_stdv, seed=0):
+        """Run _N single-pulse epochs and collect peak amplitude of each."""
+        amps = []
+        rng = np.random.default_rng(seed)
+        for _ in range(self._N):
+            p = NMPulse(config={
+                "pulse": "square", "amp": amp, "amp_stdv": amp_stdv,
+                "amp_dist": "gamma", "onset": 0.0, "duration": 5.0, "seed": int(rng.integers(0, 2**31)),
+            })
+            y = p.waveform(self._N_POINTS, 0.0, 1.0, 0)
+            amps.append(y[0])
+        return np.array(amps)
+
+    def test_gamma_all_positive(self):
+        # Gamma samples are always > 0 even with large stdv
+        amps = self._sample_amps(amp=1.0, amp_stdv=0.5)
+        self.assertTrue(np.all(amps > 0))
+
+    def test_gamma_mean_close_to_amp(self):
+        amps = self._sample_amps(amp=2.0, amp_stdv=0.3)
+        self.assertAlmostEqual(float(np.mean(amps)), 2.0, delta=0.1)
+
+    def test_gamma_stdv_close_to_amp_stdv(self):
+        amps = self._sample_amps(amp=2.0, amp_stdv=0.3)
+        self.assertAlmostEqual(float(np.std(amps)), 0.3, delta=0.05)
+
+    def test_gaussian_can_go_negative_gamma_cannot(self):
+        # With amp=0.5 and amp_stdv=0.6, Gaussian regularly goes negative;
+        # Gamma never does.
+        rng = np.random.default_rng(0)
+        gaussian_amps = [0.5 + float(rng.normal(0, 0.6)) for _ in range(self._N)]
+        self.assertTrue(any(a < 0 for a in gaussian_amps))
+
+        gamma_amps = self._sample_amps(amp=0.5, amp_stdv=0.6)
+        self.assertTrue(np.all(gamma_amps > 0))
+
+    def test_gamma_right_skewed_gaussian_symmetric(self):
+        # With the same mean and stdv, Gamma is right-skewed: most values cluster
+        # below the mean with a long right tail (rare large events).
+        # Consequence: Gamma median < mean; Gaussian median ≈ mean.
+        # amp=1, stdv=0.7 → k≈2.0, theoretical skewness≈1.4, median≈0.85.
+        amp, stdv = 1.0, 0.7
+
+        gamma_amps = self._sample_amps(amp=amp, amp_stdv=stdv)
+
+        rng = np.random.default_rng(1)
+        gaussian_amps = amp + rng.normal(0.0, stdv, self._N)
+
+        # Both distributions have the same mean
+        self.assertAlmostEqual(float(np.mean(gamma_amps)),    amp, delta=0.08)
+        self.assertAlmostEqual(float(np.mean(gaussian_amps)), amp, delta=0.08)
+
+        # Gaussian is symmetric: median ≈ mean
+        self.assertAlmostEqual(float(np.median(gaussian_amps)), amp, delta=0.06)
+
+        # Gamma is right-skewed: median clearly below mean
+        self.assertLess(float(np.median(gamma_amps)), amp - 0.05)
+
+    def test_no_noise_when_amp_stdv_zero(self):
+        # amp_stdv=0 → gamma branch skipped → constant amplitude regardless of amp_dist
+        p = NMPulse(config={"pulse": "square", "amp": 1.5, "amp_stdv": 0.0,
+                             "amp_dist": "gamma", "onset": 0.0, "duration": 5.0})
+        for _ in range(10):
+            y = p.waveform(self._N_POINTS, 0.0, 1.0, 0)
+            self.assertAlmostEqual(y[0], 1.5)
+
+    def test_note_contains_amp_dist(self):
+        t = NMToolPulse()
+        t.n_points = 20
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({"pulse": "square", "amp": 1.0, "amp_stdv": 0.2,
+                      "amp_dist": "gamma", "onset": 0.0, "duration": 5.0})
+        folder = _run_tool(t, [_make_empty_data("w0", n=20)])
+        d = folder.data["PG_0"]
+        note_text = d.notes.note
+        self.assertIn("amp_dist='gamma'", note_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `amp_dist` parameter to `NMPulse` (issue #318, partial — `amp_dist` only; `onset_dist` to follow)
- Two options: `"gaussian"` (default, existing behaviour) or `"gamma"` — both specified via the same `amp` (mean) and `amp_stdv` (stdv) parameters, so existing code is unchanged
- Gamma is always positive and right-skewed: avoids unphysical negative amplitudes when `amp_stdv` is large relative to `amp`, and better describes right-skewed EPSC amplitude distributions observed experimentally
- Two module-level helper functions for users who think in Gamma parameters rather than moments:
  - `gamma_params_from_moments(mean, stdv) → (k, θ)`
  - `gamma_moments_from_params(k, θ) → (mean, stdv)`

## Why Gamma?

Gaussian noise is symmetric — at high CV (stdv close to mean), samples regularly go negative, which is physically meaningless for an amplitude. Gamma is always positive and right-skewed: most events are small, with rare large ones pulling the mean up. This matches stochastic neurotransmitter release and EPSC amplitude distributions.

## Test plan

- [x] Helper function round-trips and exact values
- [x] Property validation: default, setter, invalid string, bool type error, config dict, `to_dict` round-trip
- [x] `amp > 0` enforced at waveform time for gamma
- [x] Sample mean and stdv match `amp` / `amp_stdv` (N=1000)
- [x] Gamma samples always positive even at high CV
- [x] Skewness test: Gamma median < mean; Gaussian median ≈ mean (same mean and stdv)
- [x] `amp_stdv=0` skips sampling regardless of `amp_dist`
- [x] Note string includes `amp_dist` when not `"gaussian"`
- [x] Full suite passes (3455 tests)