### PR TITLE
feat(analysis): add interval_type='user' for user-supplied inter-pulse intervals

### DIFF
--- a/pyneuromatic/analysis/nm_pulse.py
+++ b/pyneuromatic/analysis/nm_pulse.py
@@ -51,7 +51,7 @@ _FUNC_ONLY_KEYS: frozenset[str] = frozenset({
     "tau", "freq", "phase", "f0", "f1", "data", "data_xdelta",
 })
 
-_VALID_INTERVAL_TYPES: frozenset[str] = frozenset({"fixed", "gaussian", "poisson"})
+_VALID_INTERVAL_TYPES: frozenset[str] = frozenset({"fixed", "gaussian", "poisson", "user"})
 _VALID_DISTS: frozenset[str] = frozenset({"gaussian", "gamma"})
 
 
@@ -74,6 +74,38 @@ def gamma_moments_from_params(k: float, theta: float) -> tuple[float, float]:
     stdv values that correspond to known Gamma parameters.
     """
     return k * theta, math.sqrt(k) * theta
+
+
+def onset_times_to_intervals(onset_times: np.ndarray | list) -> np.ndarray:
+    """Convert absolute onset times to an intervals array for ``interval_type='user'``.
+
+    Returns ``np.diff(onset_times)``.  The first onset should be set as the
+    ``NMPulse.onset`` parameter; the returned intervals drive subsequent
+    pulses (N intervals → N+1 pulses total).
+
+    Example::
+
+        p.onset = times[0]
+        p.intervals = onset_times_to_intervals(times)
+        # fires len(times) pulses at the given times
+
+    Args:
+        onset_times: 1-D strictly-increasing sequence of pulse onset times.
+
+    Returns:
+        1-D float64 array of N-1 inter-pulse intervals.
+
+    Raises:
+        ValueError: If fewer than 2 times are supplied or times are not
+            strictly increasing.
+    """
+    times = np.asarray(onset_times, dtype=float)
+    if times.ndim != 1 or len(times) < 2:
+        raise ValueError("onset_times must be a 1-D sequence with at least 2 elements")
+    intervals = np.diff(times)
+    if np.any(intervals <= 0):
+        raise ValueError("onset_times must be strictly increasing")
+    return intervals
 
 
 class NMPulse:
@@ -137,6 +169,7 @@ class NMPulse:
         self._interval_min: float = 0.0
         self._interval_max: float = math.inf
         self._interval_type: str = "fixed"
+        self._intervals: np.ndarray | None = None
         self._seed: int | None = None
         self._train_duration: float = math.inf
         self._binomial_n: int = 0
@@ -442,7 +475,7 @@ class NMPulse:
 
     @property
     def interval_type(self) -> str:
-        """Interval distribution: ``'fixed'``, ``'gaussian'``, or ``'poisson'``."""
+        """Interval distribution: ``'fixed'``, ``'gaussian'``, ``'poisson'``, or ``'user'``."""
         return self._interval_type
 
     @interval_type.setter
@@ -737,6 +770,49 @@ class NMPulse:
         self._interval_type = value
         nmh.history("set interval_type=%r" % value, path=self._name, quiet=quiet)
 
+    @property
+    def intervals(self) -> np.ndarray | None:
+        """User-supplied inter-pulse intervals for ``interval_type='user'``.
+
+        N elements → N+1 pulses: pulse 0 fires at ``onset``, each subsequent
+        pulse fires ``intervals[i]`` after the previous one.  Use
+        :func:`onset_times_to_intervals` to convert absolute onset times to
+        this format.  ``n_pulses`` (if > 0) and ``train_duration`` still cap
+        the count.  ``interval``, ``interval_stdv``, ``interval_min``, and
+        ``interval_max`` are ignored in this mode.
+        """
+        return self._intervals
+
+    @intervals.setter
+    def intervals(self, value: np.ndarray | list | None) -> None:
+        self._intervals_set(value)
+        n = len(self._intervals) if self._intervals is not None else 0
+        add_nm_command(
+            "%s[%r].intervals = <array len=%d>" % (self._nm_path, self._name, n)
+        )
+
+    def _intervals_set(
+        self, value: np.ndarray | list | None, quiet: bool = nmc.QUIET
+    ) -> None:
+        if value is None:
+            self._intervals = None
+            nmh.history("set intervals=None", path=self._name, quiet=quiet)
+            return
+        if isinstance(value, list):
+            value = np.array(value, dtype=float)
+        if not isinstance(value, np.ndarray):
+            raise TypeError(nmu.type_error_str(value, "intervals", "numpy array or list"))
+        if value.ndim != 1:
+            raise ValueError("intervals must be a 1-D array, got shape %s" % str(value.shape))
+        if len(value) == 0:
+            raise ValueError("intervals must have at least one element")
+        if np.any(value <= 0):
+            raise ValueError("all intervals must be > 0")
+        self._intervals = value.astype(float)
+        nmh.history(
+            "set intervals=<array len=%d>" % len(self._intervals), path=self._name, quiet=quiet
+        )
+
     # ------------------------------------------------------------------
     # Epoch targeting
 
@@ -839,6 +915,9 @@ class NMPulse:
 
         # train of pulses...
 
+        if self._interval_type == "user" and self._intervals is None:
+            raise ValueError("intervals must be set when interval_type='user'")
+
         rp_active = self._rp_taur > 0
         df_active = self._df_taud > 0
         if rp_active and df_active:
@@ -866,6 +945,8 @@ class NMPulse:
         df_F: list[float] = []
         while True:
             if self._n_pulses > 0 and count >= self._n_pulses:
+                break
+            if self._interval_type == "user" and count > len(self._intervals):
                 break
             if not math.isinf(self._train_duration) and onset_i >= train_end:
                 break
@@ -908,12 +989,19 @@ class NMPulse:
 
             if self._interval_type == "poisson":
                 intvl = rng.exponential(scale=self._interval)
+                intvl = max(intvl, self._interval_min)
+                intvl = min(intvl, self._interval_max)
             elif self._interval_type == "gaussian":
                 intvl = rng.normal(self._interval, self._interval_stdv)
+                intvl = max(intvl, self._interval_min)
+                intvl = min(intvl, self._interval_max)
+            elif self._interval_type == "user":
+                if count <= len(self._intervals):
+                    intvl = self._intervals[count - 1]
             else:
                 intvl = self._interval
-            intvl = max(intvl, self._interval_min)
-            intvl = min(intvl, self._interval_max)
+                intvl = max(intvl, self._interval_min)
+                intvl = min(intvl, self._interval_max)
             onset_i += intvl
 
         self._last_onset_times = onset_times
@@ -952,7 +1040,7 @@ class NMPulse:
                 pulse_name = v
             elif kl in _FUNC_ONLY_KEYS:
                 func_kwargs[kl] = v
-            elif kl in ("epoch", "epoch_delta", "n_pulses", "interval_type",
+            elif kl in ("epoch", "epoch_delta", "n_pulses", "interval_type", "intervals",
                         "amp_dist", "onset_dist", "duration_dist",
                         "enabled", "seed", "binomial_n", "binomial_p") \
                     or kl in _FLOAT_ATTRS:  # includes interval, interval_stdv, train_duration
@@ -975,6 +1063,8 @@ class NMPulse:
                 self.n_pulses = v
             elif kl == "interval_type":
                 self._interval_type_set(v, quiet=True)
+            elif kl == "intervals":
+                self._intervals_set(v, quiet=True)
             elif kl in ("amp_dist", "onset_dist", "duration_dist"):
                 self._dist_set(kl, v, quiet=True)
             elif kl == "enabled":
@@ -1023,6 +1113,7 @@ class NMPulse:
             "interval_min":   self._interval_min,
             "interval_max":   self._interval_max,
             "interval_type":  self._interval_type,
+            "intervals":      self._intervals.tolist() if self._intervals is not None else None,
             "train_duration":    self._train_duration,
             "binomial_n":        self._binomial_n,
             "binomial_p":        self._binomial_p,

--- a/pyneuromatic/analysis/nm_tool_pulse.py
+++ b/pyneuromatic/analysis/nm_tool_pulse.py
@@ -301,12 +301,16 @@ class NMToolPulse(NMTool):
                     parts.append("%s=%g" % (key, d[key]))
             if p.n_pulses != 1 or not math.isinf(p.train_duration):
                 parts.append("n_pulses=%d" % p.n_pulses)
-                parts.append("interval=%g" % p.interval)
+                if p.interval_type == "user":
+                    n_itvl = len(p.intervals) if p.intervals is not None else 0
+                    parts.append("intervals=<len=%d>" % n_itvl)
+                else:
+                    parts.append("interval=%g" % p.interval)
                 if not math.isinf(p.train_duration):
                     parts.append("train_duration=%g" % p.train_duration)
                 if p.interval_type != "fixed":
                     parts.append("interval_type=%r" % p.interval_type)
-                if p.interval_stdv > 0:
+                if p.interval_type == "gaussian" and p.interval_stdv > 0:
                     parts.append("interval_stdv=%g" % p.interval_stdv)
                 if p.seed is not None:
                     parts.append("seed=%d" % p.seed)

--- a/tests/test_analysis/test_nm_tool_pulse.py
+++ b/tests/test_analysis/test_nm_tool_pulse.py
@@ -12,6 +12,7 @@ import numpy as np
 from pyneuromatic.analysis.nm_pulse import (
     NMPulse, NMPulseContainer,
     gamma_params_from_moments, gamma_moments_from_params,
+    onset_times_to_intervals,
 )
 from pyneuromatic.analysis.nm_tool_pulse import NMToolPulse, NMToolPulseConfig
 from pyneuromatic.core.nm_data import NMData
@@ -2497,6 +2498,251 @@ class TestNMPulseOnsetDurationDist(unittest.TestCase):
         folder = _run_tool(t, [_make_empty_data("w0", n=30)])
         note_text = folder.data["PG_0"].notes.note
         self.assertIn("duration_dist='gamma'", note_text)
+
+
+class TestNMPulseUserIntervals(unittest.TestCase):
+    """Tests for interval_type='user' with user-supplied intervals array."""
+
+    # ------------------------------------------------------------------
+    # Property validation
+
+    def test_intervals_default_none(self):
+        self.assertIsNone(NMPulse().intervals)
+
+    def test_intervals_setter_list(self):
+        p = NMPulse()
+        p.intervals = [20.0, 30.0, 40.0]
+        self.assertIsInstance(p.intervals, np.ndarray)
+        np.testing.assert_array_equal(p.intervals, [20.0, 30.0, 40.0])
+
+    def test_intervals_setter_ndarray(self):
+        p = NMPulse()
+        arr = np.array([10.0, 20.0])
+        p.intervals = arr
+        np.testing.assert_array_equal(p.intervals, arr)
+
+    def test_intervals_setter_none_clears(self):
+        p = NMPulse()
+        p.intervals = [10.0]
+        p.intervals = None
+        self.assertIsNone(p.intervals)
+
+    def test_intervals_wrong_type_raises(self):
+        with self.assertRaises(TypeError):
+            NMPulse().intervals = "bad"
+
+    def test_intervals_2d_raises(self):
+        with self.assertRaises(ValueError):
+            NMPulse().intervals = np.array([[10.0, 20.0]])
+
+    def test_intervals_empty_raises(self):
+        with self.assertRaises(ValueError):
+            NMPulse().intervals = []
+
+    def test_intervals_zero_value_raises(self):
+        with self.assertRaises(ValueError):
+            NMPulse().intervals = [10.0, 0.0, 20.0]
+
+    def test_intervals_negative_value_raises(self):
+        with self.assertRaises(ValueError):
+            NMPulse().intervals = [10.0, -5.0]
+
+    def test_interval_type_user_valid(self):
+        p = NMPulse()
+        p.interval_type = "user"
+        self.assertEqual(p.interval_type, "user")
+
+    def test_user_mode_without_intervals_raises(self):
+        p = NMPulse(config={"n_pulses": 3, "interval_type": "user"})
+        with self.assertRaises(ValueError):
+            p.waveform(200, 0.0, 1.0, 0)
+
+    # ------------------------------------------------------------------
+    # Waveform: pulse count and timing
+
+    def test_user_intervals_pulse_count_is_n_plus_one(self):
+        # N intervals → N+1 pulses
+        p = NMPulse(config={
+            "pulse": "square", "onset": 10.0, "duration": 1.0,
+            "n_pulses": 0, "interval_type": "user", "intervals": [20.0, 20.0, 20.0],
+        })
+        p.waveform(200, 0.0, 1.0, 0)
+        self.assertEqual(len(p._last_onset_times), 4)
+
+    def test_user_intervals_onset_times_correct(self):
+        # 3 intervals [20, 30, 40] → N+1=4 pulses at [10, 30, 60, 100]
+        p = NMPulse(config={
+            "pulse": "square", "onset": 10.0, "duration": 1.0,
+            "n_pulses": 0, "interval_type": "user", "intervals": [20.0, 30.0, 40.0],
+        })
+        p.waveform(200, 0.0, 1.0, 0)
+        expected = [10.0, 30.0, 60.0, 100.0]
+        for got, exp in zip(p._last_onset_times, expected):
+            self.assertAlmostEqual(got, exp)
+
+    def test_user_intervals_n_pulses_caps_count(self):
+        # 5 intervals but n_pulses=3 → only 3 pulses
+        p = NMPulse(config={
+            "pulse": "square", "onset": 10.0, "duration": 1.0,
+            "n_pulses": 3, "interval_type": "user",
+            "intervals": [20.0, 20.0, 20.0, 20.0, 20.0],
+        })
+        p.waveform(300, 0.0, 1.0, 0)
+        self.assertEqual(len(p._last_onset_times), 3)
+
+    def test_user_intervals_train_duration_caps_count(self):
+        # 5 intervals of 20 ms each → onsets at 10, 30, 50, 70, 90
+        # train_duration=45 → onset < 10+45=55, so pulses at 10, 30, 50 only
+        p = NMPulse(config={
+            "pulse": "square", "onset": 10.0, "duration": 1.0,
+            "n_pulses": 0, "interval_type": "user",
+            "intervals": [20.0, 20.0, 20.0, 20.0, 20.0],
+            "train_duration": 45.0,
+        })
+        p.waveform(200, 0.0, 1.0, 0)
+        self.assertEqual(len(p._last_onset_times), 3)
+
+    def test_user_single_interval_two_pulses(self):
+        # 1 interval → N+1=2 pulses
+        p = NMPulse(config={
+            "pulse": "square", "onset": 5.0, "duration": 2.0,
+            "n_pulses": 0, "interval_type": "user", "intervals": [50.0],
+        })
+        p.waveform(100, 0.0, 1.0, 0)
+        self.assertEqual(len(p._last_onset_times), 2)
+
+    def test_user_irregular_intervals_waveform_nonzero_at_correct_bins(self):
+        # 3 intervals → N+1=4 pulses at [5, 30, 45, 80]
+        intervals = [25.0, 15.0, 35.0]
+        onset = 5.0
+        p = NMPulse(config={
+            "pulse": "square", "onset": onset, "duration": 1.0,
+            "n_pulses": 0, "interval_type": "user", "intervals": intervals,
+        })
+        y = p.waveform(200, 0.0, 1.0, 0)
+        expected_onsets = [5.0, 30.0, 45.0, 80.0]
+        for onset_t in expected_onsets:
+            self.assertGreater(y[int(onset_t)], 0.0)
+
+    def test_user_interval_ignored_params_have_no_effect(self):
+        # interval, interval_stdv, interval_min, interval_max are all ignored
+        # 3 intervals → N+1=4 pulses at [10, 30, 50, 70]
+        p1 = NMPulse(config={
+            "pulse": "square", "onset": 10.0, "duration": 1.0,
+            "n_pulses": 0, "interval_type": "user", "intervals": [20.0, 20.0, 20.0],
+            "interval": 999.0, "interval_stdv": 999.0,
+            "interval_min": 1.0, "interval_max": 2.0,
+        })
+        p1.waveform(200, 0.0, 1.0, 0)
+        self.assertAlmostEqual(p1._last_onset_times[0], 10.0)
+        self.assertAlmostEqual(p1._last_onset_times[1], 30.0)
+        self.assertAlmostEqual(p1._last_onset_times[2], 50.0)
+        self.assertAlmostEqual(p1._last_onset_times[3], 70.0)
+
+    # ------------------------------------------------------------------
+    # config / to_dict round-trip
+
+    def test_config_set_intervals(self):
+        p = NMPulse(config={"interval_type": "user", "intervals": [10.0, 20.0]})
+        self.assertEqual(p.interval_type, "user")
+        np.testing.assert_array_equal(p.intervals, [10.0, 20.0])
+
+    def test_to_dict_stores_intervals_as_list(self):
+        p = NMPulse(config={"interval_type": "user", "intervals": [10.0, 20.0]})
+        d = p.to_dict()
+        self.assertEqual(d["interval_type"], "user")
+        self.assertEqual(d["intervals"], [10.0, 20.0])
+
+    def test_to_dict_intervals_none_when_not_set(self):
+        d = NMPulse().to_dict()
+        self.assertIsNone(d["intervals"])
+
+    def test_from_dict_round_trip(self):
+        p = NMPulse(config={"interval_type": "user", "intervals": [15.0, 25.0, 35.0]})
+        d = p.to_dict()
+        p2 = NMPulse.from_dict(d)
+        self.assertEqual(p2.interval_type, "user")
+        np.testing.assert_array_equal(p2.intervals, [15.0, 25.0, 35.0])
+
+    # ------------------------------------------------------------------
+    # NMToolPulse output
+
+    def test_tool_pulse_user_intervals_output_count(self):
+        # 3 intervals → N+1=4 pulses
+        t = NMToolPulse()
+        t.n_points = 200
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({
+            "pulse": "square", "onset": 10.0, "duration": 2.0,
+            "n_pulses": 0, "interval_type": "user",
+            "intervals": [20.0, 20.0, 20.0],
+        })
+        folder = _run_tool(t, [_make_empty_data("w0", n=200)])
+        tf = folder.toolfolders["Pulse_0"]
+        times = list(tf.data["PGT_0"].nparray)
+        self.assertEqual(len(times), 4)
+
+    def test_tool_pulse_user_note_contains_interval_count(self):
+        t = NMToolPulse()
+        t.n_points = 200
+        t.xstart = 0.0
+        t.xdelta = 1.0
+        t.pulses.new({
+            "pulse": "square", "onset": 10.0, "duration": 2.0,
+            "n_pulses": 0, "interval_type": "user",
+            "intervals": [20.0, 30.0, 40.0],
+        })
+        folder = _run_tool(t, [_make_empty_data("w0", n=200)])
+        tf = folder.toolfolders["Pulse_0"]
+        note_text = tf.data["PGT_0"].notes.note
+        self.assertIn("interval_type='user'", note_text)
+        self.assertIn("intervals=<len=3>", note_text)
+
+
+class TestOnsetTimesToIntervals(unittest.TestCase):
+
+    def test_basic(self):
+        result = onset_times_to_intervals([10.0, 30.0, 60.0, 100.0])
+        np.testing.assert_array_almost_equal(result, [20.0, 30.0, 40.0])
+
+    def test_returns_ndarray(self):
+        self.assertIsInstance(onset_times_to_intervals([0.0, 10.0]), np.ndarray)
+
+    def test_two_times_one_interval(self):
+        result = onset_times_to_intervals([5.0, 25.0])
+        np.testing.assert_array_almost_equal(result, [20.0])
+
+    def test_accepts_ndarray(self):
+        arr = np.array([0.0, 10.0, 30.0])
+        result = onset_times_to_intervals(arr)
+        np.testing.assert_array_almost_equal(result, [10.0, 20.0])
+
+    def test_fewer_than_two_raises(self):
+        with self.assertRaises(ValueError):
+            onset_times_to_intervals([5.0])
+
+    def test_not_strictly_increasing_raises(self):
+        with self.assertRaises(ValueError):
+            onset_times_to_intervals([10.0, 30.0, 20.0])
+
+    def test_equal_times_raises(self):
+        with self.assertRaises(ValueError):
+            onset_times_to_intervals([10.0, 10.0, 30.0])
+
+    def test_round_trip_with_waveform(self):
+        # onset_times_to_intervals + NMPulse fires pulses at the original times
+        onset_times = [10.0, 35.0, 55.0, 90.0]
+        p = NMPulse(config={
+            "pulse": "square", "duration": 1.0, "n_pulses": 0,
+            "interval_type": "user",
+            "onset": onset_times[0],
+            "intervals": onset_times_to_intervals(onset_times),
+        })
+        p.waveform(200, 0.0, 1.0, 0)
+        for got, exp in zip(p._last_onset_times, onset_times):
+            self.assertAlmostEqual(got, exp)
+        self.assertEqual(len(p._last_onset_times), len(onset_times))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `intervals` numpy array property to `NMPulse` for explicit per-pulse timing
- N intervals → N+1 pulses: `onset` fires the first pulse; each element of
  `intervals` steps to the next
- Adds `onset_times_to_intervals()` helper to convert absolute onset times to
  the intervals format: `p.onset = times[0]; p.intervals = onset_times_to_intervals(times)`
- `interval`, `interval_stdv`, `interval_min`, and `interval_max` are ignored
  when `interval_type='user'`
- `n_pulses` (if > 0) and `train_duration` still cap the count
- Note in `_note_str()` reports `intervals=<len=N>` instead of `interval=X`

## Test plan

- [ ] `TestNMPulseUserIntervals` — property validation, pulse count (N+1 convention),
  onset timing, n_pulses cap, train_duration cap, ignored params, config/dict round-trip,
  tool output count, note string
- [ ] `TestOnsetTimesToIntervals` — basic conversion, round-trip with `waveform()`,
  error cases (< 2 times, non-strictly-increasing)
- [ ] All 323 existing tests pass

Closes #317
