### PR TITLE
feat(analysis): add synexp pulse shape with sigmoidal rise and exponential decay

### DIFF
--- a/pyneuromatic/analysis/nm_pulse.py
+++ b/pyneuromatic/analysis/nm_pulse.py
@@ -48,7 +48,7 @@ _FLOAT_ATTRS: tuple[str, ...] = (
 
 # Keys that belong to the NMPulseFunc subclass, not to NMPulse directly.
 _FUNC_ONLY_KEYS: frozenset[str] = frozenset({
-    "tau", "freq", "phase", "f0", "f1", "data", "data_xdelta",
+    "tau", "tau_rise", "tau_decay", "power", "freq", "phase", "f0", "f1", "data", "data_xdelta",
 })
 
 _VALID_INTERVAL_TYPES: frozenset[str] = frozenset({"fixed", "gaussian", "poisson", "user"})

--- a/pyneuromatic/analysis/nm_pulse_func.py
+++ b/pyneuromatic/analysis/nm_pulse_func.py
@@ -28,7 +28,7 @@ import pyneuromatic.core.nm_utilities as nmu
 
 _VALID_SHAPES: frozenset[str] = frozenset({
     "square", "ramp+", "ramp-", "exp", "alpha",
-    "sin", "sinzap", "user",
+    "sin", "sinzap", "synexp", "user",
 })
 
 
@@ -369,6 +369,93 @@ class NMPulseFuncSinZap(NMPulseFunc):
         return y
 
 
+class NMPulseFuncSynExp(NMPulseFunc):
+    """Synaptic exponential pulse with sigmoidal rise and exponential decay.
+
+    Models a synaptic conductance or current waveform:
+
+        y = amp * (1 - exp(-(x-onset)/tau_rise))^power * exp(-(x-onset)/tau)
+                / peak_scale
+
+    The waveform is normalised so that ``amp`` is the actual peak amplitude.
+    The peak occurs at:
+
+        t_peak = tau_rise * ln(1 + power * tau / tau_rise)
+
+    With ``duration=inf`` (default) the waveform decays naturally to zero.
+    Set ``duration`` to hard-clip at ``onset + duration``.
+
+    Multiple ``synexp`` components with the same ``tau_rise`` and ``power``
+    but different ``amp``/``tau`` values can be combined via
+    :class:`~pyneuromatic.analysis.nm_pulse.NMPulseContainer` to produce
+    bi- or tri-exponential synaptic waveforms.
+
+    Args:
+        name: Must be ``"synexp"``.
+        tau_rise: Rise time constant (> 0). Default 1.0.
+        tau: Decay time constant (> 0). Default 10.0.
+        power: Rise exponent (> 0). Default 1.0.
+    """
+
+    _VALID_KEYS: frozenset[str] = frozenset({"tau_rise", "tau_decay", "power"})
+
+    def __init__(
+        self,
+        name: str = "synexp",
+        tau_rise: float = 1.0,
+        tau_decay: float = 10.0,
+        power: float = 1.0,
+    ) -> None:
+        if name != "synexp":
+            raise ValueError("name must be 'synexp', got %r" % name)
+        tau_rise, tau_decay, power = _validate_tau_rise_tau_power(tau_rise, tau_decay, power)
+        super().__init__(name)
+        self._tau_rise: float = tau_rise
+        self._tau_decay: float = tau_decay
+        self._power: float = power
+
+    @property
+    def tau_rise(self) -> float:
+        """Rise time constant."""
+        return self._tau_rise
+
+    @property
+    def tau_decay(self) -> float:
+        """Decay time constant."""
+        return self._tau_decay
+
+    @property
+    def power(self) -> float:
+        """Rise exponent."""
+        return self._power
+
+    def to_dict(self) -> dict:
+        return {
+            "pulse": self._name,
+            "tau_rise": self._tau_rise,
+            "tau_decay": self._tau_decay,
+            "power": self._power,
+        }
+
+    def waveform(self, n_points, xstart, xdelta, amp, onset, duration, **_):
+        x, y, mask = self._build_masked_x(n_points, xstart, xdelta, onset, duration)
+        if not np.any(mask):
+            return y
+        # Normalise so that amp equals the actual peak amplitude.
+        # At the peak: u = exp(-t_peak/tau_rise) = tau_rise / (tau_rise + power*tau_decay)
+        u = self._tau_rise / (self._tau_rise + self._power * self._tau_decay)
+        peak_scale = (1.0 - u) ** self._power * u ** (self._tau_rise / self._tau_decay)
+        if peak_scale == 0.0:
+            return y
+        t = x[mask] - onset
+        y[mask] = (
+            (amp / peak_scale)
+            * (1.0 - np.exp(-t / self._tau_rise)) ** self._power
+            * np.exp(-t / self._tau_decay)
+        )
+        return y
+
+
 class NMPulseFuncUser(NMPulseFunc):
     """User-supplied waveform pulse.
 
@@ -453,6 +540,22 @@ class NMPulseFuncUser(NMPulseFunc):
 # =========================================================================
 
 
+def _validate_tau_rise_tau_power(
+    tau_rise: float, tau_decay: float, power: float
+) -> tuple[float, float, float]:
+    for attr, val in (("tau_rise", tau_rise), ("tau_decay", tau_decay), ("power", power)):
+        if isinstance(val, bool) or not isinstance(val, (int, float)):
+            raise TypeError(nmu.type_error_str(val, attr, "float"))
+    tau_rise, tau_decay, power = float(tau_rise), float(tau_decay), float(power)
+    if tau_rise <= 0:
+        raise ValueError("tau_rise must be > 0, got %s" % tau_rise)
+    if tau_decay <= 0:
+        raise ValueError("tau_decay must be > 0, got %s" % tau_decay)
+    if power <= 0:
+        raise ValueError("power must be > 0, got %s" % power)
+    return tau_rise, tau_decay, power
+
+
 def _validate_freq_phase(freq: float, phase: float) -> tuple[float, float]:
     if isinstance(freq, bool) or not isinstance(freq, (int, float)):
         raise TypeError(nmu.type_error_str(freq, "freq", "float"))
@@ -483,14 +586,15 @@ def _validate_f0_f1(f0: float, f1: float) -> tuple[float, float]:
 # =========================================================================
 
 _PULSE_FUNC_REGISTRY: dict[str, type[NMPulseFunc]] = {
-    "square": NMPulseFuncSquare,
-    "ramp+":  NMPulseFuncRamp,
-    "ramp-":  NMPulseFuncRamp,
-    "exp":    NMPulseFuncExp,
-    "alpha":  NMPulseFuncAlpha,
-    "sin":    NMPulseFuncSin,
-    "sinzap": NMPulseFuncSinZap,
-    "user":   NMPulseFuncUser,
+    "square":  NMPulseFuncSquare,
+    "ramp+":   NMPulseFuncRamp,
+    "ramp-":   NMPulseFuncRamp,
+    "exp":     NMPulseFuncExp,
+    "alpha":   NMPulseFuncAlpha,
+    "sin":     NMPulseFuncSin,
+    "sinzap":  NMPulseFuncSinZap,
+    "synexp":  NMPulseFuncSynExp,
+    "user":    NMPulseFuncUser,
 }
 
 

--- a/pyneuromatic/analysis/nm_tool_pulse.py
+++ b/pyneuromatic/analysis/nm_tool_pulse.py
@@ -296,7 +296,7 @@ class NMToolPulse(NMTool):
             parts.append("onset=%g" % p.onset)
             if not math.isinf(p.duration):
                 parts.append("duration=%g" % p.duration)
-            for key in ("tau", "freq", "phase", "f0", "f1"):
+            for key in ("tau", "tau_rise", "tau_decay", "power", "freq", "phase", "f0", "f1"):
                 if key in d:
                     parts.append("%s=%g" % (key, d[key]))
             if p.n_pulses != 1 or not math.isinf(p.train_duration):

--- a/tests/test_analysis/test_nm_tool_pulse.py
+++ b/tests/test_analysis/test_nm_tool_pulse.py
@@ -2700,6 +2700,182 @@ class TestNMPulseUserIntervals(unittest.TestCase):
         self.assertIn("intervals=<len=3>", note_text)
 
 
+class TestNMPulseFuncSynExp(unittest.TestCase):
+    """Tests for NMPulseFuncSynExp waveform shape."""
+
+    # ------------------------------------------------------------------
+    # Construction and parameter validation
+
+    def test_default_params(self):
+        p = NMPulse(config={"pulse": "synexp"})
+        self.assertEqual(p.func.name, "synexp")
+        self.assertAlmostEqual(p.func.tau_rise, 1.0)
+        self.assertAlmostEqual(p.func.tau_decay, 10.0)
+        self.assertAlmostEqual(p.func.power, 1.0)
+
+    def test_custom_params(self):
+        p = NMPulse(config={"pulse": "synexp", "tau_rise": 2.0, "tau_decay": 20.0, "power": 2.0})
+        self.assertAlmostEqual(p.func.tau_rise, 2.0)
+        self.assertAlmostEqual(p.func.tau_decay, 20.0)
+        self.assertAlmostEqual(p.func.power, 2.0)
+
+    def test_tau_rise_zero_raises(self):
+        with self.assertRaises(ValueError):
+            NMPulse(config={"pulse": "synexp", "tau_rise": 0.0})
+
+    def test_tau_decay_zero_raises(self):
+        with self.assertRaises(ValueError):
+            NMPulse(config={"pulse": "synexp", "tau_decay": 0.0})
+
+    def test_power_zero_raises(self):
+        with self.assertRaises(ValueError):
+            NMPulse(config={"pulse": "synexp", "power": 0.0})
+
+    def test_tau_rise_bool_raises(self):
+        with self.assertRaises(TypeError):
+            NMPulse(config={"pulse": "synexp", "tau_rise": True})
+
+    def test_to_dict_round_trip(self):
+        p = NMPulse(config={"pulse": "synexp", "tau_rise": 2.0, "tau_decay": 15.0, "power": 3.0})
+        d = p.to_dict()
+        self.assertEqual(d["pulse"], "synexp")
+        self.assertAlmostEqual(d["tau_rise"], 2.0)
+        self.assertAlmostEqual(d["tau_decay"], 15.0)
+        self.assertAlmostEqual(d["power"], 3.0)
+        p2 = NMPulse.from_dict(d)
+        self.assertAlmostEqual(p2.func.tau_rise, 2.0)
+        self.assertAlmostEqual(p2.func.tau_decay, 15.0)
+        self.assertAlmostEqual(p2.func.power, 3.0)
+
+    # ------------------------------------------------------------------
+    # Waveform properties
+
+    def test_waveform_zero_before_onset(self):
+        p = NMPulse(config={"pulse": "synexp", "onset": 10.0, "tau_rise": 1.0, "tau_decay": 10.0})
+        y = p.waveform(100, 0.0, 1.0, 0)
+        self.assertTrue(np.all(y[:10] == 0.0))
+
+    def test_waveform_zero_at_onset(self):
+        # synexp starts at 0 at t=onset (rise term = 0 there)
+        p = NMPulse(config={"pulse": "synexp", "onset": 10.0, "tau_rise": 1.0, "tau_decay": 10.0})
+        y = p.waveform(100, 0.0, 1.0, 0)
+        self.assertAlmostEqual(y[10], 0.0, places=10)
+
+    def test_peak_equals_amp(self):
+        # Normalization makes amp the actual peak
+        amp = 5.0
+        p = NMPulse(config={
+            "pulse": "synexp", "amp": amp, "onset": 0.0,
+            "tau_rise": 1.0, "tau_decay": 10.0, "power": 1.0,
+        })
+        y = p.waveform(1000, 0.0, 0.1, 0)
+        self.assertAlmostEqual(float(np.max(y)), amp, delta=amp * 0.01)
+
+    def test_peak_equals_amp_power2(self):
+        amp = 3.0
+        p = NMPulse(config={
+            "pulse": "synexp", "amp": amp, "onset": 0.0,
+            "tau_rise": 2.0, "tau_decay": 20.0, "power": 2.0,
+        })
+        y = p.waveform(2000, 0.0, 0.1, 0)
+        self.assertAlmostEqual(float(np.max(y)), amp, delta=amp * 0.01)
+
+    def test_peak_time(self):
+        # Analytic peak time: t_peak = tau_rise * ln(1 + power*tau_decay/tau_rise)
+        tau_rise, tau_decay, power = 1.0, 10.0, 1.0
+        t_peak_expected = tau_rise * math.log(1.0 + power * tau_decay / tau_rise)
+        p = NMPulse(config={
+            "pulse": "synexp", "amp": 1.0, "onset": 0.0,
+            "tau_rise": tau_rise, "tau_decay": tau_decay, "power": power,
+
+        })
+        y = p.waveform(1000, 0.0, 0.1, 0)
+        t_peak_measured = float(np.argmax(y)) * 0.1
+        self.assertAlmostEqual(t_peak_measured, t_peak_expected, delta=0.15)
+
+    def test_waveform_decays_after_peak(self):
+        p = NMPulse(config={"pulse": "synexp", "onset": 0.0, "tau_rise": 1.0, "tau_decay": 10.0})
+        y = p.waveform(500, 0.0, 0.1, 0)
+        peak_idx = int(np.argmax(y))
+        # Waveform should be declining after the peak
+        self.assertGreater(y[peak_idx], y[peak_idx + 20])
+
+    def test_duration_clips_waveform(self):
+        p = NMPulse(config={
+            "pulse": "synexp", "onset": 5.0, "duration": 10.0,
+            "tau_rise": 1.0, "tau_decay": 50.0,
+        })
+        y = p.waveform(200, 0.0, 1.0, 0)
+        # Beyond onset + duration the waveform should be zero
+        self.assertAlmostEqual(y[16], 0.0)
+        self.assertAlmostEqual(y[100], 0.0)
+
+    def test_inf_duration_does_not_clip(self):
+        p = NMPulse(config={
+            "pulse": "synexp", "onset": 5.0,
+            "tau_rise": 1.0, "tau_decay": 50.0,
+        })
+        y = p.waveform(200, 0.0, 1.0, 0)
+        # Well past the peak there should still be residual signal
+        self.assertGreater(y[100], 0.0)
+
+    def test_faster_rise_shifts_peak_earlier(self):
+        # Smaller tau_rise → earlier peak
+        p_slow = NMPulse(config={"pulse": "synexp", "onset": 0.0, "tau_rise": 5.0, "tau_decay": 20.0})
+        p_fast = NMPulse(config={"pulse": "synexp", "onset": 0.0, "tau_rise": 1.0, "tau_decay": 20.0})
+        y_slow = p_slow.waveform(1000, 0.0, 0.1, 0)
+        y_fast = p_fast.waveform(1000, 0.0, 0.1, 0)
+        self.assertLess(np.argmax(y_fast), np.argmax(y_slow))
+
+    def test_higher_power_shifts_peak_later(self):
+        # Higher power → later, sharper rise → peak shifts later
+        p1 = NMPulse(config={"pulse": "synexp", "onset": 0.0, "tau_rise": 1.0, "tau_decay": 20.0, "power": 1.0})
+        p2 = NMPulse(config={"pulse": "synexp", "onset": 0.0, "tau_rise": 1.0, "tau_decay": 20.0, "power": 4.0})
+        y1 = p1.waveform(1000, 0.0, 0.1, 0)
+        y2 = p2.waveform(1000, 0.0, 0.1, 0)
+        self.assertLess(np.argmax(y1), np.argmax(y2))
+
+    # ------------------------------------------------------------------
+    # NMToolPulse integration
+
+    def test_tool_note_contains_synexp_params(self):
+        t = NMToolPulse()
+        t.n_points = 500
+        t.xstart = 0.0
+        t.xdelta = 0.1
+        t.pulses.new({"pulse": "synexp", "amp": 1.0, "onset": 5.0,
+                      "tau_rise": 2.0, "tau_decay": 20.0, "power": 2.0})
+        folder = _run_tool(t, [_make_empty_data("w0", n=500)])
+        note_text = folder.data["PG_0"].notes.note
+        self.assertIn("synexp", note_text)
+        self.assertIn("tau_rise=2", note_text)
+        self.assertIn("tau_decay=20", note_text)
+        self.assertIn("power=2", note_text)
+
+    def test_biexponential_via_two_pulses(self):
+        # Two synexp components with different tau_decay give a bi-exponential EPSC
+        t = NMToolPulse()
+        t.n_points = 1000
+        t.xstart = 0.0
+        t.xdelta = 0.1
+        t.pulses.new({"pulse": "synexp", "amp": 1.0, "onset": 5.0,
+                      "tau_rise": 0.5, "tau_decay": 5.0})
+        t.pulses.new({"pulse": "synexp", "amp": 0.5, "onset": 5.0,
+                      "tau_rise": 0.5, "tau_decay": 50.0})
+        folder = _run_tool(t, [_make_empty_data("w0", n=1000)])
+        y = folder.data["PG_0"].nparray
+        # Sum of two synexp should peak above the larger component alone
+        t2 = NMToolPulse()
+        t2.n_points = 1000
+        t2.xstart = 0.0
+        t2.xdelta = 0.1
+        t2.pulses.new({"pulse": "synexp", "amp": 1.0, "onset": 5.0,
+                       "tau_rise": 0.5, "tau_decay": 5.0})
+        folder2 = _run_tool(t2, [_make_empty_data("w0", n=1000)])
+        y2 = folder2.data["PG_0"].nparray
+        self.assertGreater(float(np.max(y)), float(np.max(y2)))
+
+
 class TestOnsetTimesToIntervals(unittest.TestCase):
 
     def test_basic(self):


### PR DESCRIPTION
## Summary

- Adds `NMPulseFuncSynExp` pulse shape (`"synexp"`) to the pulse shape library
- Formula: `y = amp * (1 - exp(-t/tau_rise))^power * exp(-t/tau_decay) / peak_scale`
- Normalised so `amp` is the actual peak amplitude; peak time is analytic:
  `t_peak = tau_rise * ln(1 + power * tau_decay / tau_rise)`
- Parameters: `tau_rise=1.0`, `tau_decay=10.0`, `power=1.0`
- `duration=inf` (default) lets the waveform decay naturally; finite `duration`
  hard-clips at `onset + duration`
- Multi-exponential synaptic waveforms (e.g. AMPA + NMDA) are composed by
  summing synexp components via `NMPulseContainer` with different `amp`/`tau_decay`

## Test plan

- [ ] `TestNMPulseFuncSynExp` — construction, parameter validation, `to_dict` round-trip,
  waveform zero before/at onset, peak equals `amp` (power=1 and power=2),
  analytic peak time, decay after peak, duration clipping, infinite duration,
  faster rise shifts peak earlier, higher power shifts peak later
- [ ] Tool integration — note string contains `tau_rise`, `tau_decay`, `power`
- [ ] Bi-exponential via two `synexp` pulses
- [ ] All 342 existing tests pass

Closes #316
