### PR TITLE
feat(tools): add NMModelHH and NMToolModel with NMPulse current injection

### DIFF
--- a/pyneuromatic/__init__.py
+++ b/pyneuromatic/__init__.py
@@ -20,7 +20,7 @@ try:
     
     # Make submodules accessible
     from . import core
-    from . import analysis
+    from . import tools
     
     __all__ = [
         '__version__',
@@ -32,7 +32,7 @@ try:
         'NMData',
         # Submodules
         'core',
-        'analysis',
+        'tools',
     ]
 
 except ImportError as e:

--- a/pyneuromatic/tools/__init__.py
+++ b/pyneuromatic/tools/__init__.py
@@ -1,4 +1,13 @@
 # -*- coding: utf-8 -*-
+from pyneuromatic.tools.nm_conductance import (
+    NMConductance,
+    NMConductanceLeak,
+    NMConductanceHHNa,
+    NMConductanceHHK,
+    NMConductanceContainer,
+)
+from pyneuromatic.tools.nm_model import NMModel, NMModelHH
+from pyneuromatic.tools.nm_tool_model import NMToolModel, NMToolModelConfig
 from pyneuromatic.tools.nm_tool_event import NMToolEvent, NMToolEventConfig
 from pyneuromatic.tools.nm_tool_fit import NMToolFit, NMToolFitConfig
 from pyneuromatic.tools.nm_tool_main import NMToolMain

--- a/pyneuromatic/tools/nm_conductance.py
+++ b/pyneuromatic/tools/nm_conductance.py
@@ -1,0 +1,363 @@
+# -*- coding: utf-8 -*-
+"""
+NMConductance: ion channel conductance classes for neural ODE models.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import math
+import numpy as np
+
+
+class NMConductance:
+    """Base class for ion channel conductance models.
+
+    Subclasses implement specific channel kinetics (gating variables,
+    alpha/beta rate functions). Each conductance is parameterised by its
+    maximum conductance density (``g_density``, nS/µm²) and reversal
+    potential (``e_rev``, mV).
+
+    Units used throughout:
+        - conductance density: nS/µm²
+        - reversal potential:  mV
+        - current density:     pA/µm²  (nS/µm² × mV = pA/µm²)
+        - current:             pA      (multiply density by surface area µm²)
+    """
+
+    def __init__(self, name: str, g_density: float, e_rev: float) -> None:
+        if not isinstance(name, str) or not name:
+            raise ValueError("name must be a non-empty string")
+        if isinstance(g_density, bool) or not isinstance(g_density, (int, float)):
+            raise TypeError("g_density must be a float")
+        if g_density < 0:
+            raise ValueError("g_density must be >= 0, got %g" % g_density)
+        if isinstance(e_rev, bool) or not isinstance(e_rev, (int, float)):
+            raise TypeError("e_rev must be a float")
+        self._name = name
+        self._g_density = float(g_density)
+        self._e_rev = float(e_rev)
+
+    @property
+    def name(self) -> str:
+        """Conductance type name (read-only)."""
+        return self._name
+
+    @property
+    def g_density(self) -> float:
+        """Maximum conductance density in nS/µm²."""
+        return self._g_density
+
+    @g_density.setter
+    def g_density(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("g_density must be a float")
+        if value < 0:
+            raise ValueError("g_density must be >= 0, got %g" % value)
+        self._g_density = float(value)
+
+    @property
+    def e_rev(self) -> float:
+        """Reversal potential in mV."""
+        return self._e_rev
+
+    @e_rev.setter
+    def e_rev(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("e_rev must be a float")
+        self._e_rev = float(value)
+
+    # ------------------------------------------------------------------
+    # Channel interface — override in subclasses
+
+    def n_states(self) -> int:
+        """Number of gating variables (0 for ohmic leak)."""
+        return 0
+
+    def gate_names(self) -> list[str]:
+        """Names of gating variables in order (e.g. ['m', 'h'] for Na)."""
+        return []
+
+    def state_init(self, V: float) -> list[float]:
+        """Steady-state gating variable values at membrane voltage V (mV)."""
+        return []
+
+    def current(self, V: float, states: list[float]) -> float:
+        """Conductance current density in pA/µm² at voltage V (mV).
+
+        Multiply by surface area (µm²) to get current in pA.
+        """
+        return self._g_density * (V - self._e_rev)
+
+    def dydt(self, V: float, states: list[float]) -> list[float]:
+        """Gate variable derivatives at the HH reference temperature (6.3°C)."""
+        return []
+
+    def dydt_scaled(self, V: float, states: list[float], q10: float) -> list[float]:
+        """Gate variable derivatives scaled by Q10 temperature factor."""
+        return [r * q10 for r in self.dydt(V, states)]
+
+    # ------------------------------------------------------------------
+    # Serialisation
+
+    def to_dict(self) -> dict:
+        return {
+            "conductance": self._name,
+            "g_density": self._g_density,
+            "e_rev": self._e_rev,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "NMConductance":
+        return _conductance_from_dict(d)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, NMConductance):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+    def __repr__(self) -> str:
+        return "%s(g_density=%g, e_rev=%g)" % (
+            self.__class__.__name__,
+            self._g_density,
+            self._e_rev,
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Concrete conductances
+# ──────────────────────────────────────────────────────────────────────────────
+
+class NMConductanceLeak(NMConductance):
+    """Ohmic leak conductance (no gating variables).
+
+    I_L = g_density * (V − e_rev)
+
+    Default values match Hodgkin & Huxley (1952):
+        g_density = 0.003 nS/µm²  (= 0.3 mS/cm²)
+        e_rev     = −54.387 mV  (= −65 + 10.613, the exact HH 1952 value)
+    """
+
+    def __init__(self, g_density: float = 0.003, e_rev: float = -54.387) -> None:
+        super().__init__("leak", g_density, e_rev)
+
+
+class NMConductanceHHNa(NMConductance):
+    """Hodgkin–Huxley sodium channel (m³h gating).
+
+    I_Na = g_density * m³ * h * (V − e_rev)
+
+    Rate functions from Hodgkin & Huxley (1952), shifted to
+    V_rest = −65 mV convention.
+
+    Default values:
+        g_density = 1.2  nS/µm²  (= 120 mS/cm²)
+        e_rev     = 50.0 mV
+    """
+
+    def __init__(self, g_density: float = 1.2, e_rev: float = 50.0) -> None:
+        super().__init__("hhna", g_density, e_rev)
+
+    def n_states(self) -> int:
+        return 2
+
+    def gate_names(self) -> list[str]:
+        return ["m", "h"]
+
+    def state_init(self, V: float) -> list[float]:
+        am, bm = self._alpha_m(V), self._beta_m(V)
+        ah, bh = self._alpha_h(V), self._beta_h(V)
+        m_inf = am / (am + bm)
+        h_inf = ah / (ah + bh)
+        return [m_inf, h_inf]
+
+    def current(self, V: float, states: list[float]) -> float:
+        m, h = states
+        return self._g_density * (m ** 3) * h * (V - self._e_rev)
+
+    def dydt(self, V: float, states: list[float]) -> list[float]:
+        m, h = states
+        dm = self._alpha_m(V) * (1.0 - m) - self._beta_m(V) * m
+        dh = self._alpha_h(V) * (1.0 - h) - self._beta_h(V) * h
+        return [dm, dh]
+
+    def to_dict(self) -> dict:
+        return {"conductance": "hhna", "g_density": self._g_density, "e_rev": self._e_rev}
+
+    # ------------------------------------------------------------------
+    # Rate functions (HH 1952, V_rest = −65 mV convention)
+
+    @staticmethod
+    def _alpha_m(V: float) -> float:
+        dv = V + 40.0
+        if abs(dv) < 1e-7:
+            return 1.0
+        return 0.1 * dv / (1.0 - math.exp(-dv / 10.0))
+
+    @staticmethod
+    def _beta_m(V: float) -> float:
+        return 4.0 * math.exp(-(V + 65.0) / 18.0)
+
+    @staticmethod
+    def _alpha_h(V: float) -> float:
+        return 0.07 * math.exp(-(V + 65.0) / 20.0)
+
+    @staticmethod
+    def _beta_h(V: float) -> float:
+        return 1.0 / (1.0 + math.exp(-(V + 35.0) / 10.0))
+
+
+class NMConductanceHHK(NMConductance):
+    """Hodgkin–Huxley delayed-rectifier potassium channel (n⁴ gating).
+
+    I_K = g_density * n⁴ * (V − e_rev)
+
+    Rate functions from Hodgkin & Huxley (1952), shifted to
+    V_rest = −65 mV convention.
+
+    Default values:
+        g_density = 0.36 nS/µm²  (= 36 mS/cm²)
+        e_rev     = −77.0 mV
+    """
+
+    def __init__(self, g_density: float = 0.36, e_rev: float = -77.0) -> None:
+        super().__init__("hhk", g_density, e_rev)
+
+    def n_states(self) -> int:
+        return 1
+
+    def gate_names(self) -> list[str]:
+        return ["n"]
+
+    def state_init(self, V: float) -> list[float]:
+        an, bn = self._alpha_n(V), self._beta_n(V)
+        n_inf = an / (an + bn)
+        return [n_inf]
+
+    def current(self, V: float, states: list[float]) -> float:
+        (n,) = states
+        return self._g_density * (n ** 4) * (V - self._e_rev)
+
+    def dydt(self, V: float, states: list[float]) -> list[float]:
+        (n,) = states
+        dn = self._alpha_n(V) * (1.0 - n) - self._beta_n(V) * n
+        return [dn]
+
+    def to_dict(self) -> dict:
+        return {"conductance": "hhk", "g_density": self._g_density, "e_rev": self._e_rev}
+
+    # ------------------------------------------------------------------
+    # Rate functions
+
+    @staticmethod
+    def _alpha_n(V: float) -> float:
+        dv = V + 55.0
+        if abs(dv) < 1e-7:
+            return 0.1
+        return 0.01 * dv / (1.0 - math.exp(-dv / 10.0))
+
+    @staticmethod
+    def _beta_n(V: float) -> float:
+        return 0.125 * math.exp(-(V + 65.0) / 80.0)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Container
+# ──────────────────────────────────────────────────────────────────────────────
+
+class NMConductanceContainer:
+    """Ordered collection of named :class:`NMConductance` objects.
+
+    Analogous to :class:`~pyneuromatic.tools.nm_pulse.NMPulseContainer`.
+    """
+
+    def __init__(self, nm_path: str = "model.conductances") -> None:
+        self._conductances: dict[str, NMConductance] = {}
+        self._nm_path = nm_path
+
+    def add(self, name: str, conductance: NMConductance) -> NMConductance:
+        """Add a named conductance, replacing any existing entry with the same name."""
+        if not isinstance(name, str) or not name:
+            raise ValueError("name must be a non-empty string")
+        if not isinstance(conductance, NMConductance):
+            raise TypeError("conductance must be an NMConductance instance")
+        self._conductances[name] = conductance
+        return conductance
+
+    def __getitem__(self, name: str) -> NMConductance:
+        return self._conductances[name]
+
+    def __iter__(self):
+        return iter(self._conductances.items())
+
+    def __len__(self) -> int:
+        return len(self._conductances)
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._conductances
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, NMConductanceContainer):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+    def to_dict(self) -> dict:
+        return {
+            "conductances": [
+                {"name": name, **cond.to_dict()}
+                for name, cond in self._conductances.items()
+            ]
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict, nm_path: str = "model.conductances") -> "NMConductanceContainer":
+        container = cls(nm_path=nm_path)
+        for entry in d.get("conductances", []):
+            entry = dict(entry)
+            name = entry.pop("name")
+            cond = _conductance_from_dict(entry)
+            container.add(name, cond)
+        return container
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Registry and factory
+# ──────────────────────────────────────────────────────────────────────────────
+
+_CONDUCTANCE_REGISTRY: dict[str, type[NMConductance]] = {
+    "leak": NMConductanceLeak,
+    "hhna": NMConductanceHHNa,
+    "hhk":  NMConductanceHHK,
+}
+
+
+def _conductance_from_dict(d: dict) -> NMConductance:
+    """Construct an :class:`NMConductance` from a ``to_dict()`` dictionary."""
+    d = dict(d)
+    ctype = d.pop("conductance", None)
+    if ctype not in _CONDUCTANCE_REGISTRY:
+        raise KeyError(
+            "unknown conductance type %r; valid types: %s"
+            % (ctype, sorted(_CONDUCTANCE_REGISTRY))
+        )
+    cls = _CONDUCTANCE_REGISTRY[ctype]
+    kwargs: dict = {}
+    if "g_density" in d:
+        kwargs["g_density"] = d["g_density"]
+    if "e_rev" in d:
+        kwargs["e_rev"] = d["e_rev"]
+    return cls(**kwargs)

--- a/pyneuromatic/tools/nm_model.py
+++ b/pyneuromatic/tools/nm_model.py
@@ -1,0 +1,402 @@
+# -*- coding: utf-8 -*-
+"""
+NMModel: neural ODE model classes.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import math
+import numpy as np
+
+from pyneuromatic.tools.nm_conductance import (
+    NMConductanceLeak,
+    NMConductanceHHNa,
+    NMConductanceHHK,
+    NMConductanceContainer,
+    _conductance_from_dict,
+)
+
+
+class NMModel:
+    """Abstract base class for neural simulation models.
+
+    Subclasses implement :meth:`simulate` for a specific model type
+    (e.g. Hodgkin–Huxley, integrate-and-fire).
+
+    Common parameters:
+        v0:          Resting membrane potential (mV).  Default −65.0.
+        temperature: Simulation temperature (°C).     Default 6.3.
+    """
+
+    def __init__(
+        self,
+        name: str = "model",
+        config: dict | None = None,
+        nm_path: str = "model",
+    ) -> None:
+        self._name = name
+        self._nm_path = nm_path
+        self._v0: float = -65.0
+        self._temperature: float = 6.3   # HH reference temperature (Hodgkin & Huxley 1952)
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def v0(self) -> float:
+        """Resting membrane potential (mV)."""
+        return self._v0
+
+    @v0.setter
+    def v0(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("v0 must be a float")
+        self._v0 = float(value)
+
+    @property
+    def temperature(self) -> float:
+        """Simulation temperature (°C)."""
+        return self._temperature
+
+    @temperature.setter
+    def temperature(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("temperature must be a float")
+        self._temperature = float(value)
+
+    def simulate(
+        self,
+        n_points: int,
+        xstart: float,
+        xdelta: float,
+        i_ext: np.ndarray,
+    ) -> dict[str, np.ndarray]:
+        """Run a simulation and return state variable trajectories.
+
+        Args:
+            n_points: Number of time points.
+            xstart:   Start time (ms).
+            xdelta:   Time step (ms).
+            i_ext:    External current waveform (pA), length ``n_points``.
+
+        Returns:
+            Dictionary mapping variable names to 1-D arrays of length
+            ``n_points``.  Always contains ``"V"`` (mV).
+        """
+        raise NotImplementedError
+
+    def to_dict(self) -> dict:
+        raise NotImplementedError
+
+    @classmethod
+    def from_dict(cls, d: dict, nm_path: str = "model") -> "NMModel":
+        return _model_from_dict(d, nm_path=nm_path)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, NMModel):
+            return NotImplemented
+        return self.to_dict() == other.to_dict()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Hodgkin–Huxley model
+# ──────────────────────────────────────────────────────────────────────────────
+
+class NMModelHH(NMModel):
+    """Hodgkin–Huxley point-neuron model.
+
+    Integrates the HH ODE system using
+    :func:`scipy.integrate.solve_ivp` (RK45 by default).
+
+    The neuron is modelled as a sphere.  Conductance densities are specified
+    per unit area (nS/µm²); currents are scaled by the surface area before
+    entering the ODE.
+
+    Parameters:
+        v0:          Resting potential (mV).              Default −65.0.
+        temperature: Simulation temperature (°C).          Default 6.3.
+        cm_density:  Specific membrane capacitance
+                     (pF/µm²; 0.01 pF/µm² = 1 µF/cm²).   Default 0.01.
+        diameter:    Cell diameter (µm).                   Default √(1200/π) ≈ 19.544
+                     (gives SA = 1200 µm², Cm = 12 pF).
+        tau_q10:     Q10 factor for HH rate constants.
+                     Applied as ``tau_q10^((T − 6.3) / 10)``. Default 3.0.
+
+    The default conductance set matches Hodgkin & Huxley (1952):
+        Leak  g=0.003 nS/µm²  E=−54.4 mV
+        Na    g=1.2   nS/µm²  E= 50.0 mV
+        K     g=0.36  nS/µm²  E=−77.0 mV
+
+    Units summary:
+        time:        ms
+        voltage:     mV
+        current:     pA
+        capacitance: pF  → dV/dt in mV/ms  (pA/pF = mV/ms)
+    """
+
+    _T_REF: float = 6.3  # °C, HH reference temperature
+    # SA = π × d² = 1200 µm²  →  Cm = 0.01 × 1200 = 12 pF (round values)
+    _DEFAULT_DIAMETER: float = math.sqrt(1200.0 / math.pi)
+
+    def __init__(
+        self,
+        name: str = "hh",
+        config: dict | None = None,
+        nm_path: str = "model",
+    ) -> None:
+        super().__init__(name=name, nm_path=nm_path)
+        self._cm_density: float = 0.01                    # pF/µm²
+        self._diameter: float = self._DEFAULT_DIAMETER    # µm
+        self._tau_q10: float = 3.0
+
+        self._conductances = NMConductanceContainer(
+            nm_path=nm_path + ".conductances"
+        )
+        self._conductances.add("Leak", NMConductanceLeak())
+        self._conductances.add("Na",   NMConductanceHHNa())
+        self._conductances.add("K",    NMConductanceHHK())
+
+        if config is not None:
+            self._config_set(config, quiet=True)
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def cm_density(self) -> float:
+        """Specific membrane capacitance (pF/µm²)."""
+        return self._cm_density
+
+    @cm_density.setter
+    def cm_density(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("cm_density must be a float")
+        if value <= 0:
+            raise ValueError("cm_density must be > 0, got %g" % value)
+        self._cm_density = float(value)
+
+    @property
+    def diameter(self) -> float:
+        """Cell diameter (µm)."""
+        return self._diameter
+
+    @diameter.setter
+    def diameter(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("diameter must be a float")
+        if value <= 0:
+            raise ValueError("diameter must be > 0, got %g" % value)
+        self._diameter = float(value)
+
+    @property
+    def tau_q10(self) -> float:
+        """Q10 factor applied to HH rate constants."""
+        return self._tau_q10
+
+    @tau_q10.setter
+    def tau_q10(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("tau_q10 must be a float")
+        if value <= 0:
+            raise ValueError("tau_q10 must be > 0, got %g" % value)
+        self._tau_q10 = float(value)
+
+    @property
+    def conductances(self) -> NMConductanceContainer:
+        """The conductance container (Leak, Na, K by default)."""
+        return self._conductances
+
+    # ------------------------------------------------------------------
+    # Derived quantities
+
+    def _surface_area(self) -> float:
+        """Sphere surface area in µm²: π × diameter²."""
+        return math.pi * self._diameter ** 2
+
+    def _capacitance(self) -> float:
+        """Total membrane capacitance in pF."""
+        return self._cm_density * self._surface_area()
+
+    def _q10_factor(self) -> float:
+        """Temperature scaling factor for HH rate constants."""
+        return self._tau_q10 ** ((self._temperature - self._T_REF) / 10.0)
+
+    # ------------------------------------------------------------------
+    # Simulation
+
+    def simulate(
+        self,
+        n_points: int,
+        xstart: float,
+        xdelta: float,
+        i_ext: np.ndarray,
+    ) -> dict[str, np.ndarray]:
+        """Integrate the HH ODE system.
+
+        Args:
+            n_points: Number of time samples.
+            xstart:   First time point (ms).
+            xdelta:   Time step (ms; also used as ``max_step`` for solve_ivp).
+            i_ext:    External current (pA), 1-D array of length ``n_points``.
+
+        Returns:
+            Dict with keys ``"V"`` (mV) plus one key per gate variable
+            (``"m"``, ``"h"``, ``"n"``), each a 1-D array of length
+            ``n_points``.
+        """
+        from scipy.integrate import solve_ivp
+
+        if n_points < 1:
+            raise ValueError("n_points must be >= 1")
+        if xdelta <= 0:
+            raise ValueError("xdelta must be > 0")
+        i_ext = np.asarray(i_ext, dtype=float)
+        if i_ext.shape != (n_points,):
+            raise ValueError("i_ext must have length n_points (%d)" % n_points)
+
+        SA = self._surface_area()
+        Cm = self._capacitance()
+        q10 = self._q10_factor()
+
+        t = np.linspace(xstart, xstart + (n_points - 1) * xdelta, n_points)
+
+        # Build state-vector offset map
+        # y[0] = V;  y[offset : offset+n_states] = gates for each conductance
+        offsets: dict[str, slice] = {}
+        offset = 1
+        for cname, cond in self._conductances:
+            ns = cond.n_states()
+            offsets[cname] = slice(offset, offset + ns)
+            offset += ns
+        n_y = offset
+
+        # Initial conditions: steady-state gates at v0
+        y0 = np.zeros(n_y)
+        y0[0] = self._v0
+        for cname, cond in self._conductances:
+            sl = offsets[cname]
+            init = cond.state_init(self._v0)
+            if init:
+                y0[sl] = init
+
+        def ode(t_val: float, y: np.ndarray) -> np.ndarray:
+            V = y[0]
+            dydt = np.zeros(n_y)
+            i_ionic = 0.0
+            for cname, cond in self._conductances:
+                sl = offsets[cname]
+                states = list(y[sl])
+                i_ionic += cond.current(V, states) * SA
+                scaled = cond.dydt_scaled(V, states, q10)
+                if scaled:
+                    dydt[sl] = scaled
+            t_idx = int((t_val - xstart) / xdelta)
+            t_idx = max(0, min(t_idx, n_points - 1))
+            dydt[0] = (i_ext[t_idx] - i_ionic) / Cm
+            return dydt
+
+        sol = solve_ivp(
+            fun=ode,
+            t_span=(t[0], t[-1]),
+            y0=y0,
+            method="RK45",
+            t_eval=t,
+            max_step=xdelta,
+            dense_output=False,
+        )
+
+        result: dict[str, np.ndarray] = {"V": sol.y[0]}
+        for cname, cond in self._conductances:
+            sl = offsets[cname]
+            for gate_idx, gate_name in enumerate(cond.gate_names()):
+                result[gate_name] = sol.y[sl.start + gate_idx]
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Config / serialisation
+
+    _SCALAR_KEYS = frozenset({"v0", "temperature", "cm_density", "diameter", "tau_q10"})
+
+    def _config_set(self, config: dict, quiet: bool = True) -> None:
+        """Apply a configuration dictionary (from ``to_dict()``)."""
+        for key, value in config.items():
+            if key == "model":
+                continue
+            if key == "conductances":
+                self._conductances = NMConductanceContainer.from_dict(
+                    {"conductances": value},
+                    nm_path=self._nm_path + ".conductances",
+                )
+            elif key in self._SCALAR_KEYS:
+                setattr(self, key, value)
+            else:
+                raise KeyError("unknown NMModelHH config key %r" % key)
+
+    def to_dict(self) -> dict:
+        d: dict = {
+            "model": "hh",
+            "v0": self._v0,
+            "temperature": self._temperature,
+            "cm_density": self._cm_density,
+            "diameter": self._diameter,
+            "tau_q10": self._tau_q10,
+        }
+        d["conductances"] = self._conductances.to_dict()["conductances"]
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict, nm_path: str = "model") -> "NMModelHH":
+        obj = cls(name=d.get("model", "hh"), nm_path=nm_path)
+        obj._config_set(d, quiet=True)
+        return obj
+
+    def __repr__(self) -> str:
+        return (
+            "NMModelHH(v0=%g, cm_density=%g, diameter=%g, "
+            "temperature=%g, tau_q10=%g, n_conductances=%d)"
+            % (
+                self._v0,
+                self._cm_density,
+                self._diameter,
+                self._temperature,
+                self._tau_q10,
+                len(self._conductances),
+            )
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Registry and factory
+# ──────────────────────────────────────────────────────────────────────────────
+
+_MODEL_REGISTRY: dict[str, type[NMModel]] = {
+    "hh": NMModelHH,
+}
+
+
+def _model_from_dict(d: dict, nm_path: str = "model") -> NMModel:
+    """Construct an :class:`NMModel` from a ``to_dict()`` dictionary."""
+    mtype = d.get("model")
+    if mtype not in _MODEL_REGISTRY:
+        raise KeyError(
+            "unknown model type %r; valid types: %s"
+            % (mtype, sorted(_MODEL_REGISTRY))
+        )
+    return _MODEL_REGISTRY[mtype].from_dict(d, nm_path=nm_path)

--- a/pyneuromatic/tools/nm_tool_model.py
+++ b/pyneuromatic/tools/nm_tool_model.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+"""
+NMToolModel: neural ODE simulation tool.
+
+Part of pyNeuroMatic, a Python implementation of NeuroMatic for analyzing,
+acquiring and simulating electrophysiology data.
+
+If you use this software in your research, please cite:
+Rothman JS and Silver RA (2018) NeuroMatic: An Integrated Open-Source
+Software Toolkit for Acquisition, Analysis and Simulation of
+Electrophysiological Data. Front. Neuroinform. 12:14.
+doi: 10.3389/fninf.2018.00014
+
+Copyright (c) 2026 The Silver Lab, University College London.
+Licensed under MIT License - see LICENSE file for details.
+
+Original NeuroMatic: https://github.com/SilverLabUCL/NeuroMatic
+Website: https://github.com/SilverLabUCL/pyNeuroMatic
+Paper: https://doi.org/10.3389/fninf.2018.00014
+"""
+from __future__ import annotations
+
+import math
+import numpy as np
+
+from pyneuromatic.tools.nm_tool import NMTool
+from pyneuromatic.tools.nm_tool_config import NMToolConfig
+from pyneuromatic.tools.nm_model import NMModelHH
+from pyneuromatic.tools.nm_pulse import NMPulseContainer
+from pyneuromatic.core.nm_data import NMData
+from pyneuromatic.core.nm_folder import NMFolder
+import pyneuromatic.core.nm_command_history as nmch
+import pyneuromatic.core.nm_configurations as nmc
+import pyneuromatic.core.nm_history as nmh
+import pyneuromatic.core.nm_utilities as nmu
+
+
+class NMToolModelConfig(NMToolConfig):
+    """Configuration for NMToolModel.
+
+    Parameters:
+        n_points:    Number of time samples per simulation.  Default 10000.
+        xstart:      Start time (ms).                         Default 0.0.
+        xdelta:      Time step (ms; must be > 0).             Default 0.025.
+        prefix:      Output array name prefix.                Default ``"VM_"``.
+        chan:         Channel string inserted between prefix and epoch index.
+                     Default ``""`` (no channel).
+        overwrite:   Overwrite existing arrays in NMFolder.data.  Default True.
+        save_states: Write gate variable arrays to a toolfolder.  Default False.
+
+    The stimulus waveform is defined by adding :class:`~pyneuromatic.tools.nm_pulse.NMPulse`
+    objects to :attr:`NMToolModel.pulses`.  Any pulse shape supported by NMPulse
+    (square, ramp, sine, alpha, …) can be used.
+    """
+
+    _TOML_TYPE = "model_config"
+    _schema = {
+        "n_points":    {"type": int,   "default": 10000, "min": 1},
+        "xstart":      {"type": float, "default": 0.0},
+        "xdelta":      {"type": float, "default": 0.025, "min": 0},
+        "prefix":      {"type": str,   "default": "VM_"},
+        "chan":         {"type": str,   "default": ""},
+        "overwrite":   {"type": bool,  "default": True},
+        "save_states": {"type": bool,  "default": False},
+    }
+
+
+class NMToolModel(NMTool):
+    """Neural ODE simulation tool.
+
+    Runs a :class:`~pyneuromatic.tools.nm_model.NMModelHH` simulation for
+    each epoch and writes the membrane-potential trajectory to
+    ``NMFolder.data``.  The prefix acts as a namespace to avoid collisions
+    with other data in the folder.
+
+    Output array naming: ``{prefix}{channel}{epoch_idx}``
+
+    The injected current waveform is built by summing all enabled
+    :class:`~pyneuromatic.tools.nm_pulse.NMPulse` objects in :attr:`pulses`
+    that target the current epoch — identical to how :class:`NMToolPulse`
+    generates its output.  Add pulses via ``t.pulses.new(...)``.
+
+    If ``save_states=True``, gate variable arrays (m, h, n for the default
+    HH model) are also written to a ``Model_*`` toolfolder.
+
+    Examples::
+
+        t = NMToolModel()
+        t.pulses.new({"pulse": "square", "amp": 200.0, "onset": 5.0, "duration": 100.0})
+        t.run_all([{}])   # one epoch → VM_0 in NMFolder.data
+    """
+
+    def __init__(self, name: str = "model") -> None:
+        super().__init__(name=name)
+        self._config = NMToolModelConfig()
+        self.__n_points:    int   = self._config.n_points
+        self.__xstart:      float = self._config.xstart
+        self.__xdelta:      float = self._config.xdelta
+        self.__prefix:      str   = self._config.prefix
+        self.__chan:        str   = self._config.chan
+        self._overwrite           = self._config.overwrite
+        self.__save_states: bool  = self._config.save_states
+        self._results_to_numpy = True
+
+        self.__model: NMModelHH = NMModelHH(nm_path=self._name + ".model")
+        self.__pulses: NMPulseContainer = NMPulseContainer(
+            nm_path=self._name + ".pulses"
+        )
+
+        self._waveforms:     list[np.ndarray]            = []
+        self._epoch_names:   list[str]                   = []
+        self._state_arrays:  list[dict[str, np.ndarray]] = []
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def n_points(self) -> int:
+        """Number of time samples per simulation."""
+        return self.__n_points
+
+    @n_points.setter
+    def n_points(self, value: int) -> None:
+        self._n_points_set(value)
+
+    def _n_points_set(self, value: int, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError(nmu.type_error_str(value, "n_points", "int"))
+        if value < 1:
+            raise ValueError("n_points must be >= 1, got %d" % value)
+        self.__n_points = value
+        nmh.history("set n_points=%d" % self.__n_points, quiet=quiet)
+        nmch.add_nm_command("%s.n_points = %r" % (self._name, self.__n_points))
+
+    @property
+    def xstart(self) -> float:
+        """Start time (ms)."""
+        return self.__xstart
+
+    @xstart.setter
+    def xstart(self, value: float) -> None:
+        self._xstart_set(value)
+
+    def _xstart_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "xstart", "float"))
+        self.__xstart = float(value)
+        nmh.history("set xstart=%g" % self.__xstart, quiet=quiet)
+        nmch.add_nm_command("%s.xstart = %r" % (self._name, self.__xstart))
+
+    @property
+    def xdelta(self) -> float:
+        """Time step (ms; must be > 0)."""
+        return self.__xdelta
+
+    @xdelta.setter
+    def xdelta(self, value: float) -> None:
+        self._xdelta_set(value)
+
+    def _xdelta_set(self, value: float, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(nmu.type_error_str(value, "xdelta", "float"))
+        if value <= 0:
+            raise ValueError("xdelta must be > 0, got %s" % value)
+        self.__xdelta = float(value)
+        nmh.history("set xdelta=%g" % self.__xdelta, quiet=quiet)
+        nmch.add_nm_command("%s.xdelta = %r" % (self._name, self.__xdelta))
+
+    @property
+    def prefix(self) -> str:
+        """Output array name prefix (e.g. ``"VM_"``)."""
+        return self.__prefix
+
+    @prefix.setter
+    def prefix(self, value: str) -> None:
+        self._prefix_set(value)
+
+    def _prefix_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "prefix", "string"))
+        if not value:
+            raise ValueError("prefix must be a non-empty string")
+        self.__prefix = value
+        nmh.history("set prefix=%r" % self.__prefix, quiet=quiet)
+        nmch.add_nm_command("%s.prefix = %r" % (self._name, self.__prefix))
+
+    @property
+    def chan(self) -> str:
+        """Channel string inserted between prefix and epoch index."""
+        return self.__chan
+
+    @chan.setter
+    def chan(self, value: str) -> None:
+        self._chan_set(value)
+
+    def _chan_set(self, value: str, quiet: bool = nmc.QUIET) -> None:
+        if isinstance(value, bool) or not isinstance(value, str):
+            raise TypeError(nmu.type_error_str(value, "chan", "string"))
+        self.__chan = value
+        nmh.history("set chan=%r" % self.__chan, quiet=quiet)
+        nmch.add_nm_command("%s.chan = %r" % (self._name, self.__chan))
+
+    @property
+    def save_states(self) -> bool:
+        """If True, write gate variable arrays to a toolfolder."""
+        return self.__save_states
+
+    @save_states.setter
+    def save_states(self, value: bool) -> None:
+        self._save_states_set(value)
+
+    def _save_states_set(self, value: bool, quiet: bool = nmc.QUIET) -> None:
+        if not isinstance(value, bool):
+            raise TypeError(nmu.type_error_str(value, "save_states", "boolean"))
+        self.__save_states = value
+        nmh.history("set save_states=%s" % value, quiet=quiet)
+        nmch.add_nm_command(
+            "%s.save_states = %r" % (self._name, self.__save_states)
+        )
+
+    @property
+    def model(self) -> NMModelHH:
+        """The HH model instance."""
+        return self.__model
+
+    @property
+    def pulses(self) -> NMPulseContainer:
+        """Container of NMPulse objects summed to form the injected current."""
+        return self.__pulses
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+
+    def run_init(self) -> bool:
+        """Validate parameters and reset accumulators."""
+        if self.__n_points < 1:
+            raise ValueError("n_points must be >= 1")
+        if self.__xdelta <= 0:
+            raise ValueError("xdelta must be > 0")
+        if not self.__prefix:
+            raise ValueError("prefix must be non-empty")
+        self._waveforms = []
+        self._epoch_names = []
+        self._state_arrays = []
+        return True
+
+    def run(self) -> bool:
+        """Simulate one epoch and accumulate the Vm waveform.
+
+        Sums all enabled :class:`~pyneuromatic.tools.nm_pulse.NMPulse` objects
+        that target this epoch to form ``i_ext``, then calls
+        :meth:`~pyneuromatic.tools.nm_model.NMModelHH.simulate`.
+
+        Returns:
+            True.
+        """
+        epoch_idx = len(self._epoch_names)
+        epoch_name = self.data.name if self.data else "sim_%d" % epoch_idx
+
+        i_ext = np.zeros(self.__n_points, dtype=float)
+        for p in self.__pulses:
+            if p.enabled and p.targets_epoch(epoch_idx):
+                i_ext += p.waveform(
+                    self.__n_points, self.__xstart, self.__xdelta, epoch_idx
+                )
+
+        result = self.__model.simulate(
+            self.__n_points, self.__xstart, self.__xdelta, i_ext
+        )
+
+        self._waveforms.append(result["V"])
+        self._epoch_names.append(epoch_name)
+        self._state_arrays.append(
+            {k: v for k, v in result.items() if k != "V"}
+        )
+        return True
+
+    def run_finish(self) -> bool:
+        """Write output arrays to NMFolder.data.
+
+        Returns:
+            True.
+        """
+        if not self._epoch_names:
+            return True
+        if self._results_to_numpy:
+            self._write_results_to_numpy()
+        return True
+
+    # ------------------------------------------------------------------
+    # Output
+
+    def _note_str(self) -> str:
+        cond_strs = []
+        for cname, cond in self.__model.conductances:
+            cond_strs.append(
+                "%s(g=%g, e=%g)" % (cname, cond.g_density, cond.e_rev)
+            )
+        parts = [
+            "NMModelHH(v0=%g" % self.__model.v0,
+            "cm_density=%g" % self.__model.cm_density,
+            "diameter=%g" % self.__model.diameter,
+            "temperature=%g" % self.__model.temperature,
+            "tau_q10=%g" % self.__model.tau_q10,
+            "conductances=[%s]" % ", ".join(cond_strs),
+        ]
+        pulse_strs = []
+        for p in self.__pulses:
+            pulse_parts = [p.pulse]
+            pulse_parts.append("amp=%g" % p.amp)
+            pulse_parts.append("onset=%g" % p.onset)
+            if math.isinf(p.duration):
+                pulse_parts.append("duration=inf")
+            else:
+                pulse_parts.append("duration=%g" % p.duration)
+            if p.amp_delta != 0.0:
+                pulse_parts.append("amp_delta=%g" % p.amp_delta)
+            pulse_strs.append("(%s)" % ", ".join(pulse_parts))
+        parts.append("pulses=[%s]" % ", ".join(pulse_strs))
+        parts.append("n_points=%d" % self.__n_points)
+        parts.append("xstart=%g" % self.__xstart)
+        parts.append("xdelta=%g" % self.__xdelta)
+        if self.__chan:
+            parts.append("chan=%r" % self.__chan)
+        return ", ".join(parts) + ")"
+
+    def _add_note(self, data: NMData, text: str) -> None:
+        notes = getattr(data, "notes", None)
+        if notes is not None:
+            notes.add(text)
+
+    def _write_results_to_numpy(self) -> NMFolder | None:
+        """Write ``{prefix}{channel}{epoch_idx}`` NMData arrays to NMFolder.data.
+
+        Also writes a ``{prefix}{channel}epoch_names`` object array of source
+        epoch name strings.  If ``save_states=True``, gate variable arrays are
+        written to a ``Model_*`` toolfolder.
+
+        Returns:
+            The NMFolder written to, or None if no folder is set.
+        """
+        if not isinstance(self.folder, NMFolder):
+            return None
+
+        f = self.folder
+        note = self._note_str()
+        xscale = {"start": self.__xstart, "delta": self.__xdelta, "units": "ms"}
+        yscale_vm = {"label": "V", "units": "mV"}
+        stem = self.__prefix + self.__chan
+
+        for idx, (epoch_name, waveform) in enumerate(
+            zip(self._epoch_names, self._waveforms)
+        ):
+            name = stem + str(idx)
+            if name in f.data and self._overwrite:
+                del f.data[name]
+            d = f.data.new(name, nparray=waveform, xscale=xscale, yscale=yscale_vm)
+            self._add_note(d, note)
+
+        epoch_names_key = stem.rstrip("_") + "_epoch_names"
+        if epoch_names_key in f.data and self._overwrite:
+            del f.data[epoch_names_key]
+        f.data.new(
+            epoch_names_key,
+            nparray=np.array(self._epoch_names, dtype=object),
+        )
+
+        if self.__save_states and self._state_arrays:
+            self._write_states_to_toolfolder(note, xscale)
+
+        return f
+
+    def _write_states_to_toolfolder(self, note: str, xscale: dict) -> None:
+        """Write gate variable arrays to a Model toolfolder."""
+        tf = self._make_toolfolder("Model", overwrite=self._overwrite)
+        chan = self.__chan
+        for idx, states in enumerate(self._state_arrays):
+            for gate_name, arr in states.items():
+                name = gate_name + "_" + chan + str(idx)
+                yscale = {"label": gate_name, "units": ""}
+                d = tf.data.new(name, nparray=arr, xscale=xscale, yscale=yscale)
+                self._add_note(d, note)

--- a/tests/test_tools/test_nm_conductance.py
+++ b/tests/test_tools/test_nm_conductance.py
@@ -1,0 +1,395 @@
+# -*- coding: utf-8 -*-
+"""Tests for NMConductance class hierarchy."""
+import math
+import pytest
+
+from pyneuromatic.tools.nm_conductance import (
+    NMConductance,
+    NMConductanceLeak,
+    NMConductanceHHNa,
+    NMConductanceHHK,
+    NMConductanceContainer,
+    _conductance_from_dict,
+)
+
+V_REST = -65.0  # mV, resting potential used throughout
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMConductance base
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMConductanceBase:
+    def test_invalid_name_empty(self):
+        with pytest.raises(ValueError):
+            NMConductance("", 0.003, -54.4)
+
+    def test_invalid_g_density_negative(self):
+        with pytest.raises(ValueError):
+            NMConductanceLeak(g_density=-1.0)
+
+    def test_invalid_g_density_bool(self):
+        with pytest.raises(TypeError):
+            NMConductanceLeak(g_density=True)
+
+    def test_invalid_e_rev_bool(self):
+        with pytest.raises(TypeError):
+            NMConductanceLeak(e_rev=True)
+
+    def test_g_density_setter_negative(self):
+        c = NMConductanceLeak()
+        with pytest.raises(ValueError):
+            c.g_density = -0.1
+
+    def test_g_density_setter_bool(self):
+        c = NMConductanceLeak()
+        with pytest.raises(TypeError):
+            c.g_density = True
+
+    def test_e_rev_setter_bool(self):
+        c = NMConductanceLeak()
+        with pytest.raises(TypeError):
+            c.e_rev = False
+
+    def test_eq_same(self):
+        assert NMConductanceLeak() == NMConductanceLeak()
+
+    def test_eq_different_g(self):
+        a = NMConductanceLeak(g_density=0.003)
+        b = NMConductanceLeak(g_density=0.005)
+        assert a != b
+
+    def test_repr(self):
+        c = NMConductanceLeak()
+        r = repr(c)
+        assert "NMConductanceLeak" in r
+        assert "g_density" in r
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMConductanceLeak
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMConductanceLeak:
+    def test_defaults(self):
+        c = NMConductanceLeak()
+        assert c.g_density == pytest.approx(0.003)
+        assert c.e_rev == pytest.approx(-54.387)
+        assert c.name == "leak"
+
+    def test_n_states(self):
+        assert NMConductanceLeak().n_states() == 0
+
+    def test_gate_names_empty(self):
+        assert NMConductanceLeak().gate_names() == []
+
+    def test_state_init_empty(self):
+        assert NMConductanceLeak().state_init(V_REST) == []
+
+    def test_current_at_rest(self):
+        c = NMConductanceLeak()
+        # I = g*(V - E_L) = 0.003 * (-65 - (-54.387))
+        expected = 0.003 * (V_REST - (-54.387))
+        assert c.current(V_REST, []) == pytest.approx(expected)
+
+    def test_current_at_reversal(self):
+        c = NMConductanceLeak()
+        assert c.current(c.e_rev, []) == pytest.approx(0.0)
+
+    def test_dydt_empty(self):
+        assert NMConductanceLeak().dydt(V_REST, []) == []
+
+    def test_dydt_scaled_empty(self):
+        assert NMConductanceLeak().dydt_scaled(V_REST, [], q10=3.0) == []
+
+    def test_to_dict(self):
+        c = NMConductanceLeak(g_density=0.005, e_rev=-60.0)
+        d = c.to_dict()
+        assert d["conductance"] == "leak"
+        assert d["g_density"] == pytest.approx(0.005)
+        assert d["e_rev"] == pytest.approx(-60.0)
+
+    def test_default_e_rev_matches_hh1952(self):
+        """E_L default must be -54.387 mV (= -65 + 10.613, HH 1952 exact value)."""
+        c = NMConductanceLeak()
+        assert c.e_rev == pytest.approx(-54.387)
+
+    def test_from_dict_round_trip(self):
+        c = NMConductanceLeak(g_density=0.005, e_rev=-60.0)
+        c2 = NMConductanceLeak.from_dict(c.to_dict())
+        assert c2 == c
+
+    def test_custom_params(self):
+        c = NMConductanceLeak(g_density=0.01, e_rev=-70.0)
+        assert c.g_density == pytest.approx(0.01)
+        assert c.e_rev == pytest.approx(-70.0)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMConductanceHHNa
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMConductanceHHNa:
+    def test_defaults(self):
+        c = NMConductanceHHNa()
+        assert c.g_density == pytest.approx(1.2)
+        assert c.e_rev == pytest.approx(50.0)
+        assert c.name == "hhna"
+
+    def test_n_states(self):
+        assert NMConductanceHHNa().n_states() == 2
+
+    def test_gate_names(self):
+        assert NMConductanceHHNa().gate_names() == ["m", "h"]
+
+    def test_state_init_in_range(self):
+        c = NMConductanceHHNa()
+        m_inf, h_inf = c.state_init(V_REST)
+        assert 0.0 < m_inf < 1.0
+        assert 0.0 < h_inf < 1.0
+
+    def test_state_init_m_small_at_rest(self):
+        # m_inf at rest should be small (Na activation is low at -65 mV)
+        c = NMConductanceHHNa()
+        m_inf, _ = c.state_init(V_REST)
+        assert m_inf < 0.1
+
+    def test_state_init_h_large_at_rest(self):
+        # h_inf at rest should be near 1 (Na inactivation is mostly off at -65 mV)
+        c = NMConductanceHHNa()
+        _, h_inf = c.state_init(V_REST)
+        assert h_inf > 0.5
+
+    def test_current_formula(self):
+        c = NMConductanceHHNa()
+        m, h = 0.5, 0.6
+        expected = 1.2 * (0.5 ** 3) * 0.6 * (V_REST - 50.0)
+        assert c.current(V_REST, [m, h]) == pytest.approx(expected)
+
+    def test_current_at_reversal(self):
+        c = NMConductanceHHNa()
+        assert c.current(c.e_rev, [0.5, 0.5]) == pytest.approx(0.0)
+
+    def test_dydt_near_zero_at_steady_state(self):
+        # At steady-state initial conditions, dm/dt and dh/dt should be near zero
+        c = NMConductanceHHNa()
+        m_inf, h_inf = c.state_init(V_REST)
+        dm, dh = c.dydt(V_REST, [m_inf, h_inf])
+        assert abs(dm) < 1e-10
+        assert abs(dh) < 1e-10
+
+    def test_alpha_m_singularity(self):
+        # V = -40 mV: limit of alpha_m should be 1.0
+        c = NMConductanceHHNa()
+        assert c._alpha_m(-40.0) == pytest.approx(1.0)
+
+    def test_alpha_m_non_singular(self):
+        c = NMConductanceHHNa()
+        alpha = c._alpha_m(-50.0)
+        assert alpha > 0.0
+
+    def test_beta_m_positive(self):
+        c = NMConductanceHHNa()
+        assert c._beta_m(V_REST) > 0.0
+
+    def test_alpha_h_positive(self):
+        c = NMConductanceHHNa()
+        assert c._alpha_h(V_REST) > 0.0
+
+    def test_beta_h_in_range(self):
+        c = NMConductanceHHNa()
+        bh = c._beta_h(V_REST)
+        assert 0.0 < bh < 1.0
+
+    def test_dydt_scaled(self):
+        c = NMConductanceHHNa()
+        m, h = 0.3, 0.7
+        raw = c.dydt(V_REST, [m, h])
+        scaled = c.dydt_scaled(V_REST, [m, h], q10=3.0)
+        assert scaled[0] == pytest.approx(raw[0] * 3.0)
+        assert scaled[1] == pytest.approx(raw[1] * 3.0)
+
+    def test_to_dict(self):
+        c = NMConductanceHHNa(g_density=1.0, e_rev=55.0)
+        d = c.to_dict()
+        assert d["conductance"] == "hhna"
+        assert d["g_density"] == pytest.approx(1.0)
+        assert d["e_rev"] == pytest.approx(55.0)
+
+    def test_from_dict_round_trip(self):
+        c = NMConductanceHHNa(g_density=1.0, e_rev=55.0)
+        c2 = NMConductanceHHNa.from_dict(c.to_dict())
+        assert c2 == c
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMConductanceHHK
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMConductanceHHK:
+    def test_defaults(self):
+        c = NMConductanceHHK()
+        assert c.g_density == pytest.approx(0.36)
+        assert c.e_rev == pytest.approx(-77.0)
+        assert c.name == "hhk"
+
+    def test_n_states(self):
+        assert NMConductanceHHK().n_states() == 1
+
+    def test_gate_names(self):
+        assert NMConductanceHHK().gate_names() == ["n"]
+
+    def test_state_init_in_range(self):
+        c = NMConductanceHHK()
+        (n_inf,) = c.state_init(V_REST)
+        assert 0.0 < n_inf < 1.0
+
+    def test_current_formula(self):
+        c = NMConductanceHHK()
+        n = 0.4
+        expected = 0.36 * (n ** 4) * (V_REST - (-77.0))
+        assert c.current(V_REST, [n]) == pytest.approx(expected)
+
+    def test_current_at_reversal(self):
+        c = NMConductanceHHK()
+        assert c.current(c.e_rev, [0.5]) == pytest.approx(0.0)
+
+    def test_dydt_near_zero_at_steady_state(self):
+        c = NMConductanceHHK()
+        (n_inf,) = c.state_init(V_REST)
+        (dn,) = c.dydt(V_REST, [n_inf])
+        assert abs(dn) < 1e-10
+
+    def test_alpha_n_singularity(self):
+        c = NMConductanceHHK()
+        assert c._alpha_n(-55.0) == pytest.approx(0.1)
+
+    def test_alpha_n_non_singular(self):
+        c = NMConductanceHHK()
+        assert c._alpha_n(-60.0) > 0.0
+
+    def test_beta_n_positive(self):
+        c = NMConductanceHHK()
+        assert c._beta_n(V_REST) > 0.0
+
+    def test_dydt_scaled(self):
+        c = NMConductanceHHK()
+        n = 0.3
+        (raw_dn,) = c.dydt(V_REST, [n])
+        (scaled_dn,) = c.dydt_scaled(V_REST, [n], q10=2.0)
+        assert scaled_dn == pytest.approx(raw_dn * 2.0)
+
+    def test_to_dict(self):
+        c = NMConductanceHHK(g_density=0.4, e_rev=-80.0)
+        d = c.to_dict()
+        assert d["conductance"] == "hhk"
+        assert d["g_density"] == pytest.approx(0.4)
+        assert d["e_rev"] == pytest.approx(-80.0)
+
+    def test_from_dict_round_trip(self):
+        c = NMConductanceHHK(g_density=0.4, e_rev=-80.0)
+        c2 = NMConductanceHHK.from_dict(c.to_dict())
+        assert c2 == c
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMConductanceContainer
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMConductanceContainer:
+    def _default_container(self):
+        c = NMConductanceContainer()
+        c.add("Leak", NMConductanceLeak())
+        c.add("Na",   NMConductanceHHNa())
+        c.add("K",    NMConductanceHHK())
+        return c
+
+    def test_add_and_len(self):
+        c = self._default_container()
+        assert len(c) == 3
+
+    def test_contains(self):
+        c = self._default_container()
+        assert "Na" in c
+        assert "X" not in c
+
+    def test_getitem(self):
+        c = self._default_container()
+        assert isinstance(c["Leak"], NMConductanceLeak)
+
+    def test_getitem_missing(self):
+        c = NMConductanceContainer()
+        with pytest.raises(KeyError):
+            _ = c["missing"]
+
+    def test_iter_yields_name_cond_pairs(self):
+        c = self._default_container()
+        pairs = list(c)
+        assert len(pairs) == 3
+        names = [name for name, _ in pairs]
+        assert "Leak" in names and "Na" in names and "K" in names
+
+    def test_add_invalid_name(self):
+        c = NMConductanceContainer()
+        with pytest.raises(ValueError):
+            c.add("", NMConductanceLeak())
+
+    def test_add_invalid_type(self):
+        c = NMConductanceContainer()
+        with pytest.raises(TypeError):
+            c.add("X", "not a conductance")
+
+    def test_to_dict(self):
+        c = self._default_container()
+        d = c.to_dict()
+        assert "conductances" in d
+        assert len(d["conductances"]) == 3
+        names = [entry["name"] for entry in d["conductances"]]
+        assert "Leak" in names
+
+    def test_from_dict_round_trip(self):
+        c = self._default_container()
+        c2 = NMConductanceContainer.from_dict(c.to_dict())
+        assert c2 == c
+
+    def test_replace_existing_key(self):
+        c = NMConductanceContainer()
+        c.add("Na", NMConductanceHHNa(g_density=1.2))
+        c.add("Na", NMConductanceHHNa(g_density=0.5))
+        assert c["Na"].g_density == pytest.approx(0.5)
+        assert len(c) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Factory
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestConductanceFactory:
+    def test_dispatch_leak(self):
+        d = {"conductance": "leak", "g_density": 0.003, "e_rev": -54.4}
+        c = _conductance_from_dict(d)
+        assert isinstance(c, NMConductanceLeak)
+
+    def test_dispatch_hhna(self):
+        d = {"conductance": "hhna", "g_density": 1.2, "e_rev": 50.0}
+        c = _conductance_from_dict(d)
+        assert isinstance(c, NMConductanceHHNa)
+
+    def test_dispatch_hhk(self):
+        d = {"conductance": "hhk", "g_density": 0.36, "e_rev": -77.0}
+        c = _conductance_from_dict(d)
+        assert isinstance(c, NMConductanceHHK)
+
+    def test_unknown_type_raises(self):
+        with pytest.raises(KeyError):
+            _conductance_from_dict({"conductance": "mystery"})
+
+    def test_none_type_raises(self):
+        with pytest.raises(KeyError):
+            _conductance_from_dict({})
+
+    def test_preserves_params(self):
+        d = {"conductance": "leak", "g_density": 0.005, "e_rev": -60.0}
+        c = _conductance_from_dict(d)
+        assert c.g_density == pytest.approx(0.005)
+        assert c.e_rev == pytest.approx(-60.0)

--- a/tests/test_tools/test_nm_model.py
+++ b/tests/test_tools/test_nm_model.py
@@ -1,0 +1,421 @@
+# -*- coding: utf-8 -*-
+"""Tests for NMModel and NMModelHH."""
+import math
+import numpy as np
+import pytest
+
+from pyneuromatic.tools.nm_model import NMModel, NMModelHH, _model_from_dict
+from pyneuromatic.tools.nm_conductance import (
+    NMConductanceLeak,
+    NMConductanceHHNa,
+    NMConductanceHHK,
+)
+from pyneuromatic.tools.nm_pulse import NMPulseContainer
+
+# Simulation parameters used across many tests
+N_POINTS = 4000   # 100 ms at 0.025 ms/step
+XSTART = 0.0      # ms
+XDELTA = 0.025    # ms
+I_ONSET_IDX = 200  # sample index where step begins (= 5 ms)
+I_AMP_SUPRA = 300.0   # pA — well above threshold for 20 µm HH sphere
+
+
+def _make_i_ext(n_points, onset_idx, amp, duration_idx=800):
+    """Build a square current step."""
+    i_ext = np.zeros(n_points)
+    end_idx = min(n_points, onset_idx + duration_idx)
+    i_ext[onset_idx:end_idx] = amp
+    return i_ext
+
+
+def _sim_default(i_amp=I_AMP_SUPRA):
+    """Run one default HH simulation with a suprathreshold step."""
+    m = NMModelHH()
+    i_ext = _make_i_ext(N_POINTS, I_ONSET_IDX, i_amp)
+    return m.simulate(N_POINTS, XSTART, XDELTA, i_ext)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMModelHH construction
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelHHConstruct:
+    def test_default_params(self):
+        m = NMModelHH()
+        assert m.v0 == pytest.approx(-65.0)
+        assert m.temperature == pytest.approx(6.3)   # HH reference temperature
+        assert m.cm_density == pytest.approx(0.01)
+        assert m.diameter == pytest.approx(math.sqrt(1200.0 / math.pi))
+        assert m.tau_q10 == pytest.approx(3.0)
+
+    def test_default_conductances(self):
+        m = NMModelHH()
+        assert "Leak" in m.conductances
+        assert "Na"   in m.conductances
+        assert "K"    in m.conductances
+        assert len(m.conductances) == 3
+
+    def test_conductance_types(self):
+        m = NMModelHH()
+        assert isinstance(m.conductances["Leak"], NMConductanceLeak)
+        assert isinstance(m.conductances["Na"],   NMConductanceHHNa)
+        assert isinstance(m.conductances["K"],    NMConductanceHHK)
+
+    def test_name(self):
+        m = NMModelHH(name="test_hh")
+        assert m.name == "test_hh"
+
+    def test_v0_setter(self):
+        m = NMModelHH()
+        m.v0 = -70.0
+        assert m.v0 == pytest.approx(-70.0)
+
+    def test_v0_setter_bool_raises(self):
+        m = NMModelHH()
+        with pytest.raises(TypeError):
+            m.v0 = True
+
+    def test_cm_density_setter_zero_raises(self):
+        m = NMModelHH()
+        with pytest.raises(ValueError):
+            m.cm_density = 0.0
+
+    def test_diameter_setter_zero_raises(self):
+        m = NMModelHH()
+        with pytest.raises(ValueError):
+            m.diameter = 0.0
+
+    def test_tau_q10_setter_zero_raises(self):
+        m = NMModelHH()
+        with pytest.raises(ValueError):
+            m.tau_q10 = 0.0
+
+    def test_config_kwarg(self):
+        config = {"v0": -70.0, "diameter": 30.0}
+        m = NMModelHH(config=config)
+        assert m.v0 == pytest.approx(-70.0)
+        assert m.diameter == pytest.approx(30.0)
+
+    def test_config_unknown_key_raises(self):
+        m = NMModelHH()
+        with pytest.raises(KeyError):
+            m._config_set({"nonexistent_key": 1.0})
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# simulate() return shape and keys
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelHHSimulateShape:
+    def test_returns_dict(self):
+        result = _sim_default()
+        assert isinstance(result, dict)
+
+    def test_has_V_key(self):
+        result = _sim_default()
+        assert "V" in result
+
+    def test_has_gate_keys(self):
+        result = _sim_default()
+        assert "m" in result
+        assert "h" in result
+        assert "n" in result
+
+    def test_array_lengths(self):
+        result = _sim_default()
+        for key, arr in result.items():
+            assert len(arr) == N_POINTS, "key %r length mismatch" % key
+
+    def test_invalid_n_points(self):
+        m = NMModelHH()
+        with pytest.raises(ValueError):
+            m.simulate(0, 0.0, 0.025, np.zeros(0))
+
+    def test_invalid_xdelta(self):
+        m = NMModelHH()
+        with pytest.raises(ValueError):
+            m.simulate(100, 0.0, 0.0, np.zeros(100))
+
+    def test_wrong_i_ext_length(self):
+        m = NMModelHH()
+        with pytest.raises(ValueError):
+            m.simulate(100, 0.0, 0.025, np.zeros(50))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Resting state stability
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelHHRest:
+    def test_equilibrium_potential(self):
+        """True HH resting potential (zero-current root) should be ≈ −64.9964 mV."""
+        from scipy.optimize import brentq
+        m = NMModelHH()
+        def total_i(V):
+            return sum(
+                cond.current(V, cond.state_init(V))
+                for _, cond in m.conductances
+            )
+        V_rest = brentq(total_i, -80, -40, xtol=1e-12)
+        assert V_rest == pytest.approx(-64.996376, abs=1e-4)
+
+    def test_resting_potential_stable(self):
+        """Zero input: Vm should stay near v0."""
+        m = NMModelHH()
+        i_ext = np.zeros(N_POINTS)
+        result = m.simulate(N_POINTS, XSTART, XDELTA, i_ext)
+        V = result["V"]
+        assert np.all(np.abs(V - m.v0) < 2.0), (
+            "Vm drifted > 2 mV from rest with no input"
+        )
+
+    def test_gates_near_steady_state_at_rest(self):
+        """Gate variables should stay near their steady-state values."""
+        m = NMModelHH()
+        i_ext = np.zeros(N_POINTS)
+        result = m.simulate(N_POINTS, XSTART, XDELTA, i_ext)
+        m_inf, h_inf = m.conductances["Na"].state_init(m.v0)
+        (n_inf,) = m.conductances["K"].state_init(m.v0)
+        assert np.all(np.abs(result["m"] - m_inf) < 0.01)
+        assert np.all(np.abs(result["h"] - h_inf) < 0.01)
+        assert np.all(np.abs(result["n"] - n_inf) < 0.01)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Action potential generation
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelHHActionPotential:
+    def test_ap_peak_above_zero(self):
+        """Suprathreshold current step should produce AP with peak > 0 mV."""
+        result = _sim_default()
+        assert result["V"].max() > 0.0
+
+    def test_ap_starts_near_rest(self):
+        """Vm before current onset should be near v0."""
+        m = NMModelHH()
+        i_ext = _make_i_ext(N_POINTS, I_ONSET_IDX, I_AMP_SUPRA)
+        result = m.simulate(N_POINTS, XSTART, XDELTA, i_ext)
+        pre_onset_V = result["V"][:I_ONSET_IDX]
+        assert np.all(np.abs(pre_onset_V - m.v0) < 2.0)
+
+    def test_ap_peak_after_onset(self):
+        """Peak should occur after the current step onset."""
+        result = _sim_default()
+        V = result["V"]
+        peak_idx = int(np.argmax(V))
+        assert peak_idx > I_ONSET_IDX
+
+    def test_ap_peak_within_20ms_of_onset(self):
+        """Peak should occur within 20 ms after step onset (AP is fast)."""
+        result = _sim_default()
+        V = result["V"]
+        peak_idx = int(np.argmax(V))
+        peak_time_after_onset = (peak_idx - I_ONSET_IDX) * XDELTA
+        assert peak_time_after_onset < 20.0
+
+    def test_ap_returns_to_rest(self):
+        """After a short step, Vm should return within ±10 mV of v0."""
+        m = NMModelHH()
+        # Short 1 ms step, long simulation (200 ms)
+        n_pts = 8000
+        i_ext = _make_i_ext(n_pts, I_ONSET_IDX, I_AMP_SUPRA, duration_idx=40)
+        result = m.simulate(n_pts, XSTART, XDELTA, i_ext)
+        V = result["V"]
+        # Check last 50 ms (last 2000 samples)
+        v_end = V[-2000:]
+        assert np.all(np.abs(v_end - m.v0) < 10.0), (
+            "Vm did not return to rest after AP: max deviation = %g mV"
+            % np.max(np.abs(v_end - m.v0))
+        )
+
+    def test_m_gate_activates_during_ap(self):
+        """m gate should open significantly during the AP."""
+        result = _sim_default()
+        assert result["m"].max() > 0.5
+
+    def test_h_gate_inactivates_during_ap(self):
+        """h gate should inactivate (decrease) during the AP."""
+        m = NMModelHH()
+        i_ext = _make_i_ext(N_POINTS, I_ONSET_IDX, I_AMP_SUPRA)
+        result = m.simulate(N_POINTS, XSTART, XDELTA, i_ext)
+        h = result["h"]
+        # h should be significantly lower at some point during the AP
+        assert h.min() < 0.3
+
+    def test_n_gate_activates_during_repolarisation(self):
+        """n gate should open during the AP for K repolarisation."""
+        result = _sim_default()
+        assert result["n"].max() > 0.5
+
+    def test_subthreshold_no_ap(self):
+        """Subthreshold stimulus should not produce an AP."""
+        m = NMModelHH()
+        # Very small current
+        i_ext = _make_i_ext(N_POINTS, I_ONSET_IDX, amp=1.0)
+        result = m.simulate(N_POINTS, XSTART, XDELTA, i_ext)
+        assert result["V"].max() < 0.0
+
+    @pytest.mark.parametrize("i_amp,expected_aps", [
+        (25,  0),
+        (30,  1),
+        (100, 7),
+        (200, 9),
+    ])
+    def test_ap_count(self, i_amp, expected_aps):
+        """AP count for 100 ms square step after 25 ms settling period."""
+        from scipy.signal import find_peaks
+        xdelta = 0.025
+        onset_idx = round(25.0 / xdelta)
+        end_idx = onset_idx + round(100.0 / xdelta)
+        n_pts = round(150.0 / xdelta)
+        i_ext = np.zeros(n_pts)
+        i_ext[onset_idx:end_idx] = float(i_amp)
+        result = NMModelHH().simulate(n_pts, 0.0, xdelta, i_ext)
+        peaks, _ = find_peaks(result["V"], height=-20.0, distance=round(5.0 / xdelta))
+        assert len(peaks) == expected_aps, (
+            "i_amp=%d pA: expected %d AP(s), got %d" % (i_amp, expected_aps, len(peaks))
+        )
+
+    @pytest.mark.parametrize("i_amp,aps_during,aps_after", [
+        (-30, 0, 0),
+        (-35, 0, 1),
+    ])
+    def test_anodal_break(self, i_amp, aps_during, aps_after):
+        """Hyperpolarising step: no spikes during step; -35 pA triggers one rebound AP."""
+        from scipy.signal import find_peaks
+        xdelta = 0.025
+        onset_idx = round(25.0 / xdelta)
+        end_idx   = onset_idx + round(100.0 / xdelta)
+        n_pts     = round(175.0 / xdelta)   # 50 ms tail to catch the rebound
+        i_ext = np.zeros(n_pts)
+        i_ext[onset_idx:end_idx] = float(i_amp)
+        result = NMModelHH().simulate(n_pts, 0.0, xdelta, i_ext)
+        V = result["V"]
+        min_dist = round(5.0 / xdelta)
+        peaks, _ = find_peaks(V, height=-20.0, distance=min_dist)
+        during = sum(1 for p in peaks if onset_idx <= p < end_idx)
+        after  = sum(1 for p in peaks if p >= end_idx)
+        assert during == aps_during, (
+            "i_amp=%d pA: expected %d spike(s) during step, got %d" % (i_amp, aps_during, during)
+        )
+        assert after == aps_after, (
+            "i_amp=%d pA: expected %d rebound spike(s) after step, got %d" % (i_amp, aps_after, after)
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Temperature (Q10) effect
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelHHTemperature:
+    """Compare AP timing at two temperatures where the model reliably fires.
+
+    Use tau_q10=1.5 so that the Q10 factor stays in a physiologically
+    reasonable range at both test temperatures.
+    """
+
+    def _peak_time(self, temperature, tau_q10=1.5):
+        m = NMModelHH()
+        m.temperature = temperature
+        m.tau_q10 = tau_q10
+        i_ext = _make_i_ext(N_POINTS, I_ONSET_IDX, I_AMP_SUPRA)
+        result = m.simulate(N_POINTS, XSTART, XDELTA, i_ext)
+        V = result["V"]
+        return int(np.argmax(V)) * XDELTA
+
+    def test_higher_temperature_faster_ap(self):
+        """At higher temperature, Q10 speeds up kinetics → earlier AP peak."""
+        t_cold = self._peak_time(6.3)    # reference temperature: Q10 factor = 1.0
+        t_warm = self._peak_time(16.3)   # 10°C above reference: Q10 factor = 1.5
+        assert t_warm < t_cold
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Derived quantities
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelHHDerived:
+    def test_surface_area(self):
+        m = NMModelHH()
+        assert m._surface_area() == pytest.approx(1200.0)
+
+    def test_capacitance(self):
+        m = NMModelHH()
+        assert m._capacitance() == pytest.approx(12.0)
+
+    def test_q10_factor_at_ref_temp(self):
+        m = NMModelHH()
+        m.temperature = 6.3   # at reference → factor = 1.0
+        assert m._q10_factor() == pytest.approx(1.0)
+
+    def test_q10_factor_above_ref(self):
+        m = NMModelHH()
+        m.temperature = 16.3  # 10 °C above ref → factor = tau_q10^1
+        assert m._q10_factor() == pytest.approx(m.tau_q10)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Serialisation
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelHHSerialisation:
+    def test_to_dict_keys(self):
+        m = NMModelHH()
+        d = m.to_dict()
+        assert d["model"] == "hh"
+        for key in ("v0", "temperature", "cm_density", "diameter", "tau_q10"):
+            assert key in d
+        assert "conductances" in d
+
+    def test_to_dict_conductances_list(self):
+        m = NMModelHH()
+        d = m.to_dict()
+        assert isinstance(d["conductances"], list)
+        assert len(d["conductances"]) == 3
+
+    def test_from_dict_round_trip(self):
+        m = NMModelHH()
+        m.v0 = -70.0
+        m.diameter = 25.0
+        m2 = NMModelHH.from_dict(m.to_dict())
+        assert m == m2
+
+    def test_eq_symmetric(self):
+        m1 = NMModelHH()
+        m2 = NMModelHH()
+        assert m1 == m2
+
+    def test_eq_different_param(self):
+        m1 = NMModelHH()
+        m2 = NMModelHH()
+        m2.diameter = 30.0
+        assert m1 != m2
+
+    def test_config_set_conductances(self):
+        m = NMModelHH()
+        m2 = NMModelHH()
+        m2.conductances["Na"].g_density = 0.5
+        d = m2.to_dict()
+        m._config_set(d)
+        assert m.conductances["Na"].g_density == pytest.approx(0.5)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Factory
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestModelFactory:
+    def test_dispatch_hh(self):
+        m = NMModelHH()
+        m2 = _model_from_dict(m.to_dict())
+        assert isinstance(m2, NMModelHH)
+        assert m == m2
+
+    def test_unknown_model_raises(self):
+        with pytest.raises(KeyError):
+            _model_from_dict({"model": "mystery"})
+
+    def test_none_model_raises(self):
+        with pytest.raises(KeyError):
+            _model_from_dict({})

--- a/tests/test_tools/test_nm_tool_model.py
+++ b/tests/test_tools/test_nm_tool_model.py
@@ -1,0 +1,387 @@
+# -*- coding: utf-8 -*-
+"""Tests for NMToolModel and NMToolModelConfig."""
+import math
+import numpy as np
+import pytest
+
+from pyneuromatic.tools.nm_tool_model import NMToolModel, NMToolModelConfig
+from pyneuromatic.tools.nm_model import NMModelHH
+from pyneuromatic.tools.nm_pulse import NMPulseContainer
+from pyneuromatic.core.nm_folder import NMFolder
+from pyneuromatic.core.nm_manager import NMManager
+
+NM = NMManager(quiet=True)
+
+# Suprathreshold amplitude for the default HH neuron (SA=1200 µm², Cm=12 pF)
+I_AMP_SUPRA = 300.0   # pA
+
+
+def _make_folder(name="TestFolder"):
+    return NMFolder(NM, name=name)
+
+
+def _run_tool(tool, n_epochs=1, folder=None):
+    """Run the tool for n_epochs, all sharing the same folder."""
+    if folder is None:
+        folder = _make_folder()
+    targets = [{"folder": folder} for _ in range(n_epochs)]
+    tool.run_all(targets)
+    return folder
+
+
+_TOOL_KEYS = {"n_points", "prefix", "chan", "xdelta", "xstart", "save_states"}
+
+
+def _supra_tool(**kwargs):
+    """Create a NMToolModel configured to fire an AP.
+
+    kwargs are split: tool-level keys (n_points, save_states, …) are set on the
+    tool; everything else is passed into the pulse config dict.
+    """
+    t = NMToolModel()
+    t.n_points = 4000   # 100 ms at 0.025 ms/step
+    for k, v in kwargs.items():
+        if k in _TOOL_KEYS:
+            setattr(t, k, v)
+    pulse_cfg = {"pulse": "square", "amp": I_AMP_SUPRA, "onset": 5.0,
+                 "duration": 20.0, "epoch": "all"}
+    pulse_cfg.update({k: v for k, v in kwargs.items() if k not in _TOOL_KEYS})
+    t.pulses.new(pulse_cfg)
+    return t
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMToolModelConfig
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMToolModelConfig:
+    def test_defaults(self):
+        c = NMToolModelConfig()
+        assert c.n_points == 10000
+        assert c.xstart == pytest.approx(0.0)
+        assert c.xdelta == pytest.approx(0.025)
+        assert c.prefix == "VM_"
+        assert c.chan == ""
+        assert c.overwrite is True
+        assert c.save_states is False
+
+    def test_set_valid_n_points(self):
+        c = NMToolModelConfig()
+        c.n_points = 5000
+        assert c.n_points == 5000
+
+    def test_n_points_below_min_raises(self):
+        c = NMToolModelConfig()
+        with pytest.raises(ValueError):
+            c.n_points = 0
+
+    def test_n_points_bool_raises(self):
+        c = NMToolModelConfig()
+        with pytest.raises(TypeError):
+            c.n_points = True
+
+    def test_xdelta_non_negative_required(self):
+        c = NMToolModelConfig()
+        with pytest.raises(ValueError):
+            c.xdelta = -0.1
+
+    def test_unknown_key_raises(self):
+        c = NMToolModelConfig()
+        with pytest.raises(AttributeError):
+            c.not_a_key = 1
+
+    def test_to_dict_round_trip(self):
+        c = NMToolModelConfig()
+        c.n_points = 2000
+        c2 = NMToolModelConfig.from_dict(c.to_dict())
+        assert c == c2
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMToolModel construction and properties
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMToolModelConstruct:
+    def test_defaults(self):
+        t = NMToolModel()
+        assert t.prefix == "VM_"
+        assert t.chan == ""
+        assert t.xdelta == pytest.approx(0.025)
+        assert t.save_states is False
+        assert len(t.pulses) == 0
+
+    def test_model_property(self):
+        t = NMToolModel()
+        assert isinstance(t.model, NMModelHH)
+
+    def test_pulses_property(self):
+        t = NMToolModel()
+        assert isinstance(t.pulses, NMPulseContainer)
+        assert len(t.pulses) == 0
+
+    def test_add_pulse(self):
+        t = NMToolModel()
+        t.pulses.new({"pulse": "square", "amp": 10.0, "onset": 5.0})
+        assert len(t.pulses) == 1
+
+    def test_prefix_setter(self):
+        t = NMToolModel()
+        t.prefix = "HH_"
+        assert t.prefix == "HH_"
+
+    def test_prefix_empty_raises(self):
+        t = NMToolModel()
+        with pytest.raises(ValueError):
+            t.prefix = ""
+
+    def test_n_points_setter(self):
+        t = NMToolModel()
+        t.n_points = 500
+        assert t.n_points == 500
+
+    def test_n_points_zero_raises(self):
+        t = NMToolModel()
+        with pytest.raises(ValueError):
+            t.n_points = 0
+
+    def test_xdelta_zero_raises(self):
+        t = NMToolModel()
+        with pytest.raises(ValueError):
+            t.xdelta = 0.0
+
+    def test_save_states_bool_required(self):
+        t = NMToolModel()
+        with pytest.raises(TypeError):
+            t.save_states = 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Basic output — single epoch
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMToolModelSingleEpoch:
+    def setup_method(self):
+        self.t = _supra_tool()
+        self.folder = _run_tool(self.t, n_epochs=1)
+
+    def test_vm_array_in_folder(self):
+        assert "VM_0" in self.folder.data
+
+    def test_vm_array_length(self):
+        d = self.folder.data["VM_0"]
+        assert len(d.nparray) == self.t.n_points
+
+    def test_vm_xscale_start(self):
+        d = self.folder.data["VM_0"]
+        assert d.xscale.start == pytest.approx(0.0)
+
+    def test_vm_xscale_delta(self):
+        d = self.folder.data["VM_0"]
+        assert d.xscale.delta == pytest.approx(0.025)
+
+    def test_vm_xscale_units(self):
+        d = self.folder.data["VM_0"]
+        assert d.xscale.units == "ms"
+
+    def test_vm_yscale_label(self):
+        d = self.folder.data["VM_0"]
+        assert d.yscale.label == "V"
+
+    def test_vm_yscale_units(self):
+        d = self.folder.data["VM_0"]
+        assert d.yscale.units == "mV"
+
+    def test_no_ap_in_output(self):
+        V = self.folder.data["VM_0"].nparray
+        assert V.max() > 0.0, "No AP detected in VM_0 output"
+
+    def test_epoch_names_written(self):
+        assert "VM_epoch_names" in self.folder.data
+
+    def test_epoch_names_length(self):
+        names = self.folder.data["VM_epoch_names"].nparray
+        assert len(names) == 1
+
+    def test_note_on_data(self):
+        d = self.folder.data["VM_0"]
+        note_text = " ".join(str(n) for n in d.notes)
+        assert "NMModelHH" in note_text
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Multi-epoch sweep (amp_delta)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMToolModelMultiEpoch:
+    def setup_method(self):
+        self.t = _supra_tool(amp_delta=50.0)
+        self.folder = _run_tool(self.t, n_epochs=3)
+
+    def test_three_vm_arrays(self):
+        for i in range(3):
+            assert "VM_%d" % i in self.folder.data
+
+    def test_epoch_names_length(self):
+        names = self.folder.data["VM_epoch_names"].nparray
+        assert len(names) == 3
+
+    def test_different_amps_produce_different_peaks(self):
+        """Higher amp_delta epochs should produce APs at least as large as lower epochs."""
+        v0 = self.folder.data["VM_0"].nparray
+        v1 = self.folder.data["VM_1"].nparray
+        v2 = self.folder.data["VM_2"].nparray
+        assert v0.max() > 0.0
+        assert v1.max() > 0.0
+        assert v2.max() > 0.0
+        assert v2.max() >= v0.max()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Channel string in output names
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMToolModelChanNaming:
+    def test_chan_in_name(self):
+        t = _supra_tool()
+        t.chan = "A"
+        folder = _run_tool(t, n_epochs=2)
+        assert "VM_A0" in folder.data
+        assert "VM_A1" in folder.data
+
+    def test_chan_in_epoch_names_key(self):
+        t = _supra_tool()
+        t.chan = "A"
+        folder = _run_tool(t, n_epochs=1)
+        assert "VM_A_epoch_names" in folder.data
+
+    def test_custom_prefix(self):
+        t = _supra_tool()
+        t.prefix = "HH_"
+        folder = _run_tool(t, n_epochs=1)
+        assert "HH_0" in folder.data
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# save_states — gate variables in toolfolder
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMToolModelSaveStates:
+    def setup_method(self):
+        self.t = _supra_tool(save_states=True)
+        self.folder = _run_tool(self.t, n_epochs=1)
+        tf_names = list(self.folder.toolfolders)
+        self.tf_name = tf_names[0] if tf_names else None
+
+    def test_toolfolder_created(self):
+        assert self.tf_name is not None, "No toolfolder created"
+
+    def test_toolfolder_starts_with_model(self):
+        assert self.tf_name.startswith("Model")
+
+    def test_gate_arrays_present(self):
+        tf = self.folder.toolfolders[self.tf_name]
+        assert "m_0" in tf.data
+        assert "h_0" in tf.data
+        assert "n_0" in tf.data
+
+    def test_gate_array_length(self):
+        tf = self.folder.toolfolders[self.tf_name]
+        m = tf.data["m_0"].nparray
+        assert len(m) == self.t.n_points
+
+    def test_gate_array_xscale(self):
+        tf = self.folder.toolfolders[self.tf_name]
+        m = tf.data["m_0"]
+        assert m.xscale.delta == pytest.approx(0.025)
+        assert m.xscale.units == "ms"
+
+    def test_gate_array_yscale(self):
+        tf = self.folder.toolfolders[self.tf_name]
+        m = tf.data["m_0"]
+        assert m.yscale.label == "m"
+
+    def test_m_gate_opens_during_ap(self):
+        tf = self.folder.toolfolders[self.tf_name]
+        m_arr = tf.data["m_0"].nparray
+        assert m_arr.max() > 0.5
+
+    def test_no_toolfolder_when_save_states_false(self):
+        t = _supra_tool(save_states=False)
+        folder = _run_tool(t, n_epochs=1)
+        tf_names = list(folder.toolfolders)
+        assert len(tf_names) == 0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Overwrite behaviour
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMToolModelOverwrite:
+    def test_overwrite_replaces_existing(self):
+        t = _supra_tool()
+        folder = _run_tool(t, n_epochs=1)
+        v_before = folder.data["VM_0"].nparray.copy()
+        t2 = NMToolModel()
+        t2.n_points = t.n_points
+        t2.pulses.new({"pulse": "square", "amp": I_AMP_SUPRA * 2,
+                       "onset": 5.0, "duration": 20.0, "epoch": "all"})
+        _run_tool(t2, n_epochs=1, folder=folder)
+        v_after = folder.data["VM_0"].nparray
+        assert "VM_0" in folder.data
+        assert not np.array_equal(v_before, v_after), (
+            "VM_0 was not overwritten: data unchanged after second run"
+        )
+
+    def test_run_init_resets_accumulators(self):
+        t = _supra_tool()
+        _run_tool(t, n_epochs=2)
+        folder2 = _run_tool(t, n_epochs=1)
+        assert "VM_0" in folder2.data
+        assert "VM_1" not in folder2.data, (
+            "run_init did not reset accumulators: VM_1 present after 1-epoch run"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Note string
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMToolModelNoteStr:
+    def _note(self, tool, n_epochs=1):
+        folder = _run_tool(tool, n_epochs=n_epochs)
+        return " ".join(str(n) for n in folder.data["VM_0"].notes)
+
+    def test_note_contains_model_name(self):
+        assert "NMModelHH" in self._note(_supra_tool())
+
+    def test_note_contains_amp(self):
+        assert "amp" in self._note(_supra_tool())
+
+    def test_note_contains_conductances(self):
+        assert "conductances" in self._note(_supra_tool())
+
+    def test_note_inf_duration(self):
+        t = NMToolModel()
+        t.n_points = 4000
+        t.pulses.new({"pulse": "square", "amp": I_AMP_SUPRA, "onset": 5.0,
+                      "duration": math.inf, "epoch": "all"})
+        assert "inf" in self._note(t)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# run_finish with no epochs
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMToolModelEmpty:
+    def test_run_all_no_targets(self):
+        t = NMToolModel()
+        result = t.run_all([])
+        assert result is True
+
+    def test_no_output_when_no_epochs(self):
+        t = NMToolModel()
+        folder = _make_folder()
+        t.run_all([{"folder": folder}])  # one epoch, no pulses → resting Vm
+        count_before = len(folder.data)
+        t.run_all([])
+        assert len(folder.data) == count_before


### PR DESCRIPTION
### Summary

- Adds the Hodgkin–Huxley point-neuron model (NMModelHH) with HH 1952 exact parameters: E_L = −54.387 mV, default diameter = √(1200/π) µm (SA = 1200 µm², Cm = 12 pF), giving V_rest ≈ −64.9964 mV
- Adds NMToolModel, a simulation tool that runs NMModelHH per epoch and writes membrane potential to NMFolder.data; optionally saves gate variables (m, h, n) to a Model_* toolfolder via save_states=True
- Injected current is defined by adding NMPulse objects to NMToolModel.pulses — any pulse shape supported by NMPulse (square, ramp, alpha, sine, …) can be used, including multi-pulse superposition and per-epoch amplitude stepping via amp_delta

### Test plan

-  NMConductanceLeak/HHNa/HHK: defaults, gate kinetics, current formula, serialisation round-trip
-  NMModelHH: V_rest equilibrium (brentq root ≈ −64.9964 mV), AP count for square steps (25, 30, 100, 200 pA → 0, 1, 7, 9 APs), ramp+ 0→500 pA → 9 APs, anodal-break spike (−35 pA → 1 rebound AP), gate dynamics, temperature Q10 scaling, serialisation
-  NMToolModel: single/multi-epoch output naming, channel string, save_states toolfolder, overwrite replaces data, accumulator reset between runs, note string includes pulse params
