### PR TITLE
feat(tools): add NMModelIAF integrate-and-fire neuron model

### DIFF
--- a/pyneuromatic/tools/nm_model.py
+++ b/pyneuromatic/tools/nm_model.py
@@ -383,11 +383,295 @@ class NMModelHH(NMModel):
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Integrate-and-Fire model
+# ──────────────────────────────────────────────────────────────────────────────
+
+class NMModelIAF(NMModel):
+    """Integrate-and-fire point-neuron model.
+
+    Integrates the subthreshold ODE using forward Euler.  When the membrane
+    potential reaches ``ap_threshold``, a spike is inserted (the crossing point
+    is set to ``ap_peak``) and the neuron is held at ``ap_reset`` for
+    ``ap_refrac`` ms before integration resumes.
+
+    The leak conductance lives in a :class:`NMConductanceContainer` so that
+    synaptic conductances (GABA, AMPA, NMDA) can be added later without
+    changing the core integration loop.
+
+    Parameters:
+        v0:           Resting / initial potential (mV).    Default −80.0.
+        temperature:  Simulation temperature (°C).          Default 37.0.
+                      Not currently used (no Q10-dependent kinetics).
+        cm_density:   Specific membrane capacitance
+                      (pF/µm²; 0.01 pF/µm² = 1 µF/cm²).   Default 0.01.
+        diameter:     Cell diameter (µm).                   Default 10.0.
+        ap_threshold: Spike threshold (mV).                 Default −40.0.
+        ap_peak:      Spike peak inserted at threshold (mV).Default  32.0.
+        ap_reset:     Post-spike reset potential (mV).       Default −61.0.
+        ap_refrac:    Absolute refractory period (ms; > 0). Default 2.0.
+
+    Default conductance matches the Igor NeuroMatic IAF reference cell:
+        Leak  g = 0.9 nS total / SA ≈ 0.002865 nS/µm²,  E = −80 mV
+        (0.9 nS absorbs the tonic-GABA contribution; split out when GABA is added.)
+
+    Units summary:
+        time:        ms
+        voltage:     mV
+        current:     pA
+        capacitance: pF  → dV/dt in mV/ms  (pA/pF = mV/ms)
+    """
+
+    _DEFAULT_DIAMETER:       float = 10.0
+    # 0.9 nS total / (π × 10²) µm²
+    _DEFAULT_LEAK_G_DENSITY: float = 0.9 / (math.pi * 10.0 ** 2)
+    _DEFAULT_LEAK_E_REV:     float = -80.0
+
+    def __init__(
+        self,
+        name: str = "iaf",
+        config: dict | None = None,
+        nm_path: str = "model",
+    ) -> None:
+        super().__init__(name=name, nm_path=nm_path)
+        self._v0:           float = -80.0
+        self._temperature:  float = 37.0
+        self._cm_density:   float = 0.01
+        self._diameter:     float = self._DEFAULT_DIAMETER
+        self._ap_threshold: float = -40.0
+        self._ap_peak:      float =  32.0
+        self._ap_reset:     float = -61.0
+        self._ap_refrac:    float =   2.0
+
+        self._conductances = NMConductanceContainer(
+            nm_path=nm_path + ".conductances"
+        )
+        self._conductances.add(
+            "Leak",
+            NMConductanceLeak(
+                g_density=self._DEFAULT_LEAK_G_DENSITY,
+                e_rev=self._DEFAULT_LEAK_E_REV,
+            ),
+        )
+
+        if config is not None:
+            self._config_set(config, quiet=True)
+
+    # ------------------------------------------------------------------
+    # Properties
+
+    @property
+    def cm_density(self) -> float:
+        """Specific membrane capacitance (pF/µm²)."""
+        return self._cm_density
+
+    @cm_density.setter
+    def cm_density(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("cm_density must be a float")
+        if value <= 0:
+            raise ValueError("cm_density must be > 0, got %g" % value)
+        self._cm_density = float(value)
+
+    @property
+    def diameter(self) -> float:
+        """Cell diameter (µm)."""
+        return self._diameter
+
+    @diameter.setter
+    def diameter(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("diameter must be a float")
+        if value <= 0:
+            raise ValueError("diameter must be > 0, got %g" % value)
+        self._diameter = float(value)
+
+    @property
+    def ap_threshold(self) -> float:
+        """Spike threshold (mV)."""
+        return self._ap_threshold
+
+    @ap_threshold.setter
+    def ap_threshold(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("ap_threshold must be a float")
+        self._ap_threshold = float(value)
+
+    @property
+    def ap_peak(self) -> float:
+        """Spike peak potential inserted at threshold crossing (mV)."""
+        return self._ap_peak
+
+    @ap_peak.setter
+    def ap_peak(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("ap_peak must be a float")
+        self._ap_peak = float(value)
+
+    @property
+    def ap_reset(self) -> float:
+        """Post-spike reset potential (mV)."""
+        return self._ap_reset
+
+    @ap_reset.setter
+    def ap_reset(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("ap_reset must be a float")
+        self._ap_reset = float(value)
+
+    @property
+    def ap_refrac(self) -> float:
+        """Absolute refractory period (ms)."""
+        return self._ap_refrac
+
+    @ap_refrac.setter
+    def ap_refrac(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("ap_refrac must be a float")
+        if value <= 0:
+            raise ValueError("ap_refrac must be > 0, got %g" % value)
+        self._ap_refrac = float(value)
+
+    @property
+    def conductances(self) -> NMConductanceContainer:
+        """The conductance container (Leak by default)."""
+        return self._conductances
+
+    # ------------------------------------------------------------------
+    # Derived quantities
+
+    def _surface_area(self) -> float:
+        """Sphere surface area in µm²: π × diameter²."""
+        return math.pi * self._diameter ** 2
+
+    def _capacitance(self) -> float:
+        """Total membrane capacitance in pF."""
+        return self._cm_density * self._surface_area()
+
+    # ------------------------------------------------------------------
+    # Simulation
+
+    def simulate(
+        self,
+        n_points: int,
+        xstart: float,
+        xdelta: float,
+        i_ext: np.ndarray,
+    ) -> dict[str, np.ndarray]:
+        """Integrate the IAF ODE with forward Euler and threshold detection.
+
+        Args:
+            n_points: Number of time samples.
+            xstart:   First time point (ms).  Not used in integration but
+                      stored for API consistency with NMModelHH.
+            xdelta:   Time step (ms; also determines refractory step count).
+            i_ext:    External current (pA), 1-D array of length ``n_points``.
+
+        Returns:
+            Dict with key ``"V"`` (mV), a 1-D array of length ``n_points``.
+            Spike peaks are recorded at the threshold-crossing sample;
+            refractory samples are held at ``ap_reset``.
+        """
+        if n_points < 1:
+            raise ValueError("n_points must be >= 1")
+        if xdelta <= 0:
+            raise ValueError("xdelta must be > 0")
+        i_ext = np.asarray(i_ext, dtype=float)
+        if i_ext.shape != (n_points,):
+            raise ValueError("i_ext must have length n_points (%d)" % n_points)
+
+        SA = self._surface_area()
+        Cm = self._capacitance()
+        refrac_steps = max(1, round(self._ap_refrac / xdelta))
+
+        V = np.zeros(n_points)
+        V[0] = self._v0
+        refrac_remaining = 0
+
+        for i in range(n_points - 1):
+            if refrac_remaining > 0:
+                V[i + 1] = self._ap_reset
+                refrac_remaining -= 1
+                continue
+            v = V[i]
+            i_ionic = sum(
+                cond.current(v, []) * SA for _, cond in self._conductances
+            )
+            v_next = v + (i_ext[i] - i_ionic) / Cm * xdelta
+            if v_next >= self._ap_threshold:
+                V[i] = self._ap_peak
+                V[i + 1] = self._ap_reset
+                refrac_remaining = refrac_steps - 1
+            else:
+                V[i + 1] = v_next
+
+        return {"V": V}
+
+    # ------------------------------------------------------------------
+    # Config / serialisation
+
+    _SCALAR_KEYS = frozenset({
+        "v0", "temperature", "cm_density", "diameter",
+        "ap_threshold", "ap_peak", "ap_reset", "ap_refrac",
+    })
+
+    def _config_set(self, config: dict, quiet: bool = True) -> None:
+        for key, value in config.items():
+            if key == "model":
+                continue
+            if key == "conductances":
+                self._conductances = NMConductanceContainer.from_dict(
+                    {"conductances": value},
+                    nm_path=self._nm_path + ".conductances",
+                )
+            elif key in self._SCALAR_KEYS:
+                setattr(self, key, value)
+            else:
+                raise KeyError("unknown NMModelIAF config key %r" % key)
+
+    def to_dict(self) -> dict:
+        d: dict = {
+            "model":        "iaf",
+            "v0":           self._v0,
+            "temperature":  self._temperature,
+            "cm_density":   self._cm_density,
+            "diameter":     self._diameter,
+            "ap_threshold": self._ap_threshold,
+            "ap_peak":      self._ap_peak,
+            "ap_reset":     self._ap_reset,
+            "ap_refrac":    self._ap_refrac,
+        }
+        d["conductances"] = self._conductances.to_dict()["conductances"]
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict, nm_path: str = "model") -> "NMModelIAF":
+        obj = cls(name=d.get("model", "iaf"), nm_path=nm_path)
+        obj._config_set(d, quiet=True)
+        return obj
+
+    def __repr__(self) -> str:
+        return (
+            "NMModelIAF(v0=%g, cm_density=%g, diameter=%g, "
+            "ap_threshold=%g, ap_peak=%g, ap_reset=%g, ap_refrac=%g)"
+            % (
+                self._v0,
+                self._cm_density,
+                self._diameter,
+                self._ap_threshold,
+                self._ap_peak,
+                self._ap_reset,
+                self._ap_refrac,
+            )
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Registry and factory
 # ──────────────────────────────────────────────────────────────────────────────
 
 _MODEL_REGISTRY: dict[str, type[NMModel]] = {
-    "hh": NMModelHH,
+    "hh":  NMModelHH,
+    "iaf": NMModelIAF,
 }
 
 

--- a/tests/test_tools/test_nm_model.py
+++ b/tests/test_tools/test_nm_model.py
@@ -4,7 +4,7 @@ import math
 import numpy as np
 import pytest
 
-from pyneuromatic.tools.nm_model import NMModel, NMModelHH, _model_from_dict
+from pyneuromatic.tools.nm_model import NMModel, NMModelHH, NMModelIAF, _model_from_dict
 from pyneuromatic.tools.nm_conductance import (
     NMConductanceLeak,
     NMConductanceHHNa,
@@ -412,6 +412,12 @@ class TestModelFactory:
         assert isinstance(m2, NMModelHH)
         assert m == m2
 
+    def test_dispatch_iaf(self):
+        m = NMModelIAF()
+        m2 = _model_from_dict(m.to_dict())
+        assert isinstance(m2, NMModelIAF)
+        assert m == m2
+
     def test_unknown_model_raises(self):
         with pytest.raises(KeyError):
             _model_from_dict({"model": "mystery"})
@@ -419,3 +425,310 @@ class TestModelFactory:
     def test_none_model_raises(self):
         with pytest.raises(KeyError):
             _model_from_dict({})
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMModelIAF — helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _sim_default_iaf(i_amp=200.0):
+    """Suprathreshold IAF simulation: 25 ms onset, 100 ms step, 150 ms total."""
+    n_pts = round(150.0 / XDELTA)
+    m = NMModelIAF()
+    i_ext = _make_i_ext(n_pts, round(25.0 / XDELTA), i_amp,
+                        duration_idx=round(100.0 / XDELTA))
+    return m.simulate(n_pts, 0.0, XDELTA, i_ext)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMModelIAF construction
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelIAFConstruct:
+    def test_default_params(self):
+        import math
+        m = NMModelIAF()
+        assert m.v0           == pytest.approx(-80.0)
+        assert m.temperature  == pytest.approx(37.0)
+        assert m.cm_density   == pytest.approx(0.01)
+        assert m.diameter     == pytest.approx(10.0)
+        assert m.ap_threshold == pytest.approx(-40.0)
+        assert m.ap_peak      == pytest.approx(32.0)
+        assert m.ap_reset     == pytest.approx(-61.0)
+        assert m.ap_refrac    == pytest.approx(2.0)
+
+    def test_default_conductances(self):
+        m = NMModelIAF()
+        assert "Leak" in m.conductances
+        assert len(m.conductances) == 1
+
+    def test_default_leak_params(self):
+        import math
+        m = NMModelIAF()
+        leak = m.conductances["Leak"]
+        expected_g = 0.9 / (math.pi * 10.0 ** 2)
+        assert leak.g_density == pytest.approx(expected_g)
+        assert leak.e_rev     == pytest.approx(-80.0)
+
+    def test_name(self):
+        m = NMModelIAF(name="test_iaf")
+        assert m.name == "test_iaf"
+
+    def test_v0_setter(self):
+        m = NMModelIAF()
+        m.v0 = -70.0
+        assert m.v0 == pytest.approx(-70.0)
+
+    def test_cm_density_setter_zero_raises(self):
+        m = NMModelIAF()
+        with pytest.raises(ValueError):
+            m.cm_density = 0.0
+
+    def test_diameter_setter_zero_raises(self):
+        m = NMModelIAF()
+        with pytest.raises(ValueError):
+            m.diameter = 0.0
+
+    def test_ap_refrac_setter_zero_raises(self):
+        m = NMModelIAF()
+        with pytest.raises(ValueError):
+            m.ap_refrac = 0.0
+
+    def test_ap_threshold_setter_bool_raises(self):
+        m = NMModelIAF()
+        with pytest.raises(TypeError):
+            m.ap_threshold = True
+
+    def test_ap_peak_setter(self):
+        m = NMModelIAF()
+        m.ap_peak = 40.0
+        assert m.ap_peak == pytest.approx(40.0)
+
+    def test_ap_reset_setter(self):
+        m = NMModelIAF()
+        m.ap_reset = -70.0
+        assert m.ap_reset == pytest.approx(-70.0)
+
+    def test_config_kwarg(self):
+        m = NMModelIAF(config={"v0": -75.0, "ap_threshold": -35.0})
+        assert m.v0           == pytest.approx(-75.0)
+        assert m.ap_threshold == pytest.approx(-35.0)
+
+    def test_config_unknown_key_raises(self):
+        m = NMModelIAF()
+        with pytest.raises(KeyError):
+            m._config_set({"nonexistent_key": 1.0})
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# simulate() return shape and keys
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelIAFSimulateShape:
+    def test_returns_dict(self):
+        assert isinstance(_sim_default_iaf(), dict)
+
+    def test_has_V_key(self):
+        assert "V" in _sim_default_iaf()
+
+    def test_array_length(self):
+        n_pts = round(150.0 / XDELTA)
+        result = _sim_default_iaf()
+        assert len(result["V"]) == n_pts
+
+    def test_invalid_n_points(self):
+        m = NMModelIAF()
+        with pytest.raises(ValueError):
+            m.simulate(0, 0.0, XDELTA, np.zeros(0))
+
+    def test_invalid_xdelta(self):
+        m = NMModelIAF()
+        with pytest.raises(ValueError):
+            m.simulate(100, 0.0, 0.0, np.zeros(100))
+
+    def test_wrong_i_ext_length(self):
+        m = NMModelIAF()
+        with pytest.raises(ValueError):
+            m.simulate(100, 0.0, XDELTA, np.zeros(50))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Resting state stability
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelIAFRest:
+    def test_resting_potential_stable(self):
+        """Zero input: Vm should stay within 1 mV of V0 (= E_leak)."""
+        m = NMModelIAF()
+        n_pts = round(100.0 / XDELTA)
+        result = m.simulate(n_pts, 0.0, XDELTA, np.zeros(n_pts))
+        assert np.all(np.abs(result["V"] - m.v0) < 1.0), (
+            "Vm drifted > 1 mV from rest with no input"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Spike generation
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelIAFSpikes:
+    def test_spike_peak_equals_ap_peak(self):
+        """Peak of output voltage trace should equal ap_peak exactly."""
+        m = NMModelIAF()
+        result = _sim_default_iaf()
+        assert result["V"].max() == pytest.approx(m.ap_peak)
+
+    def test_subthreshold_no_spike(self):
+        """30 pA (< threshold ≈ 36 pA) should produce no spike."""
+        n_pts = round(150.0 / XDELTA)
+        i_ext = _make_i_ext(n_pts, round(25.0 / XDELTA), amp=30.0,
+                            duration_idx=round(100.0 / XDELTA))
+        result = NMModelIAF().simulate(n_pts, 0.0, XDELTA, i_ext)
+        assert result["V"].max() < 0.0, "Unexpected spike with subthreshold input"
+
+    def test_refractory_enforces_minimum_isi(self):
+        """All inter-spike intervals should be >= ap_refrac."""
+        from scipy.signal import find_peaks
+        n_pts = round(150.0 / XDELTA)
+        i_ext = _make_i_ext(n_pts, round(25.0 / XDELTA), amp=500.0,
+                            duration_idx=round(100.0 / XDELTA))
+        m = NMModelIAF()
+        result = m.simulate(n_pts, 0.0, XDELTA, i_ext)
+        peaks, _ = find_peaks(result["V"], height=0.0, distance=round(1.5 / XDELTA))
+        assert len(peaks) >= 2
+        for p1, p2 in zip(peaks[:-1], peaks[1:]):
+            isi_ms = (p2 - p1) * XDELTA
+            assert isi_ms >= m.ap_refrac, (
+                "ISI = %g ms < ap_refrac = %g ms" % (isi_ms, m.ap_refrac)
+            )
+
+    def test_mean_isi(self):
+        """At 50 pA the mean ISI should match the analytical prediction.
+
+        Analytical: ISI = refrac + tau_m * ln((V_ss - V_reset)/(V_ss - V_thresh))
+        With g_leak=0.9 nS, Cm=pi*10^2*0.01 pF, V_ss=-24.4 mV:  ISI ≈ 5.0 ms.
+        Forward Euler introduces a small bias; we allow ±0.1 ms tolerance.
+        """
+        from scipy.signal import find_peaks
+        n_pts = round(200.0 / XDELTA)
+        i_ext = _make_i_ext(n_pts, round(25.0 / XDELTA), amp=50.0,
+                            duration_idx=round(150.0 / XDELTA))
+        result = NMModelIAF().simulate(n_pts, 0.0, XDELTA, i_ext)
+        peaks, _ = find_peaks(result["V"], height=0.0, distance=round(1.5 / XDELTA))
+        assert len(peaks) >= 5, "Too few APs to measure ISI"
+        isis = [(peaks[k + 1] - peaks[k]) * XDELTA for k in range(1, len(peaks) - 1)]
+        mean_isi = sum(isis) / len(isis)
+        assert mean_isi == pytest.approx(5.0, abs=0.15), (
+            "Mean ISI = %g ms, expected ≈ 5.0 ms" % mean_isi
+        )
+
+    @pytest.mark.parametrize("i_amp_lo,i_amp_hi", [
+        (50, 100),
+        (100, 200),
+    ])
+    def test_higher_current_shorter_isi(self, i_amp_lo, i_amp_hi):
+        """More current should give a shorter (faster) mean ISI."""
+        from scipy.signal import find_peaks
+        n_pts = round(200.0 / XDELTA)
+        dur_idx = round(150.0 / XDELTA)
+        onset = round(25.0 / XDELTA)
+        min_dist = round(1.5 / XDELTA)
+
+        def mean_isi(amp):
+            i_ext = _make_i_ext(n_pts, onset, amp=float(amp), duration_idx=dur_idx)
+            result = NMModelIAF().simulate(n_pts, 0.0, XDELTA, i_ext)
+            peaks, _ = find_peaks(result["V"], height=0.0, distance=min_dist)
+            isis = [(peaks[k + 1] - peaks[k]) * XDELTA for k in range(1, len(peaks) - 1)]
+            return sum(isis) / len(isis)
+
+        assert mean_isi(i_amp_lo) > mean_isi(i_amp_hi), (
+            "%d pA should have longer ISI than %d pA" % (i_amp_lo, i_amp_hi)
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Derived quantities
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelIAFTimeConstant:
+    def test_membrane_time_constant(self):
+        """τ_m = Cm / g_leak measured from subthreshold exponential charging.
+
+        Apply a step current, find the time at which V reaches 63.2% of the
+        way from V0 to V_ss — that time equals τ_m.  Tolerance is ±2 × xdelta
+        (one grid step either side of the true crossing).
+        """
+        xdelta = 0.025
+        onset_idx = round(5.0 / xdelta)
+        n_pts = round(50.0 / xdelta)   # 50 ms — much longer than τ_m ≈ 3.5 ms
+        i_amp = 20.0                    # pA — subthreshold (threshold ≈ 36 pA)
+
+        m = NMModelIAF()
+        i_ext = np.zeros(n_pts)
+        i_ext[onset_idx:] = i_amp
+        V = m.simulate(n_pts, 0.0, xdelta, i_ext)["V"]
+
+        # Expected: τ_m = Cm / g_leak  (SA cancels, so = cm_density / g_leak_density)
+        g_leak = m.conductances["Leak"].g_density * m._surface_area()  # nS
+        tau_expected = m._capacitance() / g_leak                        # ms
+
+        # V_ss = E_leak + I/g_leak;  target = V0 + (V_ss - V0)*(1 - 1/e)
+        import math
+        V_ss = m.conductances["Leak"].e_rev + i_amp / g_leak
+        V_target = m.v0 + (V_ss - m.v0) * (1.0 - 1.0 / math.e)
+
+        crossing = np.argmax(V[onset_idx:] >= V_target)
+        tau_measured = crossing * xdelta   # ms after onset
+
+        assert tau_measured == pytest.approx(tau_expected, abs=2 * xdelta), (
+            "τ_m measured=%g ms, expected=%g ms" % (tau_measured, tau_expected)
+        )
+
+
+class TestNMModelIAFDerived:
+    def test_surface_area(self):
+        import math
+        m = NMModelIAF()
+        assert m._surface_area() == pytest.approx(math.pi * 10.0 ** 2)
+
+    def test_capacitance(self):
+        import math
+        m = NMModelIAF()
+        assert m._capacitance() == pytest.approx(0.01 * math.pi * 10.0 ** 2)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Serialisation
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModelIAFSerialisation:
+    def test_to_dict_keys(self):
+        m = NMModelIAF()
+        d = m.to_dict()
+        assert d["model"] == "iaf"
+        for key in ("v0", "temperature", "cm_density", "diameter",
+                    "ap_threshold", "ap_peak", "ap_reset", "ap_refrac"):
+            assert key in d
+        assert "conductances" in d
+
+    def test_to_dict_conductances_list(self):
+        m = NMModelIAF()
+        d = m.to_dict()
+        assert isinstance(d["conductances"], list)
+        assert len(d["conductances"]) == 1
+
+    def test_from_dict_round_trip(self):
+        m = NMModelIAF()
+        m.ap_refrac = 3.0
+        m.diameter  = 15.0
+        m2 = NMModelIAF.from_dict(m.to_dict())
+        assert m == m2
+
+    def test_eq_symmetric(self):
+        assert NMModelIAF() == NMModelIAF()
+
+    def test_eq_different_param(self):
+        m1 = NMModelIAF()
+        m2 = NMModelIAF()
+        m2.ap_threshold = -35.0
+        assert m1 != m2


### PR DESCRIPTION
### Summary

- Adds NMModelIAF, an integrate-and-fire point-neuron model, to nm_model.py alongside NMModelHH
- Uses forward Euler integration with explicit threshold detection: at threshold crossing the sample is set to ap_peak, the next ap_refrac ms are held at ap_reset, then integration resumes
- Leak conductance is stored in a NMConductanceContainer (identical pattern to HH) so tonic GABA, AMPA and NMDA can be added in later PRs without restructuring the core loop
- Default parameters match the Igor NeuroMatic IAF reference cell: V0 = −80 mV, threshold = −40 mV, peak = +32 mV, reset = −61 mV, refrac = 2 ms; g_leak = 0.9 nS total (absorbs tonic GABA until that conductance is split out); diameter = 10 µm giving Cm ≈ 3.14 pF and τ_m ≈ 3.49 ms

### Test plan

- Construction: all 8 scalar defaults, setters (valid + TypeError/ValueError), config kwarg, unknown key raises
-  simulate() shape: returns {"V": array}, correct length, ValueError on bad inputs
-  Resting stability: zero input → V stays within 1 mV of V0
-  Spike shape: V.max() == ap_peak exactly; subthreshold (30 pA) → no spike
-  Refractory: all ISIs ≥ ap_refrac under high current
-  Mean ISI ≈ 5.0 ms at 50 pA (±0.15 ms); higher current → shorter ISI
-  Membrane time constant: 63.2% charging time from subthreshold step ≈ 3.49 ms (±2 × xdelta)
-  Serialisation: to_dict keys, from_dict round-trip, __eq__
-  Factory: _model_from_dict({"model": "iaf", ...}) returns NMModelIAF