### PR TITLE
feat(model): add exact integration method to NMModelIAF (#330)

### DIFF
--- a/pyneuromatic/tools/nm_model.py
+++ b/pyneuromatic/tools/nm_model.py
@@ -389,10 +389,9 @@ class NMModelHH(NMModel):
 class NMModelIAF(NMModel):
     """Integrate-and-fire point-neuron model.
 
-    Integrates the subthreshold ODE using forward Euler.  When the membrane
-    potential reaches ``ap_threshold``, a spike is inserted (the crossing point
-    is set to ``ap_peak``) and the neuron is held at ``ap_reset`` for
-    ``ap_refrac`` ms before integration resumes.
+    When the membrane potential reaches ``ap_threshold``, a spike is inserted
+    (the crossing point is set to ``ap_peak``) and the neuron is held at
+    ``ap_reset`` for ``ap_refrac`` ms before integration resumes.
 
     The leak conductance lives in a :class:`NMConductanceContainer` so that
     synaptic conductances (GABA, AMPA, NMDA) can be added later without
@@ -409,6 +408,23 @@ class NMModelIAF(NMModel):
         ap_peak:      Spike peak inserted at threshold (mV).Default  32.0.
         ap_reset:     Post-spike reset potential (mV).       Default −61.0.
         ap_refrac:    Absolute refractory period (ms; > 0). Default 2.0.
+        method:       Integration method: ``"exact"`` (default) or
+                      ``"euler"``.
+
+    Integration methods:
+
+    ``"exact"`` — closed-form update between spikes:
+
+        V(t+dt) = V_ss + (V(t) − V_ss) × exp(−dt / τ_m)
+
+    where V_ss = (I_ext + Σ gᵢ·SAᵢ·Eᵢ) / G_total and τ_m = Cm / G_total.
+    ``exp(−dt/τ_m)`` is precomputed once per simulation.  Correct at any
+    step size; allows larger ``xdelta`` for faster runs at equal accuracy.
+    Assumes all conductances are ohmic (no time-varying gating) — use
+    ``"euler"`` once synaptic conductances with kinetics are added.
+
+    ``"euler"`` — forward Euler: V(t+dt) = V(t) + dV/dt · dt.  Simple but
+    accumulates O(dt) error per step (ISI error ≈ 0.1 ms at dt = 0.025 ms).
 
     Default conductance matches the Igor NeuroMatic IAF reference cell:
         Leak  g = 0.9 nS total / SA ≈ 0.002865 nS/µm²,  E = −80 mV
@@ -425,6 +441,7 @@ class NMModelIAF(NMModel):
     # 0.9 nS total / (π × 10²) µm²
     _DEFAULT_LEAK_G_DENSITY: float = 0.9 / (math.pi * 10.0 ** 2)
     _DEFAULT_LEAK_E_REV:     float = -80.0
+    _VALID_METHODS = frozenset({"euler", "exact"})
 
     def __init__(
         self,
@@ -441,6 +458,7 @@ class NMModelIAF(NMModel):
         self._ap_peak:      float =  32.0
         self._ap_reset:     float = -61.0
         self._ap_refrac:    float =   2.0
+        self._method:       str   = "exact"
 
         self._conductances = NMConductanceContainer(
             nm_path=nm_path + ".conductances"
@@ -532,6 +550,22 @@ class NMModelIAF(NMModel):
         self._ap_refrac = float(value)
 
     @property
+    def method(self) -> str:
+        """Integration method: ``"exact"`` (default) or ``"euler"``."""
+        return self._method
+
+    @method.setter
+    def method(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("method must be a string")
+        if value not in self._VALID_METHODS:
+            raise ValueError(
+                "method must be one of %s, got %r"
+                % (sorted(self._VALID_METHODS), value)
+            )
+        self._method = value
+
+    @property
     def conductances(self) -> NMConductanceContainer:
         """The conductance container (Leak by default)."""
         return self._conductances
@@ -557,7 +591,7 @@ class NMModelIAF(NMModel):
         xdelta: float,
         i_ext: np.ndarray,
     ) -> dict[str, np.ndarray]:
-        """Integrate the IAF ODE with forward Euler and threshold detection.
+        """Integrate the IAF ODE with threshold detection.
 
         Args:
             n_points: Number of time samples.
@@ -587,22 +621,51 @@ class NMModelIAF(NMModel):
         V[0] = self._v0
         refrac_remaining = 0
 
-        for i in range(n_points - 1):
-            if refrac_remaining > 0:
-                V[i + 1] = self._ap_reset
-                refrac_remaining -= 1
-                continue
-            v = V[i]
-            i_ionic = sum(
-                cond.current(v, []) * SA for _, cond in self._conductances
+        if self._method == "exact":
+            # Precompute constants for the closed-form update:
+            #   V(t+dt) = V_ss(t) + (V(t) - V_ss(t)) * exp(-dt/tau_m)
+            # V_ss = (I_ext + sum(g_i*SA*E_i)) / G_total  (depends on i_ext each step)
+            # tau_m = Cm / G_total  (constant — all conductances are ohmic)
+            G_total = sum(
+                cond.g_density * SA for _, cond in self._conductances
             )
-            v_next = v + (i_ext[i] - i_ionic) / Cm * xdelta
-            if v_next >= self._ap_threshold:
-                V[i] = self._ap_peak
-                V[i + 1] = self._ap_reset
-                refrac_remaining = refrac_steps - 1
-            else:
-                V[i + 1] = v_next
+            sum_gE = sum(
+                cond.g_density * SA * cond.e_rev for _, cond in self._conductances
+            )
+            tau_m = Cm / G_total
+            exp_factor = math.exp(-xdelta / tau_m)
+
+            for i in range(n_points - 1):
+                if refrac_remaining > 0:
+                    V[i + 1] = self._ap_reset
+                    refrac_remaining -= 1
+                    continue
+                v = V[i]
+                V_ss = (i_ext[i] + sum_gE) / G_total
+                v_next = V_ss + (v - V_ss) * exp_factor
+                if v_next >= self._ap_threshold:
+                    V[i] = self._ap_peak
+                    V[i + 1] = self._ap_reset
+                    refrac_remaining = refrac_steps - 1
+                else:
+                    V[i + 1] = v_next
+        else:
+            for i in range(n_points - 1):
+                if refrac_remaining > 0:
+                    V[i + 1] = self._ap_reset
+                    refrac_remaining -= 1
+                    continue
+                v = V[i]
+                i_ionic = sum(
+                    cond.current(v, []) * SA for _, cond in self._conductances
+                )
+                v_next = v + (i_ext[i] - i_ionic) / Cm * xdelta
+                if v_next >= self._ap_threshold:
+                    V[i] = self._ap_peak
+                    V[i + 1] = self._ap_reset
+                    refrac_remaining = refrac_steps - 1
+                else:
+                    V[i + 1] = v_next
 
         return {"V": V}
 
@@ -623,6 +686,8 @@ class NMModelIAF(NMModel):
                     {"conductances": value},
                     nm_path=self._nm_path + ".conductances",
                 )
+            elif key == "method":
+                self.method = value
             elif key in self._SCALAR_KEYS:
                 setattr(self, key, value)
             else:
@@ -639,6 +704,7 @@ class NMModelIAF(NMModel):
             "ap_peak":      self._ap_peak,
             "ap_reset":     self._ap_reset,
             "ap_refrac":    self._ap_refrac,
+            "method":       self._method,
         }
         d["conductances"] = self._conductances.to_dict()["conductances"]
         return d
@@ -652,7 +718,7 @@ class NMModelIAF(NMModel):
     def __repr__(self) -> str:
         return (
             "NMModelIAF(v0=%g, cm_density=%g, diameter=%g, "
-            "ap_threshold=%g, ap_peak=%g, ap_reset=%g, ap_refrac=%g)"
+            "ap_threshold=%g, ap_peak=%g, ap_reset=%g, ap_refrac=%g, method=%r)"
             % (
                 self._v0,
                 self._cm_density,
@@ -661,6 +727,7 @@ class NMModelIAF(NMModel):
                 self._ap_peak,
                 self._ap_reset,
                 self._ap_refrac,
+                self._method,
             )
         )
 

--- a/tests/test_tools/test_nm_model.py
+++ b/tests/test_tools/test_nm_model.py
@@ -519,6 +519,33 @@ class TestNMModelIAFConstruct:
         with pytest.raises(KeyError):
             m._config_set({"nonexistent_key": 1.0})
 
+    def test_default_method_is_exact(self):
+        assert NMModelIAF().method == "exact"
+
+    def test_method_euler_accepted(self):
+        m = NMModelIAF()
+        m.method = "euler"
+        assert m.method == "euler"
+
+    def test_method_exact_accepted(self):
+        m = NMModelIAF()
+        m.method = "exact"
+        assert m.method == "exact"
+
+    def test_method_invalid_string_raises(self):
+        m = NMModelIAF()
+        with pytest.raises(ValueError):
+            m.method = "rk45"
+
+    def test_method_non_string_raises(self):
+        m = NMModelIAF()
+        with pytest.raises(TypeError):
+            m.method = 1
+
+    def test_config_kwarg_method(self):
+        m = NMModelIAF(config={"method": "euler"})
+        assert m.method == "euler"
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # simulate() return shape and keys
@@ -602,12 +629,35 @@ class TestNMModelIAFSpikes:
                 "ISI = %g ms < ap_refrac = %g ms" % (isi_ms, m.ap_refrac)
             )
 
+    @pytest.mark.parametrize("i_amp,expected_aps", [
+        (50,  20),
+        (100, 34),
+        (200, 42),
+    ])
+    def test_ap_count(self, i_amp, expected_aps):
+        """Exact integration gives the analytically correct AP count.
+
+        Onset=25 ms, duration=100 ms step.  Counts are determined by the
+        closed-form ISI = τ_refrac + τ_m·ln((V_ss−V_reset)/(V_ss−V_thresh))
+        and are stable at any step size with the exact method.
+        """
+        from scipy.signal import find_peaks
+        n_pts = round(150.0 / XDELTA)
+        i_ext = _make_i_ext(n_pts, round(25.0 / XDELTA), float(i_amp),
+                            duration_idx=round(100.0 / XDELTA))
+        m = NMModelIAF()
+        m.method = "exact"
+        result = m.simulate(n_pts, 0.0, XDELTA, i_ext)
+        peaks, _ = find_peaks(result["V"], height=0.0, distance=round(1.5 / XDELTA))
+        assert len(peaks) == expected_aps, (
+            "%d pA: expected %d APs, got %d" % (i_amp, expected_aps, len(peaks))
+        )
+
     def test_mean_isi(self):
         """At 50 pA the mean ISI should match the analytical prediction.
 
         Analytical: ISI = refrac + tau_m * ln((V_ss - V_reset)/(V_ss - V_thresh))
         With g_leak=0.9 nS, Cm=pi*10^2*0.01 pF, V_ss=-24.4 mV:  ISI ≈ 5.0 ms.
-        Forward Euler introduces a small bias; we allow ±0.1 ms tolerance.
         """
         from scipy.signal import find_peaks
         n_pts = round(200.0 / XDELTA)
@@ -643,6 +693,57 @@ class TestNMModelIAFSpikes:
 
         assert mean_isi(i_amp_lo) > mean_isi(i_amp_hi), (
             "%d pA should have longer ISI than %d pA" % (i_amp_lo, i_amp_hi)
+        )
+
+    def test_exact_and_euler_agree_at_small_dt(self):
+        """At dt=0.025 ms, exact and Euler give nearly identical subthreshold traces.
+
+        Uses a strictly subthreshold current (< threshold I) so there are no
+        spikes and no spike-timing offset artefacts between the two methods.
+        """
+        n_pts = round(150.0 / XDELTA)
+        # 20 pA is well below threshold (I_thresh = g_leak * (V_thresh - E_leak) ≈ 36 pA)
+        i_ext = _make_i_ext(n_pts, round(25.0 / XDELTA), amp=20.0,
+                            duration_idx=round(100.0 / XDELTA))
+        m_exact = NMModelIAF()
+        m_exact.method = "exact"
+        m_euler = NMModelIAF()
+        m_euler.method = "euler"
+        V_exact = m_exact.simulate(n_pts, 0.0, XDELTA, i_ext)["V"]
+        V_euler = m_euler.simulate(n_pts, 0.0, XDELTA, i_ext)["V"]
+        assert np.max(np.abs(V_exact - V_euler)) < 0.05, (
+            "Exact and Euler disagree by more than 0.05 mV at dt=%g ms" % XDELTA
+        )
+
+    def test_exact_correct_at_large_dt(self):
+        """Exact integration recovers the correct τ_m even at dt=0.5 ms where Euler errors."""
+        import math
+        xdelta_large = 0.5  # 20× default step — Euler accumulates large error
+        n_pts = round(50.0 / xdelta_large)
+        onset = round(5.0 / xdelta_large)
+        i_amp = 10.0  # subthreshold
+
+        m = NMModelIAF()
+        SA = math.pi * m.diameter ** 2
+        g_total = m.conductances["Leak"].g_density * SA
+        Cm = m.cm_density * SA
+        tau_m = Cm / g_total
+        e_rev = m.conductances["Leak"].e_rev
+        V_ss = e_rev + i_amp / g_total
+
+        i_ext = _make_i_ext(n_pts, onset, amp=i_amp,
+                            duration_idx=n_pts - onset)
+        m.method = "exact"
+        V_exact = m.simulate(n_pts, 0.0, xdelta_large, i_ext)["V"]
+
+        # Compare against the analytical solution at each sample
+        V_ana = np.array([
+            V_ss + (m.v0 - V_ss) * math.exp(-(i - onset) * xdelta_large / tau_m)
+            if i >= onset else m.v0
+            for i in range(n_pts)
+        ])
+        assert np.max(np.abs(V_exact[onset:] - V_ana[onset:])) < 0.01, (
+            "Exact integration deviates from analytical solution by more than 0.01 mV"
         )
 
 
@@ -707,9 +808,18 @@ class TestNMModelIAFSerialisation:
         d = m.to_dict()
         assert d["model"] == "iaf"
         for key in ("v0", "temperature", "cm_density", "diameter",
-                    "ap_threshold", "ap_peak", "ap_reset", "ap_refrac"):
+                    "ap_threshold", "ap_peak", "ap_reset", "ap_refrac", "method"):
             assert key in d
         assert "conductances" in d
+
+    def test_to_dict_method_default(self):
+        assert NMModelIAF().to_dict()["method"] == "exact"
+
+    def test_method_round_trips_euler(self):
+        m = NMModelIAF()
+        m.method = "euler"
+        m2 = NMModelIAF.from_dict(m.to_dict())
+        assert m2.method == "euler"
 
     def test_to_dict_conductances_list(self):
         m = NMModelIAF()


### PR DESCRIPTION
## Summary

- Add `method` parameter to `NMModelIAF` — `"exact"` (default) or `"euler"`
- Exact method uses the closed-form update `V(t+dt) = V_ss + (V(t) − V_ss) × exp(−dt/τ_m)`,
  with `exp(−dt/τ_m)` precomputed once per `simulate()` call; correct at any step size
- Euler retained as a fallback (e.g. once synaptic conductances with kinetics are added,
  the exact formula no longer applies)
- `method` is validated, serialised in `to_dict`/`from_dict`, and included in `__repr__`

## Test plan

- [ ] `test_default_method_is_exact` — default is `"exact"`
- [ ] `test_method_euler_accepted` / `test_method_exact_accepted` — valid strings accepted
- [ ] `test_method_invalid_string_raises` / `test_method_non_string_raises` — bad inputs rejected
- [ ] `test_config_kwarg_method` — `config={"method": "euler"}` works
- [ ] `test_ap_count` (parametrized: 50 pA→20, 100 pA→34, 200 pA→42 APs) — reinstated;
  now stable because exact integration removes Euler's ISI accumulation error
- [ ] `test_exact_and_euler_agree_at_small_dt` — subthreshold traces match within 0.05 mV at dt=0.025 ms
- [ ] `test_exact_correct_at_large_dt` — matches analytical solution within 0.01 mV at dt=0.5 ms
- [ ] `test_to_dict_method_default` / `test_method_round_trips_euler` — serialisation
