### PR TITLE
feat: add GABA, AMPA and NMDA synaptic conductances to NMModelIAF

### DIFF
--- a/pyneuromatic/tools/nm_conductance.py
+++ b/pyneuromatic/tools/nm_conductance.py
@@ -156,6 +156,35 @@ class NMConductanceLeak(NMConductance):
         super().__init__("leak", g_density, e_rev)
 
 
+class NMConductanceGABA(NMConductance):
+    """GABAergic (Cl⁻) synaptic conductance — reversal potential register only.
+
+    ``g_density=0.0``: the static (ohmic) contribution is zero.  The actual
+    time-varying conductance ``g(t)`` is supplied externally as a pre-computed
+    array (nS) via ``NMModelIAF.simulate(g_ext=...)``.  This object exists
+    solely to register ``e_rev`` in the conductance container so that
+    ``simulate()`` can look up the reversal potential by name.
+
+    Default ``e_rev = −70.0 mV`` (Cl⁻ reversal, GABAₐ).
+    """
+
+    def __init__(self, e_rev: float = -70.0, g_density: float = 0.0) -> None:
+        super().__init__("gaba", g_density=0.0, e_rev=e_rev)
+
+
+class NMConductanceAMPA(NMConductance):
+    """AMPA-receptor synaptic conductance — reversal potential register only.
+
+    Same design as :class:`NMConductanceGABA` (``g_density=0.0``; ``g(t)``
+    supplied externally via ``NMModelIAF.simulate(g_ext=...)``).
+
+    Default ``e_rev = 0.0 mV`` (cation reversal, AMPA).
+    """
+
+    def __init__(self, e_rev: float = 0.0, g_density: float = 0.0) -> None:
+        super().__init__("ampa", g_density=0.0, e_rev=e_rev)
+
+
 class NMConductanceHHNa(NMConductance):
     """Hodgkin–Huxley sodium channel (m³h gating).
 
@@ -342,6 +371,8 @@ _CONDUCTANCE_REGISTRY: dict[str, type[NMConductance]] = {
     "leak": NMConductanceLeak,
     "hhna": NMConductanceHHNa,
     "hhk":  NMConductanceHHK,
+    "gaba": NMConductanceGABA,
+    "ampa": NMConductanceAMPA,
 }
 
 

--- a/pyneuromatic/tools/nm_conductance.py
+++ b/pyneuromatic/tools/nm_conductance.py
@@ -103,6 +103,15 @@ class NMConductance:
         """
         return self._g_density * (V - self._e_rev)
 
+    def voltage_factor(self, V: float) -> float:
+        """Voltage-dependent scaling factor in [0, 1] (1.0 = no block).
+
+        Override in subclasses with voltage-dependent gating (e.g. NMDA Mg²⁺
+        block).  NMModelIAF.simulate() applies this to scale g_ext currents:
+        I = g(t) × voltage_factor(V) × (V − e_rev).
+        """
+        return 1.0
+
     def dydt(self, V: float, states: list[float]) -> list[float]:
         """Gate variable derivatives at the HH reference temperature (6.3°C)."""
         return []
@@ -161,7 +170,7 @@ class NMConductanceGABA(NMConductance):
 
     ``g_density=0.0``: the static (ohmic) contribution is zero.  The actual
     time-varying conductance ``g(t)`` is supplied externally as a pre-computed
-    array (nS) via ``NMModelIAF.simulate(g_ext=...)``.  This object exists
+    array (nS) via ``NMModel.simulate(g_ext=...)``.  This object exists
     solely to register ``e_rev`` in the conductance container so that
     ``simulate()`` can look up the reversal potential by name.
 
@@ -176,13 +185,136 @@ class NMConductanceAMPA(NMConductance):
     """AMPA-receptor synaptic conductance — reversal potential register only.
 
     Same design as :class:`NMConductanceGABA` (``g_density=0.0``; ``g(t)``
-    supplied externally via ``NMModelIAF.simulate(g_ext=...)``).
+    supplied externally via ``NMModel.simulate(g_ext=...)``).
 
     Default ``e_rev = 0.0 mV`` (cation reversal, AMPA).
     """
 
     def __init__(self, e_rev: float = 0.0, g_density: float = 0.0) -> None:
         super().__init__("ampa", g_density=0.0, e_rev=e_rev)
+
+
+class NMConductanceNMDA(NMConductance):
+    """NMDA-receptor synaptic conductance with voltage-dependent Mg²⁺ block.
+
+    ``g_density=0.0``: the static (ohmic) contribution is zero.  ``g(t)`` is
+    supplied externally via ``NMModel.simulate(g_ext=...)``.
+
+    :meth:`voltage_factor` returns the Mg²⁺ block factor B(V) for the
+    selected model (``mg_block`` property).  NMModel scales each g_ext
+    step as ``I = g(t) × B(V) × (V − e_rev)``.
+
+    Block models:
+
+    ``"boltzmann"`` (default)
+        ``1 / (1 + exp(−(V − v_half) / v_slope))``
+        Defaults: ``v_half=−12.8 mV``, ``v_slope=22.4 mV`` (Rothman 2009).
+    ``"jahr_stevens_1990"``
+        ``1 / (1 + mg_conc × exp(−0.062 V) / 3.57)``
+        Default: ``mg_conc=1.0 mM``.
+    ``"gc_schwartz_2012"``
+        Multi-exponential fit (fixed constants from Igor NeuroMatic source).
+
+    Default ``e_rev = 0.0 mV``.
+    """
+
+    _VALID_BLOCK_MODELS = frozenset({
+        "boltzmann", "jahr_stevens_1990", "gc_schwartz_2012"
+    })
+
+    def __init__(
+        self,
+        e_rev: float = 0.0,
+        g_density: float = 0.0,
+        mg_block: str = "boltzmann",
+        v_half: float = -12.8,
+        v_slope: float = 22.4,
+        mg_conc: float = 1.0,
+    ) -> None:
+        super().__init__("nmda", g_density=0.0, e_rev=e_rev)
+        self.mg_block = mg_block
+        self._v_half = float(v_half)
+        self.v_slope = v_slope
+        self.mg_conc = mg_conc
+
+    @property
+    def mg_block(self) -> str:
+        """Mg²⁺ block model name."""
+        return self._mg_block
+
+    @mg_block.setter
+    def mg_block(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise TypeError("mg_block must be a string")
+        if value not in self._VALID_BLOCK_MODELS:
+            raise ValueError(
+                "mg_block %r is not valid; choose one of %s"
+                % (value, sorted(self._VALID_BLOCK_MODELS))
+            )
+        self._mg_block = value
+
+    @property
+    def v_half(self) -> float:
+        """Boltzmann half-activation voltage (mV)."""
+        return self._v_half
+
+    @v_half.setter
+    def v_half(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("v_half must be a float")
+        self._v_half = float(value)
+
+    @property
+    def v_slope(self) -> float:
+        """Boltzmann slope factor (mV); must be non-zero."""
+        return self._v_slope
+
+    @v_slope.setter
+    def v_slope(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("v_slope must be a float")
+        if value == 0:
+            raise ValueError("v_slope must be non-zero")
+        self._v_slope = float(value)
+
+    @property
+    def mg_conc(self) -> float:
+        """Extracellular Mg²⁺ concentration (mM) for Jahr–Stevens model."""
+        return self._mg_conc
+
+    @mg_conc.setter
+    def mg_conc(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("mg_conc must be a float")
+        if value <= 0:
+            raise ValueError("mg_conc must be > 0, got %g" % value)
+        self._mg_conc = float(value)
+
+    def voltage_factor(self, V: float) -> float:
+        """Mg²⁺ block factor B(V) in [0, 1] for the selected block model."""
+        if self._mg_block == "boltzmann":
+            return 1.0 / (1.0 + math.exp(-(V - self._v_half) / self._v_slope))
+        elif self._mg_block == "jahr_stevens_1990":
+            return 1.0 / (1.0 + self._mg_conc * math.exp(-0.062 * V) / 3.57)
+        else:  # gc_schwartz_2012
+            e1 = math.exp((V - (-119.51)) / 38.427) + math.exp(-(V - (-45.895)) / 28.357)
+            e2 = e1 + math.exp(-(V - 84.784) / 38.427)
+            return e1 / e2
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        d.update({
+            "mg_block": self._mg_block,
+            "v_half": self._v_half,
+            "v_slope": self._v_slope,
+            "mg_conc": self._mg_conc,
+        })
+        return d
+
+    def __repr__(self) -> str:
+        return "%s(e_rev=%g, mg_block=%r)" % (
+            self.__class__.__name__, self._e_rev, self._mg_block
+        )
 
 
 class NMConductanceHHNa(NMConductance):
@@ -373,6 +505,7 @@ _CONDUCTANCE_REGISTRY: dict[str, type[NMConductance]] = {
     "hhk":  NMConductanceHHK,
     "gaba": NMConductanceGABA,
     "ampa": NMConductanceAMPA,
+    "nmda": NMConductanceNMDA,
 }
 
 
@@ -386,9 +519,4 @@ def _conductance_from_dict(d: dict) -> NMConductance:
             % (ctype, sorted(_CONDUCTANCE_REGISTRY))
         )
     cls = _CONDUCTANCE_REGISTRY[ctype]
-    kwargs: dict = {}
-    if "g_density" in d:
-        kwargs["g_density"] = d["g_density"]
-    if "e_rev" in d:
-        kwargs["e_rev"] = d["e_rev"]
-    return cls(**kwargs)
+    return cls(**d)

--- a/pyneuromatic/tools/nm_model.py
+++ b/pyneuromatic/tools/nm_model.py
@@ -29,6 +29,7 @@ from pyneuromatic.tools.nm_conductance import (
     NMConductanceHHK,
     NMConductanceGABA,
     NMConductanceAMPA,
+    NMConductanceNMDA,
     NMConductanceContainer,
     _conductance_from_dict,
 )
@@ -671,7 +672,7 @@ class NMModelIAF(NMModel):
                 sum_gE  = sum_gE_static
                 if g_ext:
                     for name, g_arr in g_ext.items():
-                        g_i      = g_arr[i]
+                        g_i   = g_arr[i] * self._conductances[name].voltage_factor(v)
                         G_total += g_i
                         sum_gE  += g_i * syn_e_revs[name]
                 tau_m      = Cm / G_total
@@ -696,7 +697,11 @@ class NMModelIAF(NMModel):
                 )
                 if g_ext:
                     for name, g_arr in g_ext.items():
-                        i_ionic += g_arr[i] * (v - syn_e_revs[name])
+                        i_ionic += (
+                            g_arr[i]
+                            * self._conductances[name].voltage_factor(v)
+                            * (v - syn_e_revs[name])
+                        )
                 v_next = v + (i_ext[i] - i_ionic) / Cm * xdelta
                 if v_next >= self._ap_threshold:
                     V[i] = self._ap_peak

--- a/pyneuromatic/tools/nm_model.py
+++ b/pyneuromatic/tools/nm_model.py
@@ -27,6 +27,8 @@ from pyneuromatic.tools.nm_conductance import (
     NMConductanceLeak,
     NMConductanceHHNa,
     NMConductanceHHK,
+    NMConductanceGABA,
+    NMConductanceAMPA,
     NMConductanceContainer,
     _conductance_from_dict,
 )
@@ -86,6 +88,7 @@ class NMModel:
         xstart: float,
         xdelta: float,
         i_ext: np.ndarray,
+        g_ext: dict[str, np.ndarray] | None = None,
     ) -> dict[str, np.ndarray]:
         """Run a simulation and return state variable trajectories.
 
@@ -94,6 +97,11 @@ class NMModel:
             xstart:   Start time (ms).
             xdelta:   Time step (ms).
             i_ext:    External current waveform (pA), length ``n_points``.
+            g_ext:    Optional synaptic conductance waveforms (nS), keyed by
+                      conductance name (e.g. ``{"GABA": g_arr, "AMPA": g_arr}``).
+                      Each array must have length ``n_points``.  The named
+                      conductances must be registered in the model's conductance
+                      container so that ``e_rev`` can be looked up.
 
         Returns:
             Dictionary mapping variable names to 1-D arrays of length
@@ -246,6 +254,7 @@ class NMModelHH(NMModel):
         xstart: float,
         xdelta: float,
         i_ext: np.ndarray,
+        g_ext: dict[str, np.ndarray] | None = None,
     ) -> dict[str, np.ndarray]:
         """Integrate the HH ODE system.
 
@@ -590,6 +599,7 @@ class NMModelIAF(NMModel):
         xstart: float,
         xdelta: float,
         i_ext: np.ndarray,
+        g_ext: dict[str, np.ndarray] | None = None,
     ) -> dict[str, np.ndarray]:
         """Integrate the IAF ODE with threshold detection.
 
@@ -599,6 +609,12 @@ class NMModelIAF(NMModel):
                       stored for API consistency with NMModelHH.
             xdelta:   Time step (ms; also determines refractory step count).
             i_ext:    External current (pA), 1-D array of length ``n_points``.
+            g_ext:    Optional synaptic conductance waveforms (nS), keyed by
+                      the conductance name as registered in
+                      :attr:`conductances` (e.g. ``{"GABA": g_arr}``).
+                      Each array must have length ``n_points``.  The named
+                      conductances must already be in the container so that
+                      ``e_rev`` can be looked up.
 
         Returns:
             Dict with key ``"V"`` (mV), a 1-D array of length ``n_points``.
@@ -612,28 +628,37 @@ class NMModelIAF(NMModel):
         i_ext = np.asarray(i_ext, dtype=float)
         if i_ext.shape != (n_points,):
             raise ValueError("i_ext must have length n_points (%d)" % n_points)
+        if g_ext:
+            g_ext = {name: np.asarray(arr, dtype=float) for name, arr in g_ext.items()}
+            for name, g_arr in g_ext.items():
+                if name not in self._conductances:
+                    raise KeyError("g_ext key %r not found in conductances" % name)
+                if g_arr.shape != (n_points,):
+                    raise ValueError(
+                        "g_ext[%r] must have length %d" % (name, n_points)
+                    )
 
         SA = self._surface_area()
         Cm = self._capacitance()
         refrac_steps = max(1, round(self._ap_refrac / xdelta))
+
+        # Synaptic e_rev lookup — avoid repeated dict access inside the loop
+        syn_e_revs = (
+            {name: self._conductances[name].e_rev for name in g_ext}
+            if g_ext else {}
+        )
 
         V = np.zeros(n_points)
         V[0] = self._v0
         refrac_remaining = 0
 
         if self._method == "exact":
-            # Precompute constants for the closed-form update:
-            #   V(t+dt) = V_ss(t) + (V(t) - V_ss(t)) * exp(-dt/tau_m)
-            # V_ss = (I_ext + sum(g_i*SA*E_i)) / G_total  (depends on i_ext each step)
-            # tau_m = Cm / G_total  (constant — all conductances are ohmic)
-            G_total = sum(
-                cond.g_density * SA for _, cond in self._conductances
-            )
-            sum_gE = sum(
+            # Static (ohmic) conductances precomputed once.
+            # g_density=0 for GABA/AMPA, so they contribute nothing here.
+            G_static      = sum(cond.g_density * SA for _, cond in self._conductances)
+            sum_gE_static = sum(
                 cond.g_density * SA * cond.e_rev for _, cond in self._conductances
             )
-            tau_m = Cm / G_total
-            exp_factor = math.exp(-xdelta / tau_m)
 
             for i in range(n_points - 1):
                 if refrac_remaining > 0:
@@ -641,8 +666,18 @@ class NMModelIAF(NMModel):
                     refrac_remaining -= 1
                     continue
                 v = V[i]
-                V_ss = (i_ext[i] + sum_gE) / G_total
-                v_next = V_ss + (v - V_ss) * exp_factor
+                # Per-step: fold in time-varying synaptic conductances
+                G_total = G_static
+                sum_gE  = sum_gE_static
+                if g_ext:
+                    for name, g_arr in g_ext.items():
+                        g_i      = g_arr[i]
+                        G_total += g_i
+                        sum_gE  += g_i * syn_e_revs[name]
+                tau_m      = Cm / G_total
+                exp_factor = math.exp(-xdelta / tau_m)
+                V_ss       = (i_ext[i] + sum_gE) / G_total
+                v_next     = V_ss + (v - V_ss) * exp_factor
                 if v_next >= self._ap_threshold:
                     V[i] = self._ap_peak
                     V[i + 1] = self._ap_reset
@@ -659,6 +694,9 @@ class NMModelIAF(NMModel):
                 i_ionic = sum(
                     cond.current(v, []) * SA for _, cond in self._conductances
                 )
+                if g_ext:
+                    for name, g_arr in g_ext.items():
+                        i_ionic += g_arr[i] * (v - syn_e_revs[name])
                 v_next = v + (i_ext[i] - i_ionic) / Cm * xdelta
                 if v_next >= self._ap_threshold:
                     V[i] = self._ap_peak

--- a/tests/test_tools/test_nm_conductance.py
+++ b/tests/test_tools/test_nm_conductance.py
@@ -10,6 +10,7 @@ from pyneuromatic.tools.nm_conductance import (
     NMConductanceHHK,
     NMConductanceGABA,
     NMConductanceAMPA,
+    NMConductanceNMDA,
     NMConductanceContainer,
     _conductance_from_dict,
 )
@@ -446,6 +447,10 @@ class TestConductanceFactory:
         c = _conductance_from_dict({"conductance": "ampa", "e_rev": 0.0})
         assert isinstance(c, NMConductanceAMPA)
 
+    def test_dispatch_nmda(self):
+        c = _conductance_from_dict({"conductance": "nmda", "e_rev": 0.0})
+        assert isinstance(c, NMConductanceNMDA)
+
     def test_unknown_type_raises(self):
         with pytest.raises(KeyError):
             _conductance_from_dict({"conductance": "mystery"})
@@ -459,3 +464,94 @@ class TestConductanceFactory:
         c = _conductance_from_dict(d)
         assert c.g_density == pytest.approx(0.005)
         assert c.e_rev == pytest.approx(-60.0)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMConductanceNMDA
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMConductanceNMDA:
+    def test_name(self):
+        assert NMConductanceNMDA().name == "nmda"
+
+    def test_default_e_rev(self):
+        assert NMConductanceNMDA().e_rev == pytest.approx(0.0)
+
+    def test_default_g_density(self):
+        assert NMConductanceNMDA().g_density == pytest.approx(0.0)
+
+    def test_default_mg_block(self):
+        assert NMConductanceNMDA().mg_block == "boltzmann"
+
+    def test_current_is_zero(self):
+        c = NMConductanceNMDA()
+        assert c.current(0.0, []) == pytest.approx(0.0)
+        assert c.current(-60.0, []) == pytest.approx(0.0)
+
+    def test_mg_block_setter_all_valid(self):
+        c = NMConductanceNMDA()
+        for model in ("boltzmann", "jahr_stevens_1990", "gc_schwartz_2012"):
+            c.mg_block = model
+            assert c.mg_block == model
+
+    def test_mg_block_invalid_raises_value_error(self):
+        with pytest.raises(ValueError):
+            NMConductanceNMDA(mg_block="unknown")
+
+    def test_mg_block_non_str_raises_type_error(self):
+        c = NMConductanceNMDA()
+        with pytest.raises(TypeError):
+            c.mg_block = 42
+
+    def test_v_slope_zero_raises(self):
+        with pytest.raises(ValueError):
+            NMConductanceNMDA(v_slope=0.0)
+
+    def test_mg_conc_zero_raises(self):
+        with pytest.raises(ValueError):
+            NMConductanceNMDA(mg_conc=0.0)
+
+    def test_mg_conc_negative_raises(self):
+        with pytest.raises(ValueError):
+            NMConductanceNMDA(mg_conc=-1.0)
+
+    def test_voltage_factor_boltzmann_at_v_half(self):
+        """B(V_half) must be exactly 0.5 for Boltzmann model."""
+        c = NMConductanceNMDA(mg_block="boltzmann", v_half=-12.8, v_slope=22.4)
+        assert c.voltage_factor(-12.8) == pytest.approx(0.5)
+
+    def test_voltage_factor_boltzmann_range(self):
+        c = NMConductanceNMDA(mg_block="boltzmann")
+        assert c.voltage_factor(-100.0) < 0.1   # deeply blocked at hyperpolarised
+        assert c.voltage_factor(50.0) > 0.9     # nearly unblocked at depolarised
+
+    def test_voltage_factor_jahr_stevens_range(self):
+        c = NMConductanceNMDA(mg_block="jahr_stevens_1990", mg_conc=1.0)
+        for v in (-80.0, -40.0, 0.0, 50.0):
+            b = c.voltage_factor(v)
+            assert 0.0 < b <= 1.0
+
+    def test_voltage_factor_gc_schwartz_range(self):
+        c = NMConductanceNMDA(mg_block="gc_schwartz_2012")
+        for v in (-80.0, -40.0, 0.0, 50.0):
+            b = c.voltage_factor(v)
+            assert 0.0 < b <= 1.0
+
+    def test_voltage_factor_base_class_returns_one(self):
+        """NMConductanceLeak (base default) must return 1.0 at any voltage."""
+        leak = NMConductanceLeak()
+        for v in (-80.0, -40.0, 0.0, 50.0):
+            assert leak.voltage_factor(v) == pytest.approx(1.0)
+
+    def test_to_dict_round_trip(self):
+        c = NMConductanceNMDA(e_rev=5.0, mg_block="jahr_stevens_1990", mg_conc=2.0)
+        c2 = _conductance_from_dict(c.to_dict())
+        assert c == c2
+
+    def test_to_dict_contains_block_params(self):
+        c = NMConductanceNMDA(v_half=-10.0, v_slope=20.0, mg_conc=1.5)
+        d = c.to_dict()
+        assert d["mg_block"] == "boltzmann"
+        assert d["v_half"] == pytest.approx(-10.0)
+        assert d["v_slope"] == pytest.approx(20.0)
+        assert d["mg_conc"] == pytest.approx(1.5)

--- a/tests/test_tools/test_nm_conductance.py
+++ b/tests/test_tools/test_nm_conductance.py
@@ -8,6 +8,8 @@ from pyneuromatic.tools.nm_conductance import (
     NMConductanceLeak,
     NMConductanceHHNa,
     NMConductanceHHK,
+    NMConductanceGABA,
+    NMConductanceAMPA,
     NMConductanceContainer,
     _conductance_from_dict,
 )
@@ -364,6 +366,62 @@ class TestNMConductanceContainer:
 # Factory
 # ──────────────────────────────────────────────────────────────────────────────
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Synaptic conductances
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMConductanceGABA:
+    def test_name(self):
+        assert NMConductanceGABA().name == "gaba"
+
+    def test_default_e_rev(self):
+        assert NMConductanceGABA().e_rev == pytest.approx(-70.0)
+
+    def test_default_g_density(self):
+        assert NMConductanceGABA().g_density == pytest.approx(0.0)
+
+    def test_current_is_zero(self):
+        c = NMConductanceGABA()
+        assert c.current(-70.0, []) == pytest.approx(0.0)
+        assert c.current(-40.0, []) == pytest.approx(0.0)
+
+    def test_e_rev_setter(self):
+        c = NMConductanceGABA()
+        c.e_rev = -75.0
+        assert c.e_rev == pytest.approx(-75.0)
+
+    def test_to_dict_round_trip(self):
+        c = NMConductanceGABA(e_rev=-72.0)
+        c2 = _conductance_from_dict(c.to_dict())
+        assert c == c2
+
+
+class TestNMConductanceAMPA:
+    def test_name(self):
+        assert NMConductanceAMPA().name == "ampa"
+
+    def test_default_e_rev(self):
+        assert NMConductanceAMPA().e_rev == pytest.approx(0.0)
+
+    def test_default_g_density(self):
+        assert NMConductanceAMPA().g_density == pytest.approx(0.0)
+
+    def test_current_is_zero(self):
+        c = NMConductanceAMPA()
+        assert c.current(0.0, []) == pytest.approx(0.0)
+        assert c.current(-60.0, []) == pytest.approx(0.0)
+
+    def test_e_rev_setter(self):
+        c = NMConductanceAMPA()
+        c.e_rev = 5.0
+        assert c.e_rev == pytest.approx(5.0)
+
+    def test_to_dict_round_trip(self):
+        c = NMConductanceAMPA(e_rev=2.0)
+        c2 = _conductance_from_dict(c.to_dict())
+        assert c == c2
+
+
 class TestConductanceFactory:
     def test_dispatch_leak(self):
         d = {"conductance": "leak", "g_density": 0.003, "e_rev": -54.4}
@@ -379,6 +437,14 @@ class TestConductanceFactory:
         d = {"conductance": "hhk", "g_density": 0.36, "e_rev": -77.0}
         c = _conductance_from_dict(d)
         assert isinstance(c, NMConductanceHHK)
+
+    def test_dispatch_gaba(self):
+        c = _conductance_from_dict({"conductance": "gaba", "e_rev": -70.0})
+        assert isinstance(c, NMConductanceGABA)
+
+    def test_dispatch_ampa(self):
+        c = _conductance_from_dict({"conductance": "ampa", "e_rev": 0.0})
+        assert isinstance(c, NMConductanceAMPA)
 
     def test_unknown_type_raises(self):
         with pytest.raises(KeyError):

--- a/tests/test_tools/test_nm_model.py
+++ b/tests/test_tools/test_nm_model.py
@@ -9,6 +9,8 @@ from pyneuromatic.tools.nm_conductance import (
     NMConductanceLeak,
     NMConductanceHHNa,
     NMConductanceHHK,
+    NMConductanceGABA,
+    NMConductanceAMPA,
 )
 from pyneuromatic.tools.nm_pulse import NMPulseContainer
 
@@ -842,3 +844,177 @@ class TestNMModelIAFSerialisation:
         m2 = NMModelIAF()
         m2.ap_threshold = -35.0
         assert m1 != m2
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Synaptic conductances via g_ext
+# ──────────────────────────────────────────────────────────────────────────────
+
+def _iaf_with_syn():
+    """Return an NMModelIAF with GABA and AMPA registered (method='exact')."""
+    m = NMModelIAF()
+    m.conductances.add("GABA", NMConductanceGABA())
+    m.conductances.add("AMPA", NMConductanceAMPA())
+    return m
+
+
+class TestNMModelIAFSynaptic:
+    def test_g_ext_none_unchanged(self):
+        """simulate(g_ext=None) must give the same result as simulate() without g_ext."""
+        n_pts = round(150.0 / XDELTA)
+        i_ext = _make_i_ext(n_pts, round(25.0 / XDELTA), amp=200.0,
+                            duration_idx=round(100.0 / XDELTA))
+        m = _iaf_with_syn()
+        V_base = m.simulate(n_pts, 0.0, XDELTA, i_ext)["V"]
+        V_none = m.simulate(n_pts, 0.0, XDELTA, i_ext, g_ext=None)["V"]
+        assert np.array_equal(V_base, V_none)
+
+    def test_gaba_inhibits_firing(self):
+        """Strong GABA conductance should reduce AP count vs no-GABA baseline."""
+        from scipy.signal import find_peaks
+        n_pts = round(150.0 / XDELTA)
+        onset = round(25.0 / XDELTA)
+        dur   = round(100.0 / XDELTA)
+        i_ext = _make_i_ext(n_pts, onset, amp=200.0, duration_idx=dur)
+
+        # Baseline: no GABA
+        m_base = NMModelIAF()
+        V_base = m_base.simulate(n_pts, 0.0, XDELTA, i_ext)["V"]
+        peaks_base, _ = find_peaks(V_base, height=0.0, distance=round(1.5 / XDELTA))
+
+        # With large GABA conductance step (1.0 nS, E_GABA=-70 mV pulls Vm down)
+        m_gaba = _iaf_with_syn()
+        g_gaba = _make_i_ext(n_pts, onset, amp=1.0, duration_idx=dur)
+        V_gaba = m_gaba.simulate(n_pts, 0.0, XDELTA, i_ext, g_ext={"GABA": g_gaba})["V"]
+        peaks_gaba, _ = find_peaks(V_gaba, height=0.0, distance=round(1.5 / XDELTA))
+
+        assert len(peaks_gaba) < len(peaks_base), (
+            "GABA should reduce AP count: baseline=%d, with GABA=%d"
+            % (len(peaks_base), len(peaks_gaba))
+        )
+
+    def test_ampa_drives_subthreshold_to_fire(self):
+        """Subthreshold i_ext alone gives no spikes; adding AMPA step produces spikes."""
+        from scipy.signal import find_peaks
+        n_pts = round(150.0 / XDELTA)
+        onset = round(25.0 / XDELTA)
+        dur   = round(100.0 / XDELTA)
+        # 20 pA is subthreshold (threshold ≈ 36 pA)
+        i_ext = _make_i_ext(n_pts, onset, amp=20.0, duration_idx=dur)
+
+        # No AMPA: no spikes
+        m = NMModelIAF()
+        V_sub = m.simulate(n_pts, 0.0, XDELTA, i_ext)["V"]
+        assert V_sub.max() < 0.0, "Expected no spike with 20 pA"
+
+        # With AMPA conductance (0.5 nS, E_AMPA=0 mV pushes Vm up)
+        m_syn = _iaf_with_syn()
+        g_ampa = _make_i_ext(n_pts, onset, amp=0.5, duration_idx=dur)
+        V_syn = m_syn.simulate(n_pts, 0.0, XDELTA, i_ext, g_ext={"AMPA": g_ampa})["V"]
+        peaks, _ = find_peaks(V_syn, height=0.0, distance=round(1.5 / XDELTA))
+        assert len(peaks) > 0, "Expected spikes with AMPA conductance"
+
+    def test_g_ext_wrong_length_raises(self):
+        m = _iaf_with_syn()
+        n_pts = round(100.0 / XDELTA)
+        i_ext = np.zeros(n_pts)
+        with pytest.raises(ValueError):
+            m.simulate(n_pts, 0.0, XDELTA, i_ext, g_ext={"GABA": np.zeros(n_pts + 10)})
+
+    def test_g_ext_unknown_key_raises(self):
+        m = NMModelIAF()  # no GABA/AMPA registered
+        n_pts = round(100.0 / XDELTA)
+        i_ext = np.zeros(n_pts)
+        with pytest.raises(KeyError):
+            m.simulate(n_pts, 0.0, XDELTA, i_ext, g_ext={"GABA": np.zeros(n_pts)})
+
+    @pytest.mark.parametrize("g_gaba_nS,e_gaba", [
+        (0.45, -70.0),   # half leak conductance — V_ss closer to E_leak
+        (0.9,  -70.0),   # equal to leak — V_ss midway between E_leak and E_GABA
+        (1.8,  -70.0),   # double leak — V_ss closer to E_GABA
+        (0.9,  -65.0),   # different E_GABA (more depolarised)
+    ])
+    def test_gaba_steady_state_voltage(self, g_gaba_nS, e_gaba):
+        """Constant GABA conductance drives Vm to a weighted mean of E_leak and E_GABA.
+
+        Analytical steady state:
+            V_ss = (G_leak * E_leak + G_GABA * E_GABA) / (G_leak + G_GABA)
+
+        Run for 100 ms with no i_ext; that is >> any τ_m so the transient has
+        decayed to < 0.001 mV.  Final Vm must equal V_ss within 0.01 mV.
+        """
+        n_pts = round(100.0 / XDELTA)
+        m = NMModelIAF()
+        m.conductances.add("GABA", NMConductanceGABA(e_rev=e_gaba))
+
+        SA = math.pi * m.diameter ** 2
+        G_leak = m.conductances["Leak"].g_density * SA
+        E_leak = m.conductances["Leak"].e_rev
+        V_ss_expected = (G_leak * E_leak + g_gaba_nS * e_gaba) / (G_leak + g_gaba_nS)
+
+        g_gaba = np.full(n_pts, g_gaba_nS)
+        V = m.simulate(n_pts, 0.0, XDELTA, np.zeros(n_pts),
+                       g_ext={"GABA": g_gaba})["V"]
+
+        # V_ss must lie strictly between the two reversal potentials
+        assert min(E_leak, e_gaba) < V_ss_expected < max(E_leak, e_gaba)
+        # Final Vm must match the analytical prediction
+        assert V[-1] == pytest.approx(V_ss_expected, abs=0.01), (
+            "g_GABA=%g nS, E_GABA=%g mV: expected V_ss=%g mV, got %g mV"
+            % (g_gaba_nS, e_gaba, V_ss_expected, V[-1])
+        )
+
+    @pytest.mark.parametrize("g_ampa_nS,e_ampa", [
+        (0.45, 0.0),    # half leak conductance — V_ss closer to E_leak
+        (0.9,  0.0),    # equal to leak — V_ss midway between E_leak and E_AMPA
+        (1.8,  0.0),    # double leak — V_ss closer to E_AMPA
+        (0.9,  5.0),    # slightly different E_AMPA
+    ])
+    def test_ampa_steady_state_voltage(self, g_ampa_nS, e_ampa):
+        """Constant AMPA conductance drives Vm to a weighted mean of E_leak and E_AMPA.
+
+        AP threshold is raised to 200 mV so the neuron never fires and the
+        membrane charges to the analytical steady state:
+            V_ss = (G_leak * E_leak + G_AMPA * E_AMPA) / (G_leak + G_AMPA)
+        """
+        n_pts = round(100.0 / XDELTA)
+        m = NMModelIAF()
+        m.ap_threshold = 200.0   # prevent spiking — AMPA pushes Vm above default threshold
+        m.conductances.add("AMPA", NMConductanceAMPA(e_rev=e_ampa))
+
+        SA = math.pi * m.diameter ** 2
+        G_leak = m.conductances["Leak"].g_density * SA
+        E_leak = m.conductances["Leak"].e_rev
+        V_ss_expected = (G_leak * E_leak + g_ampa_nS * e_ampa) / (G_leak + g_ampa_nS)
+
+        g_ampa = np.full(n_pts, g_ampa_nS)
+        V = m.simulate(n_pts, 0.0, XDELTA, np.zeros(n_pts),
+                       g_ext={"AMPA": g_ampa})["V"]
+
+        # V_ss must lie strictly between the two reversal potentials
+        assert min(E_leak, e_ampa) < V_ss_expected < max(E_leak, e_ampa)
+        # Final Vm must match the analytical prediction
+        assert V[-1] == pytest.approx(V_ss_expected, abs=0.01), (
+            "g_AMPA=%g nS, E_AMPA=%g mV: expected V_ss=%g mV, got %g mV"
+            % (g_ampa_nS, e_ampa, V_ss_expected, V[-1])
+        )
+
+    def test_euler_and_exact_agree_with_g_ext(self):
+        """Exact and Euler give nearly identical Vm at dt=0.025 ms with g_ext present."""
+        n_pts = round(150.0 / XDELTA)
+        onset = round(25.0 / XDELTA)
+        dur   = round(100.0 / XDELTA)
+        # Subthreshold to avoid spike-timing jitter between methods
+        i_ext = _make_i_ext(n_pts, onset, amp=20.0, duration_idx=dur)
+        g_ampa = _make_i_ext(n_pts, onset, amp=0.1, duration_idx=dur)
+
+        m_exact = _iaf_with_syn()
+        m_exact.method = "exact"
+        m_euler = _iaf_with_syn()
+        m_euler.method = "euler"
+
+        V_exact = m_exact.simulate(n_pts, 0.0, XDELTA, i_ext, g_ext={"AMPA": g_ampa})["V"]
+        V_euler = m_euler.simulate(n_pts, 0.0, XDELTA, i_ext, g_ext={"AMPA": g_ampa})["V"]
+        assert np.max(np.abs(V_exact - V_euler)) < 0.05, (
+            "Exact and Euler with g_ext disagree by > 0.05 mV at dt=%g ms" % XDELTA
+        )

--- a/tests/test_tools/test_nm_model.py
+++ b/tests/test_tools/test_nm_model.py
@@ -11,6 +11,7 @@ from pyneuromatic.tools.nm_conductance import (
     NMConductanceHHK,
     NMConductanceGABA,
     NMConductanceAMPA,
+    NMConductanceNMDA,
 )
 from pyneuromatic.tools.nm_pulse import NMPulseContainer
 
@@ -1018,3 +1019,71 @@ class TestNMModelIAFSynaptic:
         assert np.max(np.abs(V_exact - V_euler)) < 0.05, (
             "Exact and Euler with g_ext disagree by > 0.05 mV at dt=%g ms" % XDELTA
         )
+
+    def test_nmda_blocked_at_rest(self):
+        """NMDA at resting Vm (−80 mV) should be strongly blocked: far less current than AMPA.
+
+        The Boltzmann factor at −80 mV (v_half=−12.8, v_slope=22.4) is ≈ 0.03,
+        so 1 nS NMDA produces only ~3% of the current a 1 nS AMPA step would.
+        """
+        n_pts = round(100.0 / XDELTA)
+        g_1nS = np.ones(n_pts)  # constant 1 nS
+
+        # AMPA (no block): 1 nS at E_AMPA=0 mV drives Vm well above rest
+        m_ampa = NMModelIAF()
+        m_ampa.ap_threshold = 200.0
+        m_ampa.conductances.add("AMPA", NMConductanceAMPA())
+        V_ampa = m_ampa.simulate(n_pts, 0.0, XDELTA, np.zeros(n_pts),
+                                 g_ext={"AMPA": g_1nS})["V"]
+
+        # NMDA (default Boltzmann block): 1 nS at E_NMDA=0 mV, same e_rev as AMPA
+        m_nmda = NMModelIAF()
+        m_nmda.ap_threshold = 200.0
+        m_nmda.conductances.add("NMDA", NMConductanceNMDA())  # default boltzmann, v_half=-12.8
+        V_nmda = m_nmda.simulate(n_pts, 0.0, XDELTA, np.zeros(n_pts),
+                                 g_ext={"NMDA": g_1nS})["V"]
+
+        # NMDA-driven depolarisation must be much smaller than AMPA-driven
+        delta_ampa = V_ampa[-1] - m_ampa.v0
+        delta_nmda = V_nmda[-1] - m_nmda.v0
+        assert delta_nmda < delta_ampa * 0.2, (
+            "NMDA at rest should be >80%% blocked: ΔAMPA=%g mV, ΔNMDA=%g mV"
+            % (delta_ampa, delta_nmda)
+        )
+
+    def test_nmda_steady_state_with_full_unblock(self):
+        """NMDA with v_half=-200 (B≈1 everywhere) matches the AMPA steady-state formula.
+
+        V_ss = (G_leak * E_leak + G_NMDA * E_NMDA) / (G_leak + G_NMDA), within 0.01 mV.
+        """
+        g_nmda_nS = 0.9
+        n_pts = round(100.0 / XDELTA)
+
+        m = NMModelIAF()
+        m.ap_threshold = 200.0
+        m.conductances.add("NMDA", NMConductanceNMDA(
+            mg_block="boltzmann", v_half=-500.0, v_slope=22.4  # B≈1 to < 1 ppb at physiological V
+        ))
+
+        SA = math.pi * m.diameter ** 2
+        G_leak = m.conductances["Leak"].g_density * SA
+        E_leak = m.conductances["Leak"].e_rev
+        E_nmda = m.conductances["NMDA"].e_rev
+        V_ss_expected = (G_leak * E_leak + g_nmda_nS * E_nmda) / (G_leak + g_nmda_nS)
+
+        g_arr = np.full(n_pts, g_nmda_nS)
+        V = m.simulate(n_pts, 0.0, XDELTA, np.zeros(n_pts), g_ext={"NMDA": g_arr})["V"]
+
+        assert V[-1] == pytest.approx(V_ss_expected, abs=0.01), (
+            "NMDA full-unblock V_ss: expected %g mV, got %g mV" % (V_ss_expected, V[-1])
+        )
+
+    def test_nmda_all_block_models_in_range(self):
+        """voltage_factor(v) must be in (0, 1] for all block models at typical voltages."""
+        for model in ("boltzmann", "jahr_stevens_1990", "gc_schwartz_2012"):
+            c = NMConductanceNMDA(mg_block=model)
+            for v in (-80.0, -40.0, 0.0, 50.0):
+                b = c.voltage_factor(v)
+                assert 0.0 < b <= 1.0, (
+                    "model=%r, V=%g mV: voltage_factor=%g not in (0, 1]" % (model, v, b)
+                )


### PR DESCRIPTION
## Summary

Closes #332

Adds three synaptic conductance types to `nm_conductance.py` and wires
them into `NMModelIAF.simulate()` via a new `g_ext` parameter.

- **`NMConductanceGABA`** — Cl⁻ reversal, default E_rev = −70 mV
- **`NMConductanceAMPA`** — cation reversal, default E_rev = 0 mV
- **`NMConductanceNMDA`** — cation reversal with voltage-dependent Mg²⁺
  block; three selectable block models: `"boltzmann"` (default, Rothman
  2009 params), `"jahr_stevens_1990"`, `"gc_schwartz_2012"`

## Design

Synaptic conductances follow the Igor NeuroMatic pattern: users generate
time-varying g(t) waveforms externally (e.g. via NMPulse) and pass them
to `simulate()` as `g_ext={"GABA": g_arr, "AMPA": g_arr, ...}`. The
conductance objects exist solely to register `e_rev` in the container;
`g_density=0` so they contribute nothing to the static ohmic loop.

A `voltage_factor(V)` hook is added to the `NMConductance` base class
(returns 1.0). `NMConductanceNMDA` overrides it with B(V), and
`simulate()` multiplies each g_ext current by this factor — leaving GABA
and AMPA unaffected.

The exact integration method handles time-varying g_ext by treating
g_syn(t) as piecewise-constant within each dt, recomputing `exp_factor`
per step.

## Test plan

- [ ] `TestNMConductanceGABA` / `TestNMConductanceAMPA` — construction,
  defaults, serialization round-trip
- [ ] `TestNMConductanceNMDA` — all three block models, `voltage_factor`
  values, property validation, round-trip
- [ ] `TestConductanceFactory` — dispatch for gaba, ampa, nmda
- [ ] `TestNMModelIAFSynaptic` — g_ext inhibits/excites firing, wrong-
  length / unknown-key errors, steady-state Vm formula (GABA and AMPA),
  NMDA blocked at rest, full-unblock steady state, Euler/exact agreement
