### PR TITLE
refactor(model): consolidate shared logic into NMModel base class

### DIFF
--- a/pyneuromatic/tools/nm_model.py
+++ b/pyneuromatic/tools/nm_model.py
@@ -44,6 +44,9 @@ class NMModel:
     Common parameters:
         v0:          Resting membrane potential (mV).  Default −65.0.
         temperature: Simulation temperature (°C).     Default 6.3.
+        cm_density:  Specific membrane capacitance
+                     (pF/µm²; 0.01 = 1 µF/cm²).      Default 0.01.
+        diameter:    Cell diameter (µm).               Default 10.0.
     """
 
     def __init__(
@@ -56,6 +59,11 @@ class NMModel:
         self._nm_path = nm_path
         self._v0: float = -65.0
         self._temperature: float = 6.3   # HH reference temperature (Hodgkin & Huxley 1952)
+        self._cm_density: float = 0.01   # pF/µm²
+        self._diameter: float = 10.0     # µm
+        self._conductances: NMConductanceContainer = NMConductanceContainer(
+            nm_path=nm_path + ".conductances"
+        )
 
     @property
     def name(self) -> str:
@@ -82,6 +90,45 @@ class NMModel:
         if isinstance(value, bool) or not isinstance(value, (int, float)):
             raise TypeError("temperature must be a float")
         self._temperature = float(value)
+
+    @property
+    def cm_density(self) -> float:
+        """Specific membrane capacitance (pF/µm²)."""
+        return self._cm_density
+
+    @cm_density.setter
+    def cm_density(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("cm_density must be a float")
+        if value <= 0:
+            raise ValueError("cm_density must be > 0, got %g" % value)
+        self._cm_density = float(value)
+
+    @property
+    def diameter(self) -> float:
+        """Cell diameter (µm)."""
+        return self._diameter
+
+    @diameter.setter
+    def diameter(self, value: float) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError("diameter must be a float")
+        if value <= 0:
+            raise ValueError("diameter must be > 0, got %g" % value)
+        self._diameter = float(value)
+
+    @property
+    def conductances(self) -> NMConductanceContainer:
+        """The conductance container."""
+        return self._conductances
+
+    def _surface_area(self) -> float:
+        """Sphere surface area in µm²: π × diameter²."""
+        return math.pi * self._diameter ** 2
+
+    def _capacitance(self) -> float:
+        """Total membrane capacitance in pF."""
+        return self._cm_density * self._surface_area()
 
     def simulate(
         self,
@@ -110,9 +157,6 @@ class NMModel:
         """
         raise NotImplementedError
 
-    def to_dict(self) -> dict:
-        raise NotImplementedError
-
     def _prepare_g_ext(
         self,
         g_ext: dict[str, np.ndarray] | None,
@@ -137,7 +181,50 @@ class NMModel:
 
     @classmethod
     def from_dict(cls, d: dict, nm_path: str = "model") -> "NMModel":
-        return _model_from_dict(d, nm_path=nm_path)
+        if cls is NMModel:
+            return _model_from_dict(d, nm_path=nm_path)
+        obj = cls(name=d.get("model", "model"), nm_path=nm_path)
+        obj._config_set(d, quiet=True)
+        return obj
+ 
+    def to_dict(self) -> dict:
+        d: dict = {
+            "model":       self._name,
+            "v0":          self._v0,
+            "temperature": self._temperature,
+            "cm_density":  self._cm_density,
+            "diameter":    self._diameter,
+        }
+        d["conductances"] = self._conductances.to_dict()["conductances"]
+        return d
+
+    def _config_set(self, config: dict, quiet: bool = True) -> None:
+        valid_keys = set(self.to_dict()) - {"model", "conductances"}
+        for key, value in config.items():
+            if key == "model":
+                continue
+            if key == "conductances":
+                self._conductances = NMConductanceContainer.from_dict(
+                    {"conductances": value},
+                    nm_path=self._nm_path + ".conductances",
+                )
+            elif key in valid_keys:
+                setattr(self, key, value)
+            else:
+                raise KeyError(
+                    "unknown %s config key %r" % (self.__class__.__name__, key)
+                )
+
+    def __repr__(self) -> str:
+        d = self.to_dict()
+        d.pop("model")
+        d.pop("conductances")
+        d["n_conductances"] = len(self._conductances)
+        params = ", ".join(
+            "%s=%g" % (k, v) if isinstance(v, float) else "%s=%r" % (k, v)
+            for k, v in d.items()
+        )
+        return "%s(%s)" % (self.__class__.__name__, params)
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, NMModel):
@@ -193,12 +280,6 @@ class NMModelRC(NMModel):
         nm_path: str = "model",
     ) -> None:
         super().__init__(name=name, nm_path=nm_path)
-        self._cm_density: float = 0.01
-        self._diameter:   float = self._DEFAULT_DIAMETER
-
-        self._conductances = NMConductanceContainer(
-            nm_path=nm_path + ".conductances"
-        )
         self._conductances.add(
             "Leak",
             NMConductanceLeak(
@@ -209,51 +290,6 @@ class NMModelRC(NMModel):
 
         if config is not None:
             self._config_set(config, quiet=True)
-
-    # ------------------------------------------------------------------
-    # Properties
-
-    @property
-    def cm_density(self) -> float:
-        """Specific membrane capacitance (pF/µm²)."""
-        return self._cm_density
-
-    @cm_density.setter
-    def cm_density(self, value: float) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError("cm_density must be a float")
-        if value <= 0:
-            raise ValueError("cm_density must be > 0, got %g" % value)
-        self._cm_density = float(value)
-
-    @property
-    def diameter(self) -> float:
-        """Cell diameter (µm)."""
-        return self._diameter
-
-    @diameter.setter
-    def diameter(self, value: float) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError("diameter must be a float")
-        if value <= 0:
-            raise ValueError("diameter must be > 0, got %g" % value)
-        self._diameter = float(value)
-
-    @property
-    def conductances(self) -> NMConductanceContainer:
-        """The conductance container (Leak by default)."""
-        return self._conductances
-
-    # ------------------------------------------------------------------
-    # Derived quantities
-
-    def _surface_area(self) -> float:
-        """Sphere surface area in µm²: π × diameter²."""
-        return math.pi * self._diameter ** 2
-
-    def _capacitance(self) -> float:
-        """Total membrane capacitance in pF."""
-        return self._cm_density * self._surface_area()
 
     # ------------------------------------------------------------------
     # Simulation
@@ -314,48 +350,6 @@ class NMModelRC(NMModel):
 
         return {"V": V}
 
-    # ------------------------------------------------------------------
-    # Config / serialisation
-
-    _SCALAR_KEYS = frozenset({"v0", "temperature", "cm_density", "diameter"})
-
-    def _config_set(self, config: dict, quiet: bool = True) -> None:
-        for key, value in config.items():
-            if key == "model":
-                continue
-            if key == "conductances":
-                self._conductances = NMConductanceContainer.from_dict(
-                    {"conductances": value},
-                    nm_path=self._nm_path + ".conductances",
-                )
-            elif key in self._SCALAR_KEYS:
-                setattr(self, key, value)
-            else:
-                raise KeyError("unknown NMModelRC config key %r" % key)
-
-    def to_dict(self) -> dict:
-        d: dict = {
-            "model":       "rc",
-            "v0":          self._v0,
-            "temperature": self._temperature,
-            "cm_density":  self._cm_density,
-            "diameter":    self._diameter,
-        }
-        d["conductances"] = self._conductances.to_dict()["conductances"]
-        return d
-
-    @classmethod
-    def from_dict(cls, d: dict, nm_path: str = "model") -> "NMModelRC":
-        obj = cls(name=d.get("model", "rc"), nm_path=nm_path)
-        obj._config_set(d, quiet=True)
-        return obj
-
-    def __repr__(self) -> str:
-        return (
-            "NMModelRC(v0=%g, cm_density=%g, diameter=%g, n_conductances=%d)"
-            % (self._v0, self._cm_density, self._diameter, len(self._conductances))
-        )
-
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Hodgkin–Huxley model
@@ -404,13 +398,8 @@ class NMModelHH(NMModel):
         nm_path: str = "model",
     ) -> None:
         super().__init__(name=name, nm_path=nm_path)
-        self._cm_density: float = 0.01                    # pF/µm²
-        self._diameter: float = self._DEFAULT_DIAMETER    # µm
+        self._diameter = self._DEFAULT_DIAMETER    # µm; overrides NMModel default
         self._tau_q10: float = 3.0
-
-        self._conductances = NMConductanceContainer(
-            nm_path=nm_path + ".conductances"
-        )
         self._conductances.add("Leak", NMConductanceLeak())
         self._conductances.add("Na",   NMConductanceHHNa())
         self._conductances.add("K",    NMConductanceHHK())
@@ -420,32 +409,6 @@ class NMModelHH(NMModel):
 
     # ------------------------------------------------------------------
     # Properties
-
-    @property
-    def cm_density(self) -> float:
-        """Specific membrane capacitance (pF/µm²)."""
-        return self._cm_density
-
-    @cm_density.setter
-    def cm_density(self, value: float) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError("cm_density must be a float")
-        if value <= 0:
-            raise ValueError("cm_density must be > 0, got %g" % value)
-        self._cm_density = float(value)
-
-    @property
-    def diameter(self) -> float:
-        """Cell diameter (µm)."""
-        return self._diameter
-
-    @diameter.setter
-    def diameter(self, value: float) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError("diameter must be a float")
-        if value <= 0:
-            raise ValueError("diameter must be > 0, got %g" % value)
-        self._diameter = float(value)
 
     @property
     def tau_q10(self) -> float:
@@ -460,21 +423,8 @@ class NMModelHH(NMModel):
             raise ValueError("tau_q10 must be > 0, got %g" % value)
         self._tau_q10 = float(value)
 
-    @property
-    def conductances(self) -> NMConductanceContainer:
-        """The conductance container (Leak, Na, K by default)."""
-        return self._conductances
-
     # ------------------------------------------------------------------
     # Derived quantities
-
-    def _surface_area(self) -> float:
-        """Sphere surface area in µm²: π × diameter²."""
-        return math.pi * self._diameter ** 2
-
-    def _capacitance(self) -> float:
-        """Total membrane capacitance in pF."""
-        return self._cm_density * self._surface_area()
 
     def _q10_factor(self) -> float:
         """Temperature scaling factor for HH rate constants."""
@@ -584,54 +534,10 @@ class NMModelHH(NMModel):
     # ------------------------------------------------------------------
     # Config / serialisation
 
-    _SCALAR_KEYS = frozenset({"v0", "temperature", "cm_density", "diameter", "tau_q10"})
-
-    def _config_set(self, config: dict, quiet: bool = True) -> None:
-        """Apply a configuration dictionary (from ``to_dict()``)."""
-        for key, value in config.items():
-            if key == "model":
-                continue
-            if key == "conductances":
-                self._conductances = NMConductanceContainer.from_dict(
-                    {"conductances": value},
-                    nm_path=self._nm_path + ".conductances",
-                )
-            elif key in self._SCALAR_KEYS:
-                setattr(self, key, value)
-            else:
-                raise KeyError("unknown NMModelHH config key %r" % key)
-
     def to_dict(self) -> dict:
-        d: dict = {
-            "model": "hh",
-            "v0": self._v0,
-            "temperature": self._temperature,
-            "cm_density": self._cm_density,
-            "diameter": self._diameter,
-            "tau_q10": self._tau_q10,
-        }
-        d["conductances"] = self._conductances.to_dict()["conductances"]
+        d = super().to_dict()
+        d["tau_q10"] = self._tau_q10
         return d
-
-    @classmethod
-    def from_dict(cls, d: dict, nm_path: str = "model") -> "NMModelHH":
-        obj = cls(name=d.get("model", "hh"), nm_path=nm_path)
-        obj._config_set(d, quiet=True)
-        return obj
-
-    def __repr__(self) -> str:
-        return (
-            "NMModelHH(v0=%g, cm_density=%g, diameter=%g, "
-            "temperature=%g, tau_q10=%g, n_conductances=%d)"
-            % (
-                self._v0,
-                self._cm_density,
-                self._diameter,
-                self._temperature,
-                self._tau_q10,
-                len(self._conductances),
-            )
-        )
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -704,17 +610,12 @@ class NMModelIAF(NMModel):
         super().__init__(name=name, nm_path=nm_path)
         self._v0:           float = -80.0
         self._temperature:  float = 37.0
-        self._cm_density:   float = 0.01
-        self._diameter:     float = self._DEFAULT_DIAMETER
         self._ap_threshold: float = -40.0
         self._ap_peak:      float =  32.0
         self._ap_reset:     float = -61.0
         self._ap_refrac:    float =   2.0
         self._method:       str   = "exact"
 
-        self._conductances = NMConductanceContainer(
-            nm_path=nm_path + ".conductances"
-        )
         self._conductances.add(
             "Leak",
             NMConductanceLeak(
@@ -728,32 +629,6 @@ class NMModelIAF(NMModel):
 
     # ------------------------------------------------------------------
     # Properties
-
-    @property
-    def cm_density(self) -> float:
-        """Specific membrane capacitance (pF/µm²)."""
-        return self._cm_density
-
-    @cm_density.setter
-    def cm_density(self, value: float) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError("cm_density must be a float")
-        if value <= 0:
-            raise ValueError("cm_density must be > 0, got %g" % value)
-        self._cm_density = float(value)
-
-    @property
-    def diameter(self) -> float:
-        """Cell diameter (µm)."""
-        return self._diameter
-
-    @diameter.setter
-    def diameter(self, value: float) -> None:
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise TypeError("diameter must be a float")
-        if value <= 0:
-            raise ValueError("diameter must be > 0, got %g" % value)
-        self._diameter = float(value)
 
     @property
     def ap_threshold(self) -> float:
@@ -816,22 +691,6 @@ class NMModelIAF(NMModel):
                 % (sorted(self._VALID_METHODS), value)
             )
         self._method = value
-
-    @property
-    def conductances(self) -> NMConductanceContainer:
-        """The conductance container (Leak by default)."""
-        return self._conductances
-
-    # ------------------------------------------------------------------
-    # Derived quantities
-
-    def _surface_area(self) -> float:
-        """Sphere surface area in µm²: π × diameter²."""
-        return math.pi * self._diameter ** 2
-
-    def _capacitance(self) -> float:
-        """Total membrane capacitance in pF."""
-        return self._cm_density * self._surface_area()
 
     # ------------------------------------------------------------------
     # Simulation
@@ -943,64 +802,14 @@ class NMModelIAF(NMModel):
     # ------------------------------------------------------------------
     # Config / serialisation
 
-    _SCALAR_KEYS = frozenset({
-        "v0", "temperature", "cm_density", "diameter",
-        "ap_threshold", "ap_peak", "ap_reset", "ap_refrac",
-    })
-
-    def _config_set(self, config: dict, quiet: bool = True) -> None:
-        for key, value in config.items():
-            if key == "model":
-                continue
-            if key == "conductances":
-                self._conductances = NMConductanceContainer.from_dict(
-                    {"conductances": value},
-                    nm_path=self._nm_path + ".conductances",
-                )
-            elif key == "method":
-                self.method = value
-            elif key in self._SCALAR_KEYS:
-                setattr(self, key, value)
-            else:
-                raise KeyError("unknown NMModelIAF config key %r" % key)
-
     def to_dict(self) -> dict:
-        d: dict = {
-            "model":        "iaf",
-            "v0":           self._v0,
-            "temperature":  self._temperature,
-            "cm_density":   self._cm_density,
-            "diameter":     self._diameter,
-            "ap_threshold": self._ap_threshold,
-            "ap_peak":      self._ap_peak,
-            "ap_reset":     self._ap_reset,
-            "ap_refrac":    self._ap_refrac,
-            "method":       self._method,
-        }
-        d["conductances"] = self._conductances.to_dict()["conductances"]
+        d = super().to_dict()
+        d["ap_threshold"] = self._ap_threshold
+        d["ap_peak"]      = self._ap_peak
+        d["ap_reset"]     = self._ap_reset
+        d["ap_refrac"]    = self._ap_refrac
+        d["method"]       = self._method
         return d
-
-    @classmethod
-    def from_dict(cls, d: dict, nm_path: str = "model") -> "NMModelIAF":
-        obj = cls(name=d.get("model", "iaf"), nm_path=nm_path)
-        obj._config_set(d, quiet=True)
-        return obj
-
-    def __repr__(self) -> str:
-        return (
-            "NMModelIAF(v0=%g, cm_density=%g, diameter=%g, "
-            "ap_threshold=%g, ap_peak=%g, ap_reset=%g, ap_refrac=%g, method=%r)"
-            % (
-                self._v0,
-                self._cm_density,
-                self._diameter,
-                self._ap_threshold,
-                self._ap_peak,
-                self._ap_reset,
-                self._ap_refrac,
-                self._method,
-            )
-        )
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/tests/test_tools/test_nm_model.py
+++ b/tests/test_tools/test_nm_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tests for NMModel and NMModelHH."""
+"""Tests for NMModel, NMModelHH, NMModelRC and NMModelIAF."""
 import math
 import numpy as np
 import pytest
@@ -12,6 +12,7 @@ from pyneuromatic.tools.nm_conductance import (
     NMConductanceGABA,
     NMConductanceAMPA,
     NMConductanceNMDA,
+    NMConductanceContainer,
 )
 from pyneuromatic.tools.nm_pulse import NMPulseContainer
 
@@ -36,6 +37,99 @@ def _sim_default(i_amp=I_AMP_SUPRA):
     m = NMModelHH()
     i_ext = _make_i_ext(N_POINTS, I_ONSET_IDX, i_amp)
     return m.simulate(N_POINTS, XSTART, XDELTA, i_ext)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# NMModel — shared base-class properties
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestNMModel:
+    """Tests for properties and helpers defined on the NMModel base class.
+
+    NMModel can be instantiated directly (simulate/to_dict raise
+    NotImplementedError) so these tests exercise the shared behaviour
+    once, rather than repeating it in every subclass test suite.
+    """
+
+    def test_v0_default(self):
+        assert NMModel().v0 == pytest.approx(-65.0)
+
+    def test_v0_setter(self):
+        m = NMModel()
+        m.v0 = -70.0
+        assert m.v0 == pytest.approx(-70.0)
+
+    def test_v0_setter_bool_raises(self):
+        with pytest.raises(TypeError):
+            NMModel().v0 = True
+
+    def test_temperature_default(self):
+        assert NMModel().temperature == pytest.approx(6.3)
+
+    def test_temperature_setter(self):
+        m = NMModel()
+        m.temperature = 37.0
+        assert m.temperature == pytest.approx(37.0)
+
+    def test_temperature_setter_bool_raises(self):
+        with pytest.raises(TypeError):
+            NMModel().temperature = True
+
+    def test_cm_density_default(self):
+        assert NMModel().cm_density == pytest.approx(0.01)
+
+    def test_cm_density_setter(self):
+        m = NMModel()
+        m.cm_density = 0.02
+        assert m.cm_density == pytest.approx(0.02)
+
+    def test_cm_density_setter_zero_raises(self):
+        with pytest.raises(ValueError):
+            NMModel().cm_density = 0.0
+
+    def test_cm_density_setter_bool_raises(self):
+        with pytest.raises(TypeError):
+            NMModel().cm_density = True
+
+    def test_diameter_default(self):
+        assert NMModel().diameter == pytest.approx(10.0)
+
+    def test_diameter_setter(self):
+        m = NMModel()
+        m.diameter = 20.0
+        assert m.diameter == pytest.approx(20.0)
+
+    def test_diameter_setter_zero_raises(self):
+        with pytest.raises(ValueError):
+            NMModel().diameter = 0.0
+
+    def test_diameter_setter_bool_raises(self):
+        with pytest.raises(TypeError):
+            NMModel().diameter = True
+
+    def test_conductances_is_container(self):
+        assert isinstance(NMModel().conductances, NMConductanceContainer)
+
+    def test_conductances_empty_by_default(self):
+        assert len(NMModel().conductances) == 0
+
+    def test_surface_area(self):
+        m = NMModel()
+        assert m._surface_area() == pytest.approx(math.pi * 10.0 ** 2)
+
+    def test_capacitance(self):
+        m = NMModel()
+        assert m._capacitance() == pytest.approx(0.01 * math.pi * 10.0 ** 2)
+
+    def test_surface_area_updates_with_diameter(self):
+        m = NMModel()
+        m.diameter = 20.0
+        assert m._surface_area() == pytest.approx(math.pi * 20.0 ** 2)
+
+    def test_capacitance_updates_with_cm_density(self):
+        m = NMModel()
+        m.cm_density = 0.02
+        assert m._capacitance() == pytest.approx(0.02 * math.pi * 10.0 ** 2)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -67,26 +161,6 @@ class TestNMModelHHConstruct:
     def test_name(self):
         m = NMModelHH(name="test_hh")
         assert m.name == "test_hh"
-
-    def test_v0_setter(self):
-        m = NMModelHH()
-        m.v0 = -70.0
-        assert m.v0 == pytest.approx(-70.0)
-
-    def test_v0_setter_bool_raises(self):
-        m = NMModelHH()
-        with pytest.raises(TypeError):
-            m.v0 = True
-
-    def test_cm_density_setter_zero_raises(self):
-        m = NMModelHH()
-        with pytest.raises(ValueError):
-            m.cm_density = 0.0
-
-    def test_diameter_setter_zero_raises(self):
-        m = NMModelHH()
-        with pytest.raises(ValueError):
-            m.diameter = 0.0
 
     def test_tau_q10_setter_zero_raises(self):
         m = NMModelHH()
@@ -339,14 +413,6 @@ class TestNMModelHHTemperature:
 # ──────────────────────────────────────────────────────────────────────────────
 
 class TestNMModelHHDerived:
-    def test_surface_area(self):
-        m = NMModelHH()
-        assert m._surface_area() == pytest.approx(1200.0)
-
-    def test_capacitance(self):
-        m = NMModelHH()
-        assert m._capacitance() == pytest.approx(12.0)
-
     def test_q10_factor_at_ref_temp(self):
         m = NMModelHH()
         m.temperature = 6.3   # at reference → factor = 1.0
@@ -476,21 +542,6 @@ class TestNMModelIAFConstruct:
     def test_name(self):
         m = NMModelIAF(name="test_iaf")
         assert m.name == "test_iaf"
-
-    def test_v0_setter(self):
-        m = NMModelIAF()
-        m.v0 = -70.0
-        assert m.v0 == pytest.approx(-70.0)
-
-    def test_cm_density_setter_zero_raises(self):
-        m = NMModelIAF()
-        with pytest.raises(ValueError):
-            m.cm_density = 0.0
-
-    def test_diameter_setter_zero_raises(self):
-        m = NMModelIAF()
-        with pytest.raises(ValueError):
-            m.diameter = 0.0
 
     def test_ap_refrac_setter_zero_raises(self):
         m = NMModelIAF()
@@ -789,18 +840,6 @@ class TestNMModelIAFTimeConstant:
         )
 
 
-class TestNMModelIAFDerived:
-    def test_surface_area(self):
-        import math
-        m = NMModelIAF()
-        assert m._surface_area() == pytest.approx(math.pi * 10.0 ** 2)
-
-    def test_capacitance(self):
-        import math
-        m = NMModelIAF()
-        assert m._capacitance() == pytest.approx(0.01 * math.pi * 10.0 ** 2)
-
-
 # ──────────────────────────────────────────────────────────────────────────────
 # Serialisation
 # ──────────────────────────────────────────────────────────────────────────────
@@ -1003,16 +1042,6 @@ class TestNMModelRC:
 
     def test_name(self):
         assert NMModelRC(name="test_rc").name == "test_rc"
-
-    def test_cm_density_setter_zero_raises(self):
-        m = NMModelRC()
-        with pytest.raises(ValueError):
-            m.cm_density = 0.0
-
-    def test_diameter_setter_zero_raises(self):
-        m = NMModelRC()
-        with pytest.raises(ValueError):
-            m.diameter = 0.0
 
     def test_simulate_returns_dict_with_V(self):
         m = NMModelRC()


### PR DESCRIPTION
### Summary
- Move cm_density, diameter, conductances, _surface_area(), _capacitance() to NMModel — all three subclasses inherit them; NMModel.__init__ initialises all shared state
- Move to_dict() shared keys to NMModel; subclasses call super().to_dict() and append model-specific keys; NMModelRC.to_dict() removed entirely
- Move _config_set() to NMModel; valid keys derived from to_dict() at call time, eliminating per-class _SCALAR_KEYS frozensets
- Move __repr__() to NMModel; built generically from to_dict(), removing three subclass overrides
- Move from_dict() to NMModel; dispatches via _MODEL_REGISTRY when called on the base class, constructs directly when called on a subclass, removing three subclass overrides
- Add TestNMModel (20 tests) for all shared base-class properties; remove duplicate setter and derived-quantity tests from subclass suites
- 
### Test plan
-  TestNMModel — v0, temperature, cm_density, diameter, conductances, _surface_area(), _capacitance() all tested on NMModel() directly
-  All existing HH, IAF, RC, and synaptic tests continue to pass (no behaviour change)
-  python3 -m pytest tests/test_tools/test_nm_model.py -q — all 149 tests pass
