### PR TITLE
feat(tools): add gsyn_sources to NMToolModel for folder-based synaptic conductance wiring

### DIFF
--- a/pyneuromatic/tools/nm_tool_model.py
+++ b/pyneuromatic/tools/nm_tool_model.py
@@ -106,6 +106,7 @@ class NMToolModel(NMTool):
         self.__pulses: NMPulseContainer = NMPulseContainer(
             nm_path=self._name + ".pulses"
         )
+        self.__gsyn_sources: dict[str, str] = {}
 
         self._waveforms:     list[np.ndarray]            = []
         self._epoch_names:   list[str]                   = []
@@ -228,6 +229,35 @@ class NMToolModel(NMTool):
         """Container of NMPulse objects summed to form the injected current."""
         return self.__pulses
 
+    @property
+    def gsyn_sources(self) -> dict[str, str]:
+        """Mapping from conductance name to array prefix in folder.data.
+
+        For each entry, run() reads ``{prefix}{chan}{epoch_idx}`` from
+        folder.data and passes the array (nS) as ``g_ext`` to
+        model.simulate().  The conductance name must match a key in
+        model.conductances.
+
+        Example::
+
+            t.gsyn_sources = {"AMPA": "AMPA_", "NMDA": "NMDA_"}
+            # reads AMPA_0, NMDA_0 for epoch 0; AMPA_1, NMDA_1 for epoch 1; …
+        """
+        return dict(self.__gsyn_sources)
+
+    @gsyn_sources.setter
+    def gsyn_sources(self, value: dict[str, str]) -> None:
+        if not isinstance(value, dict):
+            raise TypeError(nmu.type_error_str(value, "gsyn_sources", "dict"))
+        for k, v in value.items():
+            if not isinstance(k, str) or not isinstance(v, str):
+                raise TypeError("gsyn_sources keys and values must be strings")
+        self.__gsyn_sources = dict(value)
+        nmh.history("set gsyn_sources=%r" % self.__gsyn_sources, quiet=True)
+        nmch.add_nm_command(
+            "%s.gsyn_sources = %r" % (self._name, self.__gsyn_sources)
+        )
+
     # ------------------------------------------------------------------
     # Lifecycle
 
@@ -264,8 +294,31 @@ class NMToolModel(NMTool):
                     self.__n_points, self.__xstart, self.__xdelta, epoch_idx
                 )
 
+        g_ext: dict[str, np.ndarray] | None = None
+        if self.__gsyn_sources:
+            if not isinstance(self.folder, NMFolder):
+                raise ValueError(
+                    "gsyn_sources is set but no folder is available for epoch %d"
+                    % epoch_idx
+                )
+            g_ext = {}
+            for cond_name, arr_prefix in self.__gsyn_sources.items():
+                arr_name = arr_prefix + self.__chan + str(epoch_idx)
+                nmdata = self.folder.data.get(arr_name)
+                if nmdata is None:
+                    raise KeyError(
+                        "gsyn_sources: %r not found in folder.data (epoch %d)"
+                        % (arr_name, epoch_idx)
+                    )
+                arr = nmdata.nparray
+                if arr is None:
+                    raise ValueError(
+                        "gsyn_sources: %r has no data (nparray is None)" % arr_name
+                    )
+                g_ext[cond_name] = arr
+
         result = self.__model.simulate(
-            self.__n_points, self.__xstart, self.__xdelta, i_ext
+            self.__n_points, self.__xstart, self.__xdelta, i_ext, g_ext=g_ext
         )
 
         self._waveforms.append(result["V"])
@@ -317,6 +370,8 @@ class NMToolModel(NMTool):
                 pulse_parts.append("amp_delta=%g" % p.amp_delta)
             pulse_strs.append("(%s)" % ", ".join(pulse_parts))
         parts.append("pulses=[%s]" % ", ".join(pulse_strs))
+        if self.__gsyn_sources:
+            parts.append("gsyn_sources=%r" % self.__gsyn_sources)
         parts.append("n_points=%d" % self.__n_points)
         parts.append("xstart=%g" % self.__xstart)
         parts.append("xdelta=%g" % self.__xdelta)

--- a/tests/test_tools/test_nm_tool_model.py
+++ b/tests/test_tools/test_nm_tool_model.py
@@ -6,6 +6,7 @@ import pytest
 
 from pyneuromatic.tools.nm_tool_model import NMToolModel, NMToolModelConfig
 from pyneuromatic.tools.nm_model import NMModelHH
+from pyneuromatic.tools.nm_conductance import NMConductanceAMPA, NMConductanceGABA
 from pyneuromatic.tools.nm_pulse import NMPulseContainer
 from pyneuromatic.core.nm_folder import NMFolder
 from pyneuromatic.core.nm_manager import NMManager
@@ -385,3 +386,159 @@ class TestNMToolModelEmpty:
         count_before = len(folder.data)
         t.run_all([])
         assert len(folder.data) == count_before
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# gsyn_sources — folder-based synaptic conductance wiring
+# ──────────────────────────────────────────────────────────────────────────────
+
+N_POINTS_SYN = 4000    # 100 ms at 0.025 ms/step
+XDELTA_SYN   = 0.025
+ONSET_IDX    = round(5.0 / XDELTA_SYN)    # 5 ms onset
+DUR_IDX      = round(50.0 / XDELTA_SYN)   # 50 ms duration
+
+
+def _add_cond_arrays(folder, prefix, n_epochs, n_points, amp_nS, chan=""):
+    """Pre-populate folder.data with constant conductance arrays."""
+    for i in range(n_epochs):
+        arr = np.full(n_points, amp_nS)
+        folder.data.new(prefix + chan + str(i), nparray=arr)
+
+
+def _syn_tool(gsyn_sources, chan=""):
+    """NMToolModel with AMPA conductance added and subthreshold i_ext."""
+    t = NMToolModel()
+    t.n_points = N_POINTS_SYN
+    t.xdelta = XDELTA_SYN
+    if chan:
+        t.chan = chan
+    t.model.conductances.add("AMPA", NMConductanceAMPA())
+    t.model.conductances.add("GABA", NMConductanceGABA())
+    # subthreshold current pulse — not enough to fire on its own
+    t.pulses.new({"pulse": "square", "amp": 50.0, "onset": 5.0,
+                  "duration": 50.0, "epoch": "all"})
+    t.gsyn_sources = gsyn_sources
+    return t
+
+
+class TestNMToolModelGSynSources:
+    def test_gsyn_sources_default_empty(self):
+        t = NMToolModel()
+        assert t.gsyn_sources == {}
+
+    def test_gsyn_sources_setter(self):
+        t = NMToolModel()
+        t.gsyn_sources = {"AMPA": "AMPA_"}
+        assert t.gsyn_sources == {"AMPA": "AMPA_"}
+
+    def test_gsyn_sources_returns_copy(self):
+        t = NMToolModel()
+        t.gsyn_sources = {"AMPA": "AMPA_"}
+        t.gsyn_sources["X"] = "Y"  # mutating returned dict should have no effect
+        assert "X" not in t.gsyn_sources
+
+    def test_gsyn_sources_non_dict_raises(self):
+        t = NMToolModel()
+        with pytest.raises(TypeError):
+            t.gsyn_sources = "AMPA_"
+
+    def test_gsyn_sources_non_string_value_raises(self):
+        t = NMToolModel()
+        with pytest.raises(TypeError):
+            t.gsyn_sources = {"AMPA": 42}
+
+    def test_ampa_depolarizes_vm(self):
+        """Constant AMPA conductance should push Vm above baseline."""
+        folder = _make_folder()
+        _add_cond_arrays(folder, "AMPA_", n_epochs=1,
+                         n_points=N_POINTS_SYN, amp_nS=5.0)
+        t_base = _syn_tool({})
+        _run_tool(t_base, n_epochs=1, folder=folder)
+        vm_base_max = folder.data["VM_0"].nparray.max()
+
+        folder2 = _make_folder()
+        _add_cond_arrays(folder2, "AMPA_", n_epochs=1,
+                         n_points=N_POINTS_SYN, amp_nS=5.0)
+        t_syn = _syn_tool({"AMPA": "AMPA_"})
+        _run_tool(t_syn, n_epochs=1, folder=folder2)
+        vm_syn_max = folder2.data["VM_0"].nparray.max()
+
+        assert vm_syn_max > vm_base_max
+
+    def test_two_conductances_two_epochs(self):
+        """Both AMPA and GABA wiring across 2 epochs produces correctly shaped output."""
+        folder = _make_folder()
+        _add_cond_arrays(folder, "AMPA_", n_epochs=2,
+                         n_points=N_POINTS_SYN, amp_nS=3.0)
+        _add_cond_arrays(folder, "GABA_", n_epochs=2,
+                         n_points=N_POINTS_SYN, amp_nS=1.0)
+        t = _syn_tool({"AMPA": "AMPA_", "GABA": "GABA_"})
+        _run_tool(t, n_epochs=2, folder=folder)
+        for i in range(2):
+            vm = folder.data["VM_%d" % i].nparray
+            assert vm.shape == (N_POINTS_SYN,)
+
+    def test_chan_used_in_array_lookup(self):
+        """gsyn_sources lookup uses {prefix}{chan}{epoch_idx}."""
+        folder = _make_folder()
+        _add_cond_arrays(folder, "AMPA_", n_epochs=1,
+                         n_points=N_POINTS_SYN, amp_nS=5.0, chan="A")
+        t = _syn_tool({"AMPA": "AMPA_"}, chan="A")
+        _run_tool(t, n_epochs=1, folder=folder)
+        assert "VM_A0" in folder.data
+
+    def test_gsyn_sources_empty_no_change(self):
+        """gsyn_sources={} leaves run() behaviour unchanged."""
+        folder = _make_folder()
+        t = _syn_tool({})
+        _run_tool(t, n_epochs=1, folder=folder)
+        assert "VM_0" in folder.data
+
+    def test_gsyn_sources_no_folder_raises(self):
+        """Setting gsyn_sources but providing no folder raises ValueError."""
+        t = _syn_tool({"AMPA": "AMPA_"})
+        with pytest.raises(ValueError, match="no folder"):
+            t.run_all([{}])  # no "folder" key in target
+
+    def test_gsyn_sources_missing_array_raises(self):
+        """Missing conductance array in folder.data raises KeyError."""
+        folder = _make_folder()
+        # intentionally do NOT add AMPA_ arrays
+        t = _syn_tool({"AMPA": "AMPA_"})
+        with pytest.raises(KeyError, match="AMPA_0"):
+            _run_tool(t, n_epochs=1, folder=folder)
+
+    def test_gsyn_sources_none_nparray_raises(self):
+        """NMData with nparray=None raises ValueError."""
+        folder = _make_folder()
+        folder.data.new("AMPA_0", nparray=None)
+        t = _syn_tool({"AMPA": "AMPA_"})
+        with pytest.raises(ValueError, match="nparray is None"):
+            _run_tool(t, n_epochs=1, folder=folder)
+
+    def test_gsyn_sources_wrong_length_raises(self):
+        """Array length != n_points raises ValueError (via model._prepare_g_ext)."""
+        folder = _make_folder()
+        folder.data.new("AMPA_0", nparray=np.ones(10))  # wrong length
+        t = _syn_tool({"AMPA": "AMPA_"})
+        with pytest.raises(ValueError):
+            _run_tool(t, n_epochs=1, folder=folder)
+
+    def test_gsyn_sources_unknown_conductance_raises(self):
+        """Conductance name not in model.conductances raises KeyError."""
+        folder = _make_folder()
+        _add_cond_arrays(folder, "NMDA_", n_epochs=1,
+                         n_points=N_POINTS_SYN, amp_nS=1.0)
+        t = _syn_tool({"NMDA": "NMDA_"})  # NMDA not added to model conductances
+        with pytest.raises(KeyError):
+            _run_tool(t, n_epochs=1, folder=folder)
+
+    def test_note_str_includes_gsyn_sources(self):
+        """Note string includes gsyn_sources when set."""
+        folder = _make_folder()
+        _add_cond_arrays(folder, "AMPA_", n_epochs=1,
+                         n_points=N_POINTS_SYN, amp_nS=5.0)
+        t = _syn_tool({"AMPA": "AMPA_"})
+        _run_tool(t, n_epochs=1, folder=folder)
+        note = " ".join(str(n) for n in folder.data["VM_0"].notes)
+        assert "gsyn_sources" in note


### PR DESCRIPTION
## Summary

- Adds `gsyn_sources: dict[str, str]` property to `NMToolModel` mapping conductance name (e.g. `"AMPA"`) to an array prefix in `NMFolder.data` (e.g. `"AMPA_"`)
- At `run()` time, each entry is resolved as `{prefix}{chan}{epoch_idx}` from `folder.data` and passed as `g_ext` to `model.simulate()`, enabling a two-step workflow where `NMToolPulse` generates per-epoch conductance waveforms and `NMToolModel` consumes them
- Adds `gsyn_sources` to the note string when set; getter returns a defensive copy

## Motivation

Previously `NMToolModel` could only drive simulations with injected current (`i_ext`). Synaptic inputs require conductance waveforms whose shape depends on the stimulus (alpha, exponential, etc.), so they need to be pre-generated — `NMToolPulse` already does this. `gsyn_sources` connects the two tools via `NMFolder.data`, keeping waveforms inspectable and reusable between runs.

## Test plan

- [ ] `TestNMToolModelGSynSources` (13 tests): default empty dict, setter/copy isolation, type errors, AMPA depolarisation, two conductances × two epochs, channel used in lookup key, empty dict no-op, no-folder `ValueError`, missing array `KeyError`, `None` nparray `ValueError`, wrong-length `ValueError`, unknown conductance `KeyError`, note string
- [ ] Full test suite passes (`python3 -m pytest`)

Closes #338
